### PR TITLE
bug in software, toolchain and easyconfig check. 

### DIFF
--- a/framework/main.py
+++ b/framework/main.py
@@ -235,9 +235,16 @@ def main():
 			toolchain = "dummy/dummy"
 	
 		toolchain=toolchain.split("/")
+
+		# only check toolchain argument with module tree if its not dummy toolchain
+		if ["dummy","dummy"] != toolchain:
+			# checking if toolchain argument has a valid module file
+			software_exists(toolchain,verbose)
+
 		# checking if its a valid toolchain 
 		toolchain_exists(toolchain,verbose)
 	
+		
 		tcname,tcversion=toolchain
 
 	

--- a/framework/modules.py
+++ b/framework/modules.py
@@ -196,8 +196,8 @@ def software_exists(software,verbose):
 	checks whether software exist, there must be a module file present with the 
 	same name specified as the argument. 
 	"""
-	success_msg = "Checking Software Exists ... SUCCESS"  
-	fail_msg = "Checking Software Exists ... FAILED"
+	success_msg = "Checking Software: " + software[0] + "/" + software[1] + "  ... SUCCESS"  
+	fail_msg = "Checking Software: " + software[0] + "/" + software[1] + " ... FAILED"
 	if len(software) != 2:
 		print fail_msg
 		msg = "Too many arguments, -s takes argument <software>,<version> \n"
@@ -225,8 +225,8 @@ def toolchain_exists(toolchain,verbose):
 	"""
 	checks to see if toolchain passed on command line exist in toolchain list
 	"""
-	success_msg = "Checking Toolchain Exists ... SUCCESS"
-	fail_msg = "Checking Software Exists ... FAILED"
+	success_msg = "Checking Toolchain: " + toolchain[0] + "/" + toolchain[1] + " ... SUCCESS"
+	fail_msg = "Checking Toolchain: " + toolchain[0] + "/" + toolchain[1] + " ... FAILED"
         # catch all exception cases for invalid value for -t flag
         if len(toolchain) != 2:
 		print fail_msg
@@ -384,28 +384,19 @@ def check_software_version_in_easyconfig(easyconfig_repo,software,toolchain, ver
 		BUILDTEST_LOGCONTENT.append("Version Suffix: " + versionsuffix + "\n")
 		BUILDTEST_LOGCONTENT.append("Version + Version Suffix: " + version_versionsuffix + "\n")
 
-		# master condition to determine if easyconfig parameter match argument for software and toolchain
-		if tcname == "dummy" and tcversion == "dummy":
-			if name == appname and version_versionsuffix == appversion:
-				BUILDTEST_LOGCONTENT.append("Comparing strings: the following strings \n" )
-				BUILDTEST_LOGCONTENT.append("name: " + name + " with appname: " + appname + " AND ")
-				BUILDTEST_LOGCONTENT.append("version_versionsuffix: " + version_versionsuffix + " with appversion: " + appversion + "\n")
-				print success_msg
-				return True
-		else:
-			if name == appname and version_versionsuffix == appversion and toolchain_name == tcname and toolchain_version == tcversion:
-				BUILDTEST_LOGCONTENT.append("Comparing strings: the following strings \n") 
-				BUILDTEST_LOGCONTENT.append("name:" + name + " with appname = " + appname + " AND ")
-				BUILDTEST_LOGCONTENT.append("version_versionsuffix: " + version_versionsuffix + " with appversion: " + appversion + " AND ")
-				BUILDTEST_LOGCONTENT.append("toolchain_name: " + toolchain_name + " with tcname: " + tcname + " AND ")
-				BUILDTEST_LOGCONTENT.append("toolchain_version: " + toolchain_version + "with tcversion: " + tcversion + "\n")
-				print success_msg
-				return True
+		if name == appname and version_versionsuffix == appversion and toolchain_name == tcname and toolchain_version == tcversion:
+			BUILDTEST_LOGCONTENT.append("Comparing strings: the following strings \n") 
+			BUILDTEST_LOGCONTENT.append("name:" + name + " with appname = " + appname + " AND ")
+			BUILDTEST_LOGCONTENT.append("version_versionsuffix: " + version_versionsuffix + " with appversion: " + appversion + " AND ")
+			BUILDTEST_LOGCONTENT.append("toolchain_name: " + toolchain_name + " with tcname: " + tcname + " AND ")
+			BUILDTEST_LOGCONTENT.append("toolchain_version: " + toolchain_version + "with tcversion: " + tcversion + "\n")
+			print success_msg
+			return True
 
 	# mismatch in easyconfig entries for name,version+versionsuffix, and toolchain with specified entries
 	if match == False:
 		print fail_msg
-	 	msg = "Can't find easyconfig file with argument: -s " + appname + "/" + appversion + " -t " + tcname + "/" + tcversion
+	 	msg = "ERROR: Attempting to  find easyconfig file  " + appname + "-" + appversion + "-" + tcname + "-" + tcversion + ".eb"
 		print msg
 		BUILDTEST_LOGCONTENT.append(msg)
 		update_logfile(verbose)

--- a/framework/tools/generic.py
+++ b/framework/tools/generic.py
@@ -32,12 +32,10 @@ def check_buildtest_setup():
 	print "=============================================="
 	
 	print "Checking buildtest environment variables ..."
-	time.sleep(0.5)
 
 	ec = 0
 
-	print "Checking BUILDTEST_ROOT ..."
-	time.sleep(0.5)
+	time.sleep(0.2)
 	if not os.path.exists(os.environ["BUILDTEST_ROOT"]):
 		ec = 1
 		print "STATUS: BUILDTEST_ROOT is not set ... FAILED"
@@ -45,8 +43,7 @@ def check_buildtest_setup():
 		print "STATUS: BUILDTEST_ROOT ... PASSED"
 
 
-	print "Checking BUILDTEST_SOURCEDIR ..."
-	time.sleep(0.5)
+	time.sleep(0.2)
 	if not os.path.exists(os.environ["BUILDTEST_SOURCEDIR"]):
 		ec = 1
 		print "STATUS: BUILDTEST_SOURCEDIR is not set ... FAILED"
@@ -54,8 +51,7 @@ def check_buildtest_setup():
 		print "STATUS: BUILDTEST_SOURCEDIR ... PASSED" 
 
 	
-	print "Checking BUILDTEST_TESTDIR ..."
-	time.sleep(0.5)
+	time.sleep(0.2)
 	if not os.path.exists(os.environ["BUILDTEST_TESTDIR"]):
 		ec = 1
 		print "STATUS: BUILDTEST_TESTDIR is not set ... FAILED"
@@ -64,8 +60,7 @@ def check_buildtest_setup():
 
 
 
-	print "Checking BUILDTEST_MODULE_EBROOT ..."
-	time.sleep(0.5)
+	time.sleep(0.2)
 	if not os.path.exists(os.environ["BUILDTEST_MODULE_EBROOT"]):
 		ec = 1
 		print "STATUS: BUILDTEST_MODULE_EBROOT is not set"
@@ -73,8 +68,7 @@ def check_buildtest_setup():
 		print "STATUS: BUILDTEST_MODULE_EBROOT ... PASSED"
 	
 
-	print "Checking BUILDTEST_EASYCONFIGDIR ..."
-	time.sleep(0.5)
+	time.sleep(0.2)
 	if not os.path.exists(os.environ["BUILDTEST_EASYCONFIGDIR"]):
 		ec = 1
 		print "STATUS: BUILDTEST_EASYCONFIGDIR is not set ... FAILED"
@@ -82,8 +76,7 @@ def check_buildtest_setup():
 		print "STATUS: BUILDTEST_EASYCONFIGDIR ... PASSED"
 	
 
-	print "Checking BUILDTEST_R_DIR ..."
-	time.sleep(0.5)
+	time.sleep(0.2)
 	if not os.path.exists(os.environ["BUILDTEST_R_DIR"]):
 		ec = 1
 		print "STATUS: BUILDTEST_R_DIR is not set"
@@ -91,8 +84,7 @@ def check_buildtest_setup():
 		print "STATUS: BUILDTEST_R_DIR ... PASSED"
 
 
-	print "Checking BUILDTEST_PERL_DIR ..."
-	time.sleep(0.5)
+	time.sleep(0.2)
 	if not os.path.exists(os.environ["BUILDTEST_PERL_DIR"]):
 		ec = 1
 		print "STATUS: BUILDTEST_PERL_DIR is not set ... FAILED"
@@ -100,8 +92,7 @@ def check_buildtest_setup():
 		print "STATUS: BUILDTEST_PERL_DIR ... PASSED"
 	
 
-	print "Checking BUILDTEST_PYTHON_DIR ..."
-	time.sleep(0.5)
+	time.sleep(0.2)
 	if not os.path.exists(os.environ["BUILDTEST_PYTHON_DIR"]):
 		ec = 1
 		print "STATUS: BUILDTEST_PYTHON_DIR is not set ... FAILED"
@@ -111,15 +102,21 @@ def check_buildtest_setup():
 	if ec == 0:
 		print "buildtest environment variable PASSED!"
 
-	print "Checking module command ..."
-	time.sleep(0.5)
+	time.sleep(0.2)
 
 	cmd = "module --version"
 	ret = subprocess.Popen(cmd,shell=True,stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-	ret.communicate()
+	(outputmsg,errormsg) = ret.communicate()
 	ec = ret.returncode
+
 	if ec == 0:
-		print "module command found!:"
+		print "Detecting module command .... "
+		print outputmsg, errormsg
+
+	else:
+		print "module commmand not found in system"
+		print outputmsg, errormsg
+
 
 	# detecting whether we have Lmod or environment-modules
 	# query Lmod rpm 
@@ -133,8 +130,9 @@ def check_buildtest_setup():
 
 	cmd = "rpm -q environment-modules"
 	ret = subprocess.Popen(cmd,shell=True,stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-	(outputmsg,errormsg) = ret.communicate()
+	(outputmsg) = ret.communicate()[0]
 	ec = ret.returncode
+
 	if ec == 0:
 		print "System detected environment-modules found package - ", outputmsg
 


### PR DESCRIPTION
Displayed package name when invoking software_exists and toolchain_exists
module. Arguments for --software and --toolchain will check for software
to ensure module file exists. This was a bug in previous implementation
only checked for software for argument to --software.

Fixed a bug in easyconfig check when dummy argument is passed for toolchain.
Now easyconfig has strict checking to ensure easyconfig is found and matches
argument to --software & --toolchain.