### PR TITLE
adding flag --submitjob to automate job submission with LSF

### DIFF
--- a/framework/main.py
+++ b/framework/main.py
@@ -35,6 +35,7 @@ sys.path.insert(0,os.path.abspath('.'))
 from framework.env import BUILDTEST_ROOT, BUILDTEST_LOGDIR, BUILDTEST_MODULE_NAMING_SCHEME, BUILDTEST_SOURCEDIR, BUILDTEST_TESTDIR, BUILDTEST_MODULE_EBROOT, BUILDTEST_EASYCONFIGDIR, BUILDTEST_JOB_EXTENSION, logID
 from framework.runtest import runtest_menu
 from framework.test.binarytest import generate_binary_test
+from framework.test.job import submit_job_to_scheduler
 from framework.test.sourcetest import recursive_gen_test
 from framework.test.testsets import run_testset
 from framework.tools.check_setup import check_buildtest_setup
@@ -82,7 +83,8 @@ def main():
 	sysyaml = args_dict["sysyaml"]
 	ebyaml = args_dict["ebyaml"]
 	jobtemplate = args_dict["job_template"]
-	
+	submitjob = args_dict["submitjob"]
+
 	if version == True:
 		buildtest_version()
 		sys.exit(1)
@@ -130,6 +132,9 @@ def main():
 		if os.path.splitext(jobtemplate)[1]  not in BUILDTEST_JOB_EXTENSION:
 			print "Invalid file extension, must be one of the following extension", BUILDTEST_JOB_EXTENSION
 			sys.exit(1)
+	if submitjob != None:
+		submit_job_to_scheduler(submitjob)
+		sys.exit(0)
 
 	if sysyaml != None:
 		create_system_yaml(sysyaml)

--- a/framework/test/job.py
+++ b/framework/test/job.py
@@ -24,10 +24,14 @@
 This file generates the job script
 :author: Shahzeb Siddiqui (Pfizer)
 """
-
+from framework.env import BUILDTEST_ROOT
 from shutil import copyfile
 import os
+import glob
 def generate_job(testpath,shell_type, jobtemplate):
+
+	if not os.path.isabs(jobtemplate):
+		jobtemplate=os.path.join(BUILDTEST_ROOT,jobtemplate)
 
         jobname = os.path.splitext(testpath)[0]
         jobext = os.path.splitext(jobtemplate)[1]
@@ -37,4 +41,21 @@ def generate_job(testpath,shell_type, jobtemplate):
         cmd  = shell_type + " " + testpath
         fd.write(cmd)
         fd.close()
+
+def submit_job_to_scheduler(job_path):
+
+	job_ext = ".lsf"
+	job_launcher = "bsub"
+	if os.path.isdir(job_path):
+		for root, dirs, files in os.walk(job_path):
+			for file in files:
+				if file.endswith(job_ext):
+					cmd = job_launcher + " < " + os.path.join(root,file) 
+					os.system(cmd)
+				
+					print "Submitting Job:", os.path.join(root,file), " to scheduler"
+	if os.path.isfile(job_path):
+		cmd = job_launcher + " < " + job_path
+		os.system(cmd)
+		print "Submitting Job:", job_path, " to scheduler"
 

--- a/framework/tools/menu.py
+++ b/framework/tools/menu.py
@@ -53,6 +53,7 @@ in eb stack and system packages""", action="store_true")
 	parser.add_argument("--sysyaml", help = "generate binary test YAML configuration for system package")
 	parser.add_argument("--ebyaml", help = "generate binary test YAML configuration for easybuild package (Not Implemented)")
 	parser.add_argument("--job-template", help = "specify  job template file to create job submission script for the test to run with resource scheduler")
+	parser.add_argument("--submitjob", help = "specify a directory or job script to submit to resource scheduler")
         args = parser.parse_args()
 
         return args


### PR DESCRIPTION
Fixed an issue when using --job-template, the file was not copying
when using relative path.