### PR TITLE
Fix output of -svr with concurrent software,version modules in different trees 

### DIFF
--- a/framework/main.py
+++ b/framework/main.py
@@ -49,17 +49,17 @@ from framework.tools.utility import  print_set
 from framework.tools.utility import get_appname, get_appversion, get_toolchain_name, get_toolchain_version
 from framework.tools.version import buildtest_version
 
+
 import subprocess
 import argparse
 import logging
 from datetime import datetime
-import fnmatch
 import glob
 
 def main():
 	module=""
 	version=""
-	
+
 	args = buildtest_menu()
 
 	# convert args into a dictionary
@@ -109,7 +109,7 @@ def main():
                 sys.exit(0)
 
         if list_unique_software == True:
-                software_set=get_unique_software(BUILDTEST_MODULE_EBROOT)
+                software_set=get_unique_software()
                 text =  """ \n
                        List of Unique Software:
                        ---------------------------- \n """
@@ -119,7 +119,7 @@ def main():
                 sys.exit(0)
 
         if sw_ver_relation == True:
-                software_dict = software_version_relation(BUILDTEST_MODULE_EBROOT)
+                software_dict = software_version_relation()
 		print_software_version_relation(software_dict)
                 sys.exit(0)
 

--- a/framework/tools/modules.py
+++ b/framework/tools/modules.py
@@ -33,20 +33,22 @@ This python module does the following
 :author: Shahzeb Siddiqui (Pfizer)
 """
 
-from framework.env import BUILDTEST_MODULE_NAMING_SCHEME
+from framework.env import BUILDTEST_MODULE_NAMING_SCHEME,BUILDTEST_MODULE_EBROOT
 from framework.tools.menu import buildtest_menu
 from framework.tools.utility import get_appname, get_appversion, get_toolchain_name, get_toolchain_version
 import os
 
 
-def get_module_list(moduletree):
+def get_module_list():
 	"""
-	returns a complete list of modules found in module tree
+	returns a complete list of modules and full path in module tree
 	"""
-	find_cmd_module=os.popen("find " + moduletree + " -type f """).read()
-        modulelist=find_cmd_module.rstrip().split('\n')
-	return modulelist
+	modulefiles = []
+	for root, dirs, files in os.walk(BUILDTEST_MODULE_EBROOT):
+		for file in files:
+			modulefiles.append(os.path.join(root,file))
 
+	return modulefiles
 
 
 def load_modules():

--- a/framework/tools/print_functions.py
+++ b/framework/tools/print_functions.py
@@ -34,7 +34,10 @@ def print_software_version_relation(software_dict):
 -----|----------------------------|----------------------------- """
 	print text
 	count = 0
-        for key in software_dict:
+	keylist = software_dict.keys()
+	keylist.sort()
+        for key in keylist:
 		count = count + 1
-                print (str(count) + "\t |").expandtabs(4) , "\t" + (key + "\t |" ).expandtabs(25) + "\t", sset(software_dict[key])
+		for value in sset(software_dict[key]):
+	        	print (str(count) + "\t |").expandtabs(4) , "\t" + (key + "\t |" ).expandtabs(25) + "\t" +  value
 

--- a/framework/tools/software.py
+++ b/framework/tools/software.py
@@ -85,23 +85,23 @@ def get_toolchain_version():
 		return toolchain[1]
 
 
-def get_unique_software(moduletrees):
+def get_unique_software():
         """
         returns a set of software packages found in the module tree
         """
         logger = logging.getLogger(logID)
-        logger.info("Traversing Module Tree: %s to find all unique software", moduletrees)
+        logger.info("Traversing Module Tree: %s to find all unique software", BUILDTEST_MODULE_EBROOT)
 
-        moduletreelist=moduletrees.split(":")
+        #moduletreelist=moduletrees.split(":")
         module_set=set()
-        for moduletree in moduletreelist:
-                modulelist=get_module_list(moduletree)
-                module_set=set()
-                for module in modulelist:
-                        # extract the module name from filepath
-                        modulename=os.path.basename(os.path.dirname(module))
-                        #modulename=os.popen(os.path.basename(module)).read().rstrip()
-                        module_set.add(modulename)
+        #for moduletree in moduletreelist:
+        modulelist=get_module_list()
+
+	# extract module name and add to module set
+        for module in modulelist:
+        	# extract the module name from filepath
+                modulename=os.path.basename(os.path.dirname(module))
+                module_set.add(modulename)
 
         logger.info("List of modules found:")
         logger.info("----------------------------------------")
@@ -109,53 +109,52 @@ def get_unique_software(moduletrees):
         return sorted(module_set)
 
 
-def get_unique_software_version(moduletree):
+def get_unique_software_version():
         """
         returns a set of software-version collection found in module files. Duplicates are
         ignored for instance, same package version is built with two different toolchains
         """
         moduleversion_set=set()
-        modulelist=get_module_list(moduletree)
+        modulelist=get_module_list()
 
         for module in modulelist:
                 # extract the module name and version from the file path returned from find
                 modulename = os.path.basename(os.path.dirname(module))
                 version=os.path.basename(module)
+
+		ext = os.path.splitext(version)[1]
                 # skip .version files
-                if version == ".version":
+                if ext == ".version":
                         continue
 
                 # if modulefile is lua extension then strip extension from version
-                if version[-4:] == ".lua":
-                        version=version[:-4]
+                if ext == ".lua":
+                        version=os.path.splitext(version)[0]
 
                 moduleversion_set.add(modulename+" "+version)
 
         return sorted(moduleversion_set)
 
 
-def software_version_relation(moduletree):
+def software_version_relation():
         """
         relationship between software name and version. The function will return a
         dictionary with key values as software name and values will be a set of version
         """
-        modulelist=get_module_list(moduletree)
+        modulelist=get_module_list()
 
-        module_set=get_unique_software(moduletree)
+        module_set=get_unique_software()
         # This set contains one entry of sorted lists of modules, need to iterate over list and not set.
         #module_set = module_set[0]
 
         # dictionary used for keeping a relationship between software name and its corresponding versions found as modulefiles
         module_dict = {}
 
-        logger = logging.getLogger(logID)
-        logger.info("Calculating Application Modules with corresponding versions ...")
 
         # for every app iterate over module tree and add unique version in set, then add this to a dictionary. That way
         # a dictionary can reference via key,value where key is application name and value is the list of versions
         for item in  module_set:
                 version_set = set()
-                logger.debug("Application: %s", item)
                 for app in modulelist:
                         #logger.debug("ModuleFile: %s", app)
                         name = os.path.basename(os.path.dirname(app))
@@ -166,37 +165,11 @@ def software_version_relation(moduletree):
 
                         version = os.path.basename(app)
                         version = os.path.splitext(version)[0]
-                        logger.debug("Extracting Version: %s from ModuleFile: %s", version, app)
 
                         # only add module version to set when module name is found in tree
-                        #if item == name:
-                        version_set.add(version)
-                        logger.debug("APPLICATION: %s - Adding %s to version_set: %s ",name, version, list(version_set))
+                        version_set.add(version + " (" + app +")")
 
                 module_dict[item] = version_set
-
-        text = """
-                        ------------------------------------------
-                        |      Software Version Relationship     |
-                        ------------------------------------------
-
-
- ID  |        Software            |      Versions
------|----------------------------|----------------------------- """
-        #print text
-
-        text = text.splitlines()
-        for line in text:
-                logger.info(line)
-
-        # sorting keys in dictionary for printing in alphabetical order by software name
-        keylist = module_dict.keys()
-        keylist.sort()
-        count = 1
-        for key in keylist:
-                #print (str(count) + "\t |").expandtabs(4) , "\t" + (key + "\t |" ).expandtabs(25) + "\t", sset(module_dict[key])
-                logger.info("%s %s %s", (str(count) + "\t |").expandtabs(4) , "\t" + (key + "\t |" ).expandtabs(25) + "\t", sset(module_dict[key]))
-                count = count + 1
 
         return module_dict
 
@@ -219,7 +192,7 @@ def software_exists(software):
                 logger.error("%s",msg)
                 sys.exit(1)
 
-        softwarecollection=get_unique_software_version(BUILDTEST_MODULE_EBROOT)
+        softwarecollection=get_unique_software_version()
         software_name=software[0]+" "+software[1]
 
         logger.debug("Checking %s is found in software version list", software_name)


### PR DESCRIPTION
…t missed

when same app version module was installed in different module trees. Now module set
adds the modulepath to ensure all modules are added correctly.

Removed all reference to argument moduletree that was passed into to several
modules. Now get_module_list will operate on BUILDTEST_MODUL_EBROOT by default. Now
you can't pass multiple module trees into the modules