### PR TITLE
Add complete support for option --ebyaml.

### DIFF
--- a/framework/main.py
+++ b/framework/main.py
@@ -47,7 +47,7 @@ from framework.tools.file import create_dir
 from framework.tools.find import find_all_yaml_configs, find_yaml_configs_by_arg
 from framework.tools.find import find_all_tests, find_tests_by_arg
 from framework.tools.easybuild import list_toolchain, find_easyconfigs, is_easybuild_app
-from framework.tools.generate_yaml import create_system_yaml
+from framework.tools.generate_yaml import create_system_yaml, create_software_yaml
 from framework.tools.log import init_log, clean_logs
 from framework.tools.menu import buildtest_menu
 from framework.tools.modules import diff_trees, module_load_test
@@ -175,7 +175,7 @@ def main():
         create_system_yaml(bt_opts.sysyaml)
 
     if bt_opts.ebyaml != None:
-        raise NotImplementedError
+        create_software_yaml(bt_opts.ebyaml)
 
 
     logger,logpath,logfile = init_log()
@@ -194,7 +194,7 @@ def main():
         logger.debug(line)
 
     get_system_info()
-        
+
     # generate system pkg test
     if bt_opts.system is not None:
         if bt_opts.system == "all":

--- a/framework/tools/generate_yaml.py
+++ b/framework/tools/generate_yaml.py
@@ -31,7 +31,7 @@ import sys
 import yaml
 from framework.env import config_opts
 from framework.tools.file import create_dir
-from framework.tools.software import get_unique_software
+from framework.tools.software import get_unique_software, get_toolchain_stack, get_binaries_from_application
 from framework.tools.system import check_system_package_installed, get_binaries_from_systempackage
 def create_system_yaml(name):
     """ create YAML configuration for binary test for system package """
@@ -56,10 +56,44 @@ def create_system_yaml(name):
     # get binary from system package
     binary = get_binaries_from_systempackage(name)
 
-    # no test, then stop immediately
-    if len(binary) == 0:
-        print "There are no binaries found in package: ", name
+    fd = open(yamlfile,"w")
+    binarydict = { "binaries": binary }
+    with open(yamlfile, 'a') as outfile:
+        yaml.dump(binarydict, outfile, default_flow_style=False)
+
+    print "Please check YAML file", yamlfile, " and fix test accordingly"
+    sys.exit(0)
+
+def create_software_yaml(module_name):
+    """ create yaml configuration for software packages """
+    BUILDTEST_CONFIGS_REPO = config_opts['BUILDTEST_CONFIGS_REPO']
+
+    binary = get_binaries_from_application(module_name)
+
+    toolchain_stack = get_toolchain_stack()
+    toolchain_name = [name.split("/")[0] for name in toolchain_stack]
+    # get module version
+    module_version = module_name.split("/")[1]
+    # remove any toolchain from module version when figuring path to yaml file
+    for tc in toolchain_name:
+        idx = module_version.find(tc)
+
+        if idx != -1:
+            module_name = module_name.split("/")[0] + "/" + module_version[0:idx-1]
+
+
+
+    module_name = module_name.lower()
+    destdir = os.path.join(BUILDTEST_CONFIGS_REPO,"ebapps",module_name)
+    yamlfile = os.path.join(destdir,"command.yaml")
+    
+    # if yaml file exists then exit out
+    if os.path.isfile(yamlfile):
+        print "YAML file already exists, please check: ", yamlfile
         sys.exit(0)
+
+    # if directory is not present then create it
+    create_dir(destdir)
 
     fd = open(yamlfile,"w")
     binarydict = { "binaries": binary }

--- a/framework/tools/system.py
+++ b/framework/tools/system.py
@@ -79,6 +79,10 @@ def get_binaries_from_systempackage(pkg):
         if statmode and os.path.dirname(file) in bindirs:
             binarylist.append(file)
 
+    if len(binarylist) == 0:
+        print "There are no binaries found in package: ", name
+        sys.exit(0)
+
 	return binarylist
 
 def systempackage_installed_list():


### PR DESCRIPTION
Binary yaml configs will be stored in each version sub-directory since 
test may differ amongst different versions.