### PR TITLE
add option --python-package to build python packages. 

### DIFF
--- a/framework/main.py
+++ b/framework/main.py
@@ -40,8 +40,10 @@ from framework.env import config_opts
 from framework.test.binarytest import generate_binary_test
 from framework.test.function import clean_tests
 from framework.test.job import submit_job_to_scheduler, update_job_template
+from framework.test.python import build_python_test
 from framework.test.sourcetest import recursive_gen_test
 from framework.test.testsets import run_testset
+from framework.tools.cmake import setup_software_cmake
 from framework.tools.config import check_configuration, show_configuration
 from framework.tools.file import create_dir
 from framework.tools.find import find_all_yaml_configs, find_yaml_configs_by_arg
@@ -266,6 +268,8 @@ def main():
         logger.debug("Config Directory: %s ", configdir)
         logger.debug("Code Directory: %s", codedir)
 
+        setup_software_cmake()
+        
         generate_binary_test(bt_opts,None)
 
         # this generates all the compilation tests found in application directory ($BUILDTEST_CONFIGS_REPO/ebapps/<software>)
@@ -275,6 +279,9 @@ def main():
         # if flag --testset is set, then
         if bt_opts.testset is not  None:
             run_testset(bt_opts)
+
+        if bt_opts.python_package:
+                build_python_test(bt_opts.python_package)
 
         # moving log file from $BUILDTEST_LOGDIR/buildtest_%H_%M_%d_%m_%Y.log to $BUILDTEST_LOGDIR/app/appver/tcname/tcver/buildtest_%H_%M_%d_%m_%Y.log
         os.rename(logpath, os.path.join(BUILDTEST_LOGDIR,logfile))

--- a/framework/test/python.py
+++ b/framework/test/python.py
@@ -1,0 +1,139 @@
+############################################################################
+#
+#  Copyright 2017
+#
+#   https://github.com/shahzebsiddiqui/buildtest
+#
+#  This file is part of buildtest.
+#
+#    buildtest is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    buildtest is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with buildtest.  If not, see <http://www.gnu.org/licenses/>.
+#############################################################################
+
+"""
+:author: Shahzeb Siddiqui (Pfizer)
+"""
+import logging
+import os
+import subprocess
+import sys
+from framework.env import config_opts, PYTHON_APPS, logID
+from framework.test.job import generate_job
+from framework.tools.file import create_dir
+from framework.tools.modules import load_modules
+from framework.tools.utility import get_appname, get_appversion, get_toolchain_name, get_toolchain_version
+
+
+
+def build_python_test(python_lib):
+    """ responsible for creating python test for python library"""
+
+    from framework.tools.cmake import add_test_to_CMakeLists, setup_software_cmake
+
+    BUILDTEST_PYTHON_REPO = config_opts['BUILDTEST_PYTHON_REPO']
+    BUILDTEST_TESTDIR = config_opts['BUILDTEST_TESTDIR']
+    BUILDTEST_SHELL = config_opts['BUILDTEST_SHELL']
+    BUILDTEST_ENABLE_JOB = config_opts['BUILDTEST_ENABLE_JOB']
+    BUILDTEST_JOB_TEMPLATE = config_opts['BUILDTEST_JOB_TEMPLATE']
+
+    appname = get_appname()
+    appver=get_appversion()
+    tcname=get_toolchain_name()
+    tcver=get_toolchain_version()
+
+    logger = logging.getLogger(logID)
+
+    if appname.lower() not in PYTHON_APPS:
+        print "ERROR: valid choices for software are the following: ", PYTHON_APPS
+        sys.exit(1)
+
+    app_destdir = os.path.join(BUILDTEST_TESTDIR,"ebapp",appname,appver,tcname,tcver)
+    cmakelist = os.path.join(app_destdir,"CMakeLists.txt")
+    python_package_dir = os.path.join(BUILDTEST_PYTHON_REPO,"python","code",python_lib)
+
+    if not os.path.exists(cmakelist):
+        setup_software_cmake()
+
+    check_python_library(python_lib)
+    count = 0
+    dummy_array=[]
+    for root,subdirs,files in os.walk(python_package_dir):
+
+        for file in files:
+            filename_strip_ext = os.path.splitext(file)[0]
+            ext = os.path.splitext(file)[1]
+
+            # skip if file is not .py extension
+            if ext != ".py":
+                    continue
+            # command to execute the script
+            cmd = "python " + os.path.join(root,file)
+
+            # getting subdirectory path to write test to correct path
+            subdir = os.path.basename(root)
+            subdirpath = os.path.join(app_destdir,subdir)
+            create_dir(subdirpath)
+
+            testname = filename_strip_ext + "." + BUILDTEST_SHELL
+            testpath = os.path.join(subdirpath,testname)
+            fd = open(testpath,'w')
+            header=load_modules(BUILDTEST_SHELL)
+            fd.write(header)
+            fd.write(cmd)
+            fd.close()
+
+            cmakelist = os.path.join(subdirpath,"CMakeLists.txt")
+            add_test_to_CMakeLists(app_destdir,subdir,cmakelist,testname)
+            msg = "Creating Test: " + testpath
+            logger.info(msg)
+            count = count + 1
+
+            if BUILDTEST_ENABLE_JOB:
+                generate_job(testpath,BUILDTEST_SHELL,BUILDTEST_JOB_TEMPLATE,dummy_array)
+
+        print "Generating ", count, "tests for ", os.path.basename(root)
+
+def python_lib_choices():
+    """ return a list of python libraries for --python-package option """
+    BUILDTEST_PYTHON_REPO = config_opts['BUILDTEST_PYTHON_REPO']
+    python_choices =  os.listdir(os.path.join(BUILDTEST_PYTHON_REPO,"python","code"))
+    return python_choices
+
+def check_python_library(python_lib):
+    """ check if python package exist for request python module, if it exists create test otherwise skip test creation"""
+
+    logger = logging.getLogger(logID)
+
+    appname=get_appname()
+    appver=get_appversion()
+
+    BUILDTEST_MODULE_NAMING_SCHEME = config_opts['BUILDTEST_MODULE_NAMING_SCHEME']
+    cmd = "module purge; module load " + os.path.join(appname,appver) + "; python -c \"import " + python_lib + "\""
+
+    if BUILDTEST_MODULE_NAMING_SCHEME == "HMNS":
+        tcname = get_toolchain_name()
+        tcver = get_toolchain_version()
+        if len(tcname) > 0:
+            cmd = "module purge; module load " + os.path.join(tcname,tcver) + "; module load " + os.path.join(appname,appver) + "; python -c \"import " +  python_lib + "\""
+
+    logger.debug("Check Python Package:" + python_lib)
+    logger.debug("Running command -" + cmd)
+
+    ret = subprocess.Popen(cmd,shell=True,stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+    ret.communicate()
+    ret_code = ret.returncode
+    if ret_code != 0:
+        print python_lib, "is not installed in software", os.path.join(appname,appver)
+        sys.exit(1)
+
+    print ret_code

--- a/framework/tools/cmake.py
+++ b/framework/tools/cmake.py
@@ -201,9 +201,9 @@ def setup_software_cmake():
         create_dir(test_toolchain_name_dir)
         create_dir(test_toolchain_version_dir)
 
-    # create CMakeList.txt file in each directory of <software>/<version>/<toolchain-name>/<toolchain-version> if it doesn't exist
+    # create CMakeList.txt file in each directory of $BUILDTEST_ROOT/<software>/<version>/<toolchain-name>/<toolchain-version> if it doesn't exist
+    create_file(test_cmakelist)
     create_file(test_ebapp_cmakelist)
-
     create_file(test_name_cmakelist)
     create_file(test_version_cmakelist)
 

--- a/framework/tools/menu.py
+++ b/framework/tools/menu.py
@@ -29,6 +29,7 @@ import argparse
 import argcomplete
 
 from framework.env import BUILDTEST_SHELLTYPES, config_opts
+from framework.test.python import python_lib_choices
 from framework.tools.options import override_configuration
 from framework.tools.system import systempackage_installed_list
 from framework.tools.software import get_software_stack, get_toolchain_stack,ebyaml_choices
@@ -44,6 +45,7 @@ class buildtest_menu():
 
 
         pkglist = systempackage_installed_list()
+        python_choices = python_lib_choices()
 
         yaml_apps = ebyaml_choices()
         software_list = get_software_stack()
@@ -59,14 +61,14 @@ class buildtest_menu():
             parser.add_argument("--testdir", help="Path to write buildtest tests. Overrides configuration BUILDTEST_TESTDIR")
             parser.add_argument("--ignore-easybuild", help="ignore if application is not built with easybuild",action="store_true")
             parser.add_argument("--show", help="show buildtest environment configuration", action="store_true")
-            parser.add_argument("--clean-build", help="delete test directory before writing test scripts", action="store_true")
+            parser.add_argument("--clean-build", help="delete software test directory before writing test scripts", action="store_true")
 
             group1 = parser.add_argument_group('Basic Options', 'buildtest basic options')
             group1.add_argument("-mns", "--module-naming-scheme", help="Specify module naming scheme for easybuild apps", choices=["HMNS","FNS"])
             group1.add_argument("--scantest", help=""" Report all tests that can be built with buildtest by checking all available apps found
             in eb stack and system packages""", action="store_true")
-            group1.add_argument("--clean-logs", help="delete buildtest logs",action="store_true")
-            group1.add_argument("--clean-tests",help="delete testing directory",action="store_true")
+            group1.add_argument("--clean-logs", help="delete buildtest log directory ($BUILDTEST_LOGDIR)",action="store_true")
+            group1.add_argument("--clean-tests",help="delete testing directory ($BUILDTEST_TESTDIR)",action="store_true")
 
             group2 = parser.add_argument_group('Find Options', 'buildtest options for finding software, toolchains, tests, yaml files')
 
@@ -88,10 +90,10 @@ class buildtest_menu():
                              To build all system package test use --system all """, choices=self.syspkg_list, metavar='SYSTEM-PACKAGE')
             group3.add_argument("--testset", help="Select the type of test set to run (Python, R, Ruby, Perl, Tcl, MPI)", choices=["Python","R","Ruby","Perl","Tcl","MPI"])
             group3.add_argument("--module-load-test", help="conduct module load test for all modules defined in BUILDTEST_MODULE_ROOT", action="store_true")
-
+            group3.add_argument("--python-package", help="build test for python packages", choices=self.python_choices,metavar='PYTHONPACKAGES')
             group4 = parser.add_argument_group('YAML Options', 'Options for YAML configuration')
-            group4.add_argument("--sysyaml", help = "generate binary test YAML configuration for system package", choices=self.pkglist, metavar='INSTALLED-SYSTEM-PACKAGE')
-            group4.add_argument("--ebyaml", help = "generate binary test YAML configuration for easybuild package (Not Implemented)", choices=self.yaml_apps, metavar='YAML-APP-CHOICES')
+            group4.add_argument("--sysyaml", help = "generate YAML configuration for binary test for system package", choices=self.pkglist, metavar='INSTALLED-SYSTEM-PACKAGE')
+            group4.add_argument("--ebyaml", help = "generate YAML configuration for binary test for software package", choices=self.yaml_apps, metavar='YAML-APP-CHOICES')
 
 
             group5 = parser.add_argument_group('Job Scheduler Options', 'Options for interacting with Job Scheduler')
@@ -101,6 +103,8 @@ class buildtest_menu():
 
             group6 = parser.add_argument_group('Miscellaneous Options', 'rest of buildtest options')
             group6.add_argument("--runtest", help="Run the test interactively through runtest.py", action="store_true")
+
+
             self.parser = parser
 
         #argcomplete.autocomplete(parser)


### PR DESCRIPTION
Choices are automatically generated and checks if python library exist before creating test. Fix cmake behavior and reuse prototype cmake methods in writing test to CMakeList for binary tests