### PR TITLE
Testing customized greeing to not run on forked pull requests

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,27 +1,13 @@
-name: Greetings
+name: First Issue Greeting
 
-on: [pull_request, issues]
+on: [issues]
 
 jobs:
   greeting:
     runs-on: ubuntu-latest
     steps:
-
-      - name: Derive if this is a forked pull request
-        if: github.event_name == 'pull_request'
-        run: echo ::set-env name=IS_FORKED::$(if [ -z "$GITHUB_HEAD_REF" ]; then echo "no"; else echo "yes"; fi)
-        shell: bash
-
-      - name: Pull Request Greeting
-        if: github.event_name == 'pull_request' && env.IS_FORKED == 'no'
-        uses: actions/first-interaction@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: 'This looks like your first pull request contribution. Great Work! '
-
       - name: Issue Greeting
-        if: github.event_name == 'issues'
         uses: actions/first-interaction@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: 'This looks like your first issue. Welcome to the community! '
+          issue-message: 'This looks like your first contribution. Thank you, and welcome to the community!'

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -6,8 +6,22 @@ jobs:
   greeting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/first-interaction@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: 'This looks like your first contribution, Great Work!!! '
-        pr-message: 'This looks like your first contribution, Great Work!!!'
+
+      - name: Derive if this is a forked pull request
+        if: github.event_name == 'pull_request'
+        run: echo ::set-env name=IS_FORKED::$(if [ -z "$GITHUB_HEAD_REF" ]; then echo "no"; else echo "yes"; fi)
+        shell: bash
+
+      - name: Pull Request Greeting
+        if: github.event_name == 'pull_request' && env.IS_FORKED == 'no'
+        uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: 'This looks like your first pull request contribution. Great Work! '
+
+      - name: Issue Greeting
+        if: github.event_name == 'issues'
+        uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: 'This looks like your first issue. Welcome to the community! '


### PR DESCRIPTION
Currently, if a user opens a pull request on a first, and it's their first PR (so the action is triggered to greet them) the greeting will fail because a forked PR does not have permission to post to the upstream repository. This update to the greeting recipe should modify the logic of greetings to derive if it's a fork, and only greet the user if it's on an organization branch. In practice, I've tended to just remove the PR greeting because it's unlikely that a new contributor will be part of the org, so that's another option. The issue greeting should work as expected.

Signed-off-by: vsoch <vsochat@stanford.edu>