### PR TITLE
removing the sponsor page from GitHub for now. CommunityBridge won't

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-community_bridge: HPC-buildtest


### PR DESCRIPTION
accept sponsor until we have 100 stars so no point in adding it now.