### PR TITLE
Add pre commit hook for black

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,67 @@
+#!/bin/sh
+#
+# This pre-commit hook will run black linting before finishing the commit.
+# If the linting has any failures (indicating a functional error) we don't commit.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, move / rename this file to .github/pre-commit.
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+## STEP 1: Black linting should be automatically done, unless there are
+#  functional issues, then the commit is cancelled, or if the user didn't
+#  install black, they should not be using the pre-commit.
+if black --version >/dev/null 2>&1
+then
+	printf "Black is installed\n"
+        black buildtest tests/*.py
+        if [ "$?" -ne "0" ]
+            then
+                printf "There was a problem with formatting, commit cancelled.\n"
+                exit 1
+        fi
+else
+	printf "Black is not installed. Install or remove hook to use it.\n"
+        exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+# exec git diff-index --check --cached $against --

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -55,8 +55,10 @@ Links to the following apps
 When contributing back to buildtest, please consider checking the following GitHub apps, most important being **Travis-CI**
 as it will test your pull request before merging to ``devel`` branch.
 
+
+
 GitHub Actions
------------------
+--------------
 
 buildtest runs a few automated checks via GitHub Actions that can be found in ``.github/workflows``
 
@@ -64,8 +66,28 @@ buildtest runs a few automated checks via GitHub Actions that can be found in ``
 
 - **URLs-checker** - buildtest is a GitHub action called **URLs-checker** found at https://github.com/marketplace/actions/urls-checker. The workflow is defined in `urlchecker.yml <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/.github/workflows/urlchecker.yml>`_
 
+GitHub Hooks
+------------
+
+The above actions check formatting, but are conservative and do not do commits to fix issues on behalf of the user.
+To support an easier workflow, we have provided a git hook that you can install locally to run black directly before each
+commit. To install the hook, simply copy the file to the ``.git/hooks`` folder as follows::
+
+    cp .github/hooks/pre-commit .git.hooks
+
+
+This hook will exit on error either if you don't have black installed::
+
+    pip install black==19.3b0
+
+
+or if you have black installed, but running it on the repository code results in an error due
+to a functional issue with the code. Code that simply needs to be formatted will be formatted,
+and then the commit will follow.
+
+
 GitHub Bots
--------------
+-----------
 
 Buildtest has a few bots to do various operations that are described below.
 


### PR DESCRIPTION
This is a first shot to add a pre-commit hook to run for the repository and run black to address #174. I have also added instructions to the docs for "installing it." I have installed it locally, and can test it for a few days to assess if it's working properly (the push to this branch was okay but I hadn't edited much python code).