### PR TITLE
fixing hooks typo in docs and adding examples folder to commit

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -52,7 +52,7 @@ fi
 if black --version >/dev/null 2>&1
 then
 	printf "Black is installed\n"
-        black buildtest tests/*.py
+        black buildtest tests/*.py examples/*.py
         if [ "$?" -ne "0" ]
             then
                 printf "There was a problem with formatting, commit cancelled.\n"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate black
-          black --check buildtest tests/*.py
+          black --check buildtest tests/*.py examples/*.py
 
       - name: Derive organization name
         if: github.event_name == 'pull_request' && failure()

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -73,7 +73,7 @@ The above actions check formatting, but are conservative and do not do commits t
 To support an easier workflow, we have provided a git hook that you can install locally to run black directly before each
 commit. To install the hook, simply copy the file to the ``.git/hooks`` folder as follows::
 
-    cp .github/hooks/pre-commit .git.hooks
+    cp .github/hooks/pre-commit .git/hooks/
 
 
 This hook will exit on error either if you don't have black installed::


### PR DESCRIPTION
This will fix the incorrect copy paste command for the git hook, and add the examples folder to be checked by black.

Signed-off-by: vsoch <vsochat@stanford.edu>