### PR TITLE
remove ModuleCollection class and merge methods into Module()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ script:
   - module use $LMOD_PKG/modulefiles/Core
   - echo $MODULEPATH
   - cd $TRAVIS_BUILD_DIR
+  - echo $MODULEPATH
+  - module av
   - coverage run buildtest_regtest.py
   - coverage report -m
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   - cd $TRAVIS_BUILD_DIR
   - echo $MODULEPATH
   - module av
-  - coverage run buildtest_regtest.py
+  - coverage run -m pytest -vra tests/
   - coverage report -m
 
 after_success:

--- a/buildtest/module.py
+++ b/buildtest/module.py
@@ -1,5 +1,6 @@
 from buildtest.tools.system import BuildTestCommand
 
+
 def get_all_collections():
     """Get all Lmod user collections that is retrieved by running ``module -t savelist``.
 
@@ -14,6 +15,7 @@ def get_all_collections():
     out = cmd.get_error().split()
 
     return out
+
 
 class Module:
     """Class declaration for Module class"""
@@ -34,12 +36,15 @@ class Module:
         self.debug = debug
         self.modules = modules
 
+        # when no modules are passed into initializer, just return immediately
         if self.modules is None:
             return
 
         # catch all exceptions to argument modules. Must be of type list or string.
         if (not isinstance(modules, list)) and (not isinstance(modules, str)):
-            raise TypeError(f"Expecting of type 'list' or 'string' for argument modules. Got of type {type(modules)}")
+            raise TypeError(
+                f"Expecting of type 'list' or 'string' for argument modules. Got of type {type(modules)}"
+            )
 
         # if argument is a string, than use space as delimeter to get list of all modules.
         if isinstance(modules, str):
@@ -144,7 +149,7 @@ class Module:
 
         print(out)
 
-    def get_collection(self,collection="default"):
+    def get_collection(self, collection="default"):
         """Return the command to restore a collection.
 
         :param collection: collection name to restore
@@ -158,7 +163,6 @@ class Module:
             raise TypeError(f"Type Error: {collection} is not of type string")
 
         return f"module restore {collection}"
-
 
     def test_collection(self, collection="default"):
         """Test the module collection by running ``module restore <collection>``.

--- a/buildtest/module.py
+++ b/buildtest/module.py
@@ -1,6 +1,5 @@
 from buildtest.tools.system import BuildTestCommand
 
-
 def get_all_collections():
     """Get all Lmod user collections that is retrieved by running ``module -t savelist``.
 
@@ -16,61 +15,10 @@ def get_all_collections():
 
     return out
 
-
-class ModuleCollection:
-    """Class declaration of ModuleCollection."""
-
-    def __init__(self, collection, debug=True):
-        """Initializer method of ModuleCollection class.
-
-        :param collection: name of module collection
-        :param debug: debug mode for troubleshooting
-
-        :type collection: str
-        :type debug: bool
-        """
-        self.debug = debug
-
-        # raise TypeError exception if collection is not a string type since that is required
-        # when working with module collection
-        if not isinstance(collection, str):
-            raise TypeError(f"Type Error: {collection} is not of type string")
-
-        self.collection = collection
-        self.module_cmd = f"module restore {self.collection}"
-
-    def test_collection(self):
-        """Test the module collection by running ``module restore <collection>``.
-
-        :return: return code of ``module restore`` command
-        :rtype: int
-        """
-
-        cmd = BuildTestCommand()
-        cmd.execute(self.module_cmd)
-        ret = cmd.returnCode()
-
-        # print executed command for debugging
-        if self.debug:
-            print(f"[DEBUG] Executing module command: {self.module_cmd}")
-            print(f"[DEBUG] Return Code: {ret}")
-
-        return ret
-
-    def get_command(self):
-        """ Get the module command used to restore a collection
-
-        :return: Return the actual command to restore a collection.
-        :rtype: str
-        """
-
-        return self.module_cmd
-
-
 class Module:
     """Class declaration for Module class"""
 
-    def __init__(self, modules, purge=True, force=False, debug=False):
+    def __init__(self, modules=None, purge=True, force=False, debug=False):
         """Initialize method for Module class.
 
         :param modules: list of modules
@@ -86,9 +34,16 @@ class Module:
         self.debug = debug
         self.modules = modules
 
-        # convert input to list if not specified already.
-        if not isinstance(modules, list):
-            self.modules = [modules]
+        if self.modules is None:
+            return
+
+        # catch all exceptions to argument modules. Must be of type list or string.
+        if (not isinstance(modules, list)) and (not isinstance(modules, str)):
+            raise TypeError(f"Expecting of type 'list' or 'string' for argument modules. Got of type {type(modules)}")
+
+        # if argument is a string, than use space as delimeter to get list of all modules.
+        if isinstance(modules, str):
+            self.modules = modules.split(" ")
 
         # building actual command. Note that we are doing command chaining when loading modules
         self.module_load_cmd = [f"module load {x} && " for x in self.modules]
@@ -188,3 +143,43 @@ class Module:
             print(f"[DEBUG] Return Code: {ret}")
 
         print(out)
+
+    def get_collection(self,collection="default"):
+        """Return the command to restore a collection.
+
+        :param collection: collection name to restore
+        :type collection: str
+
+        :return: return the ``module restore`` command with the collection name
+        :rtype: str
+        """
+        # raise error if collection is not a string
+        if not isinstance(collection, str):
+            raise TypeError(f"Type Error: {collection} is not of type string")
+
+        return f"module restore {collection}"
+
+
+    def test_collection(self, collection="default"):
+        """Test the module collection by running ``module restore <collection>``.
+        :param collection: collection name to test
+        :type collection: str
+
+        :return: return code of ``module restore`` against the collection name
+        :rtype: int
+        """
+        # raise error if collection is not a string
+        if not isinstance(collection, str):
+            raise TypeError(f"Type Error: {collection} is not of type string")
+
+        module_restore_cmd = f"module restore {collection}"
+        cmd = BuildTestCommand()
+        cmd.execute(module_restore_cmd)
+        ret = cmd.returnCode()
+
+        # print executed command for debugging
+        if self.debug:
+            print(f"[DEBUG] Executing command: {module_restore_cmd}")
+            print(f"[DEBUG] Return Code: {ret}")
+
+        return ret

--- a/examples/collection.py
+++ b/examples/collection.py
@@ -1,21 +1,20 @@
-from buildtest.module import get_all_collections, ModuleCollection
+from buildtest.module import get_all_collections, Module
 
 collections = get_all_collections()
 
-# adding a collection name "invalid_collection" that is bound to fail
-collections = collections + ["invalid_collection"]
 for i in collections:
-    collection_object = ModuleCollection(i)
-    print(collection_object.get_command())
-    ec = collection_object.test_collection()
-    if ec != 0:
-        print(f"Failed to load collection: {i} with exit status: {ec}")
-    else:
-        print(f"Successfully loaded collection: {i}")
+    a = Module()
+    restore_cmd, ret_code = a.get_collection(i), a.test_collection(i)
+
+    print(f"Collection Command: {restore_cmd}    Return Code: {ret_code}")
 
 # test Python collection with debug enabled
-a = ModuleCollection("Python", debug=True)
+a = Module(debug=True)
+a.test_collection("Python")
+
+# test default collection with debug enabled
+a = Module(debug=True)
 a.test_collection()
 
-# Type Error when passing a collection name not of string type
-ModuleCollection(1)
+# This will raise an exception
+a.test_collection(1)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -26,14 +26,6 @@ def test_module_deps():
     find_module_deps("GCCcore/8.1.0")
     module_tree_rm(["/mxg-hpc/users/ssi29/easybuild-HMNS/modules/all/Core"])
 
-
-@pytest.mark.skip("not working")
-def test_diff_trees():
-    diff_trees(
-        "/mxg-hpc/users/ssi29/easybuild-HMNS/modules/all/Core,/usr/share/lmod/lmod/modulefiles/Core/"
-    )
-
-
 @pytest.mark.skip("not working")
 def test_easybuild_modules():
     module_tree_add(["/opt/easybuild/modules/all"])

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -12,6 +12,7 @@ from buildtest.tools.modulesystem.tree import module_tree_add, module_tree_rm
 from buildtest.tools.log import BuildTestError
 from buildtest.module import Module, get_all_collections
 
+
 @pytest.mark.skip("not working")
 def test_spack_modules():
     module_tree_add(["/mxg-hpc/users/ssi29/spack/modules/linux-rhel7-x86_64/Core"])
@@ -25,9 +26,13 @@ def test_module_deps():
     find_module_deps("GCCcore/8.1.0")
     module_tree_rm(["/mxg-hpc/users/ssi29/easybuild-HMNS/modules/all/Core"])
 
+
 @pytest.mark.skip("not working")
 def test_diff_trees():
-    diff_trees("/mxg-hpc/users/ssi29/easybuild-HMNS/modules/all/Core,/usr/share/lmod/lmod/modulefiles/Core/")
+    diff_trees(
+        "/mxg-hpc/users/ssi29/easybuild-HMNS/modules/all/Core,/usr/share/lmod/lmod/modulefiles/Core/"
+    )
+
 
 @pytest.mark.skip("not working")
 def test_easybuild_modules():
@@ -36,7 +41,6 @@ def test_easybuild_modules():
     module_tree_rm(["/opt/easybuild/modules/all"])
 
 
-@pytest.mark.skip("not working")
 def test_module_diff():
     """Testing module difference between two trees. First test is testing against same module tree, and the second
         test is against a different tree. """
@@ -62,11 +66,12 @@ def test_module_diff_invalid_args():
 def test_list_all_parents():
     list_all_parent_modules()
 
+
 class TestModule:
     def test_module(self):
         mod_names = ["lmod"]
         a = Module(mod_names)
-        a.get_command()
+        print(a.get_command())
         assert 0 == a.test_modules()
 
         b = Module(mod_names, force=True)
@@ -118,4 +123,3 @@ class TestModule:
     )
     def test_type_error(self):
         a = Module(1)
-

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -10,7 +10,7 @@ from buildtest.tools.modules import (
 from buildtest.tools.modulesystem.module_difference import diff_trees
 from buildtest.tools.modulesystem.tree import module_tree_add, module_tree_rm
 from buildtest.tools.log import BuildTestError
-from buildtest.module import Module, ModuleCollection, get_all_collections
+from buildtest.module import Module, get_all_collections
 
 @pytest.mark.skip("not working")
 def test_spack_modules():
@@ -36,6 +36,7 @@ def test_easybuild_modules():
     module_tree_rm(["/opt/easybuild/modules/all"])
 
 
+@pytest.mark.skip("not working")
 def test_module_diff():
     """Testing module difference between two trees. First test is testing against same module tree, and the second
         test is against a different tree. """
@@ -85,11 +86,14 @@ class TestModule:
         # show "settarg" collection
         cmd.describe("settarg")
 
+        assert 0 == cmd.test_collection("settarg")
+        assert 0 == cmd.test_collection()
+
     @pytest.mark.xfail(
         reason="Collection Name must be string when saving", raises=TypeError
     )
     def test_type_error_save_collection(self):
-        cmd = Module(["settarg"])
+        cmd = Module()
         cmd.save(1)
 
     @pytest.mark.xfail(
@@ -97,14 +101,13 @@ class TestModule:
         raises=TypeError,
     )
     def test_type_error_describe_collection(self):
-        cmd = Module(["settarg"])
+        cmd = Module()
         cmd.describe(1)
 
-
-class TestModuleCollection:
-    def test_get_collection_string(self):
-        a = ModuleCollection("settarg")
-        assert "module restore settarg" == a.get_command()
+    def test_get_collection(self):
+        a = Module()
+        assert "module restore settarg" == a.get_collection("settarg")
+        assert "module restore default" == a.get_collection()
 
     def test_collection_exists(self):
         assert "settarg" in get_all_collections()
@@ -114,5 +117,5 @@ class TestModuleCollection:
         raises=TypeError,
     )
     def test_type_error(self):
-        a = ModuleCollection(1)
+        a = Module(1)
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -60,6 +60,7 @@ def test_list_all_parents():
 
 
 class TestModule:
+    @pytest.mark.skip("not working")
     def test_module(self):
         mod_names = ["lmod"]
         a = Module(mod_names)

--- a/tests/test_testconfigs.py
+++ b/tests/test_testconfigs.py
@@ -1,5 +1,0 @@
-from buildtest.tools.testconfigs import func_testconfigs_show
-
-
-def test_testconfigs_show():
-    func_testconfigs_show()


### PR DESCRIPTION
add error checking on argument passed to Module class. It's ok
to pass no arguments to Module, this is only required when you want
to work with module collection methods.
Remove tests related to "buildtest testconfigs"
Refactor few regression tests for Module() class.
Add MODULEPATH and module av command to Travis for debugging