### PR TITLE
Removing argcomplete and termcolor, not essential for buildtest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,10 @@
 CHANGELOG
-=================
+=========
 
-v0.8.0 (Feb xxx, 2020)
+v0.8.0 (Mar xxx, 2020)
 -----------------------
 
+ - removing extra dependencies argcomplete and termcolor
  - removing dependency of Lmod, only needed if modules specified in configs
  - replace toolkit/suite with site in code and documentation examples
  - removing bash script and sourcing in favor of Python module install

--- a/buildtest/tools/menu.py
+++ b/buildtest/tools/menu.py
@@ -3,7 +3,6 @@ buildtest menu
 """
 
 import argparse
-import argcomplete
 
 from buildtest.tools.config import config_opts
 from buildtest.tools.build import func_build_subcmd
@@ -73,8 +72,6 @@ class BuildTestParser:
         :return: return a parsed dictionary returned by ArgumentParser
         :rtype: dict
         """
-
-        argcomplete.autocomplete(self.parser)
         args = self.parser.parse_args()
 
         if args.subcommands:

--- a/docs/installing_buildtest.rst
+++ b/docs/installing_buildtest.rst
@@ -70,27 +70,6 @@ Depending on your python version, install buildtest::
     $ python3 setup.py install
 
 
-If you want auto-completion using ``argcomplete`` on buildtest options, you can
-run this command::
-
-    # for bash, shell
-    eval "$(register-python-argcomplete buildtest)"
-
-    # for csh, tsch
-    eval `register-python-argcomplete --shell tcsh buildtest
-
-
-You can add this to your bash ``.profile`` at ``$HOME/.profile`` to have it sourced
-each time. After you do this, you can press **TAB** key on the keyboard to
-fill in the arguments options::
-
-    $ buildtest
-    build        -h           module       --version
-    config       --help       show         -V
-
-
-For more details on argcomplete please see https://pypi.org/project/argcomplete/
-
 Usage (``buildtest --help``)
 ------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 alabaster==0.7.12
-argcomplete==1.11.1
 Babel==2.8.0
 certifi==2019.11.28
 chardet==3.0.4
@@ -29,6 +28,5 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-programoutput==0.15
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-termcolor==1.1.0
 urllib3==1.25.8
 zipp==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,8 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "argcomplete==1.9.5",
         "PyYAML>=5.2",
         "distro==1.4.0",
-        "termcolor==1.1.0",
     ],
     entry_points={"console_scripts": ["buildtest=buildtest.main:main"]},
 )


### PR DESCRIPTION
This PR will remove argcomplete and termcolor, which are either no longer necessary or add extra (unneeded) dependencies. It's a move in the right direction to keep the library simple - the minimum number of dependencies that we need is the way to go! :) 

 - This will close #206 

I also updated the current changelog to be for March (I can't believe it's March already...)

Signed-off-by: vsoch <vsochat@stanford.edu>