### PR TITLE
fixing client and running first test for script

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -447,6 +447,13 @@ class BuilderBase:
 
         result["RETURN_CODE"] = command.returncode
         result["END_TIME"] = self.get_formatted_time("end_time")
+
+        # Print the test result for the user
+        if command.returncode == 0:
+            print("{:<40} {}".format("[RUNNING TEST]", "PASSED"))
+        else:
+            print("{:<40} {}".format("[RUNNING TEST]", "FAILED"))
+
         print("Writing results to " + run_output_file)
         return result
 

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -67,15 +67,17 @@ class BuildTestParser:
         )
 
     def parse_options(self):
-        """This method parses the argument from ArgumentParser class and returns as a dictionary. Also it
-        redirects sub-commands to appropriate methods.
+        """This method parses the argument from ArgumentParser class and returns
+        the arguments. We store extra (non parsed arguments) with the class if
+        they are needed.
 
         :return: return a parsed dictionary returned by ArgumentParser
         :rtype: dict
         """
-        args = self.parser.parse_args()
+        args, extra = self.parser.parse_known_args()
+        self.extra = extra
 
-        if args.subcommands:
+        if args.subcommands and args.func:
             args.func(args)
 
         return args
@@ -107,7 +109,7 @@ class BuildTestParser:
             action="store_true",
         )
 
-        # parser_build.set_defaults(func=func_build_subcmd)
+        parser_build.set_defaults(func=func_build_subcmd)
 
         # -------------------------- buildtest build report ------------------------------
         subparsers_build = parser_build.add_subparsers(

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -108,13 +108,19 @@ def func_build_subcmd(args):
             total_tests += 1
             if not args.dry:
                 result = builder.run()
+
+                # Update results
+                if result["RETURN_CODE"] == 0:
+                    passed_tests += 1
+                else:
+                    failed_tests += 1
             else:
                 result = builder.dry_run()
 
             # Update build history
             BUILDTEST_BUILD_HISTORY[result["BUILD_ID"]] = result
 
-    if not args.dry_run():
+    if not args.dry:
         print(f"Finished running {total_tests} total tests.")
         print
         print
@@ -122,10 +128,10 @@ def func_build_subcmd(args):
         print("                         Test summary                         ")
         print(f"Executed {total_tests} tests")
         print(
-            f"Passed Tests: {passed_tests} Percentage: {passed_test*100/total_tests}%"
+            f"Passed Tests: {passed_tests} Percentage: {passed_tests*100/total_tests}%"
         )
         print(
-            f"Failed Tests: {failed_tests} Percentage: {failed_test*100/total_tests}%"
+            f"Failed Tests: {failed_tests} Percentage: {failed_tests*100/total_tests}%"
         )
         print
         print


### PR DESCRIPTION
This pull request will:

 - fix the build command to run from the command line (it was a commented out line that should not have been, this was my fault!)
 - address tiny bugs with running `buildtest build -c <config>`
 - add a clear message to print the status as PASSED or FAILED for each test (this was missing).

Specifically, here is an example running on my localmachine. One of the two tests is running a command that requires an executable that I don't have (and the other is just printing a hello world) so I expect one failure and one passing:

```
$ buildtest build -c tests/testdir/slurm-hello.yml 
________________________________________________________________________________
                             start time: 2020-03-17 17:14:24.420442
                     configuration file: /home/vanessa/Desktop/Code/buildtest/buildtest-framework/tests/testdir/slurm-hello.yml
                                testdir: /home/vanessa/.buildtest/testdir/hello_dinosaur
                               testpath: /home/vanessa/.buildtest/testdir/hello_dinosaur/hello_dinosaur_script_03-17-2020-17-14-S.sh
                                logpath: None
________________________________________________________________________________



STAGE                                    VALUE
________________________________________________________________________________
[WRITING TEST]                           PASSED
[RUNNING TEST]                           PASSED
Writing results to /home/vanessa/.buildtest/testdir/hello_dinosaur/run/hello_dinosaur_script_03-17-2020-17-14-S.out
________________________________________________________________________________
                             start time: 2020-03-17 17:14:24.422737
                     configuration file: /home/vanessa/Desktop/Code/buildtest/buildtest-framework/tests/testdir/slurm-hello.yml
                                testdir: /home/vanessa/.buildtest/testdir/slurm_check
                               testpath: /home/vanessa/.buildtest/testdir/slurm_check/slurm_check_script_03-17-2020-17-14-S.sh
                                logpath: None
________________________________________________________________________________



STAGE                                    VALUE
________________________________________________________________________________
[WRITING TEST]                           PASSED
[RUNNING TEST]                           FAILED
Writing results to /home/vanessa/.buildtest/testdir/slurm_check/run/slurm_check_script_03-17-2020-17-14-S.out
Finished running 2 total tests.
==============================================================
                         Test summary                         
Executed 2 tests
Passed Tests: 1 Percentage: 50.0%
Failed Tests: 1 Percentage: 50.0%
```

I think likely we should have discussion about the organization of the output / logs, and what gets put there, but this is outside the scope of this fix. This PR addresses an issue that wasn't open about fixing the argparser, and also ensuring that the command line run works.

Signed-off-by: vsoch <vsochat@stanford.edu>