### PR TITLE
Generate local testdir by default in present working directory

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -215,12 +215,15 @@ class BuilderBase:
            recipe_config: the loaded section from the config_file for the user.
            config_file: the pull path to the configuration file, must exist.
         """
-        self.testdir = testdir or os.path.join(os.getcwd(), ".buildtest")
         self.name = name
         self.result = {}
         self.build_id = None
         self.metadata = {}
         self.config_file = config_file
+        self.config_name = re.sub("[.](yml|yaml)", "", os.path.basename(config_file))
+        self.testdir = testdir or os.path.join(
+            os.getcwd(), ".buildtest", self.config_name
+        )
 
         # A builder is required to define the type attribute
         if not hasattr(self, "type"):

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -154,7 +154,7 @@ class BuildConfig:
 
     # Builders
 
-    def get_builders(self):
+    def get_builders(self, testdir=None):
         """Based on a loaded configuration file, return the correct builder
            for each based on the type. Each type is associated with a known 
            Builder class.
@@ -167,7 +167,9 @@ class BuildConfig:
                 # Add the builder based on the type
                 if recipe_config["type"] == "script":
                     builders.append(
-                        ScriptBuilder(name, recipe_config, self.config_file)
+                        ScriptBuilder(
+                            name, recipe_config, self.config_file, testdir=testdir
+                        )
                     )
                 else:
                     print(
@@ -199,7 +201,7 @@ class BuilderBase:
        any kind of builder.
     """
 
-    def __init__(self, name, recipe_config, config_file=None):
+    def __init__(self, name, recipe_config, config_file=None, testdir=None):
         """initiate a builder base. A recipe configuration (loaded) is required.
            this can be handled easily with the BuildConfig class:
 
@@ -213,6 +215,7 @@ class BuilderBase:
            recipe_config: the loaded section from the config_file for the user.
            config_file: the pull path to the configuration file, must exist.
         """
+        self.testdir = testdir or os.path.join(os.getcwd(), ".buildtest")
         self.name = name
         self.result = {}
         self.build_id = None
@@ -345,7 +348,7 @@ class BuilderBase:
         if hasattr(self, "_finish_run"):
             self._finish_run()
 
-    def prepare_run(self):
+    def prepare_run(self, testdir=None):
         """Prepare run provides shared functions to set up metadata and
            class data structures that are used by both run and dry_run
            This section cannot be reached without a valid, loaded recipe
@@ -356,9 +359,6 @@ class BuilderBase:
         # History is returned at the end of a run
         self.history = {}
         self.history["TESTS"] = []
-
-        # Create a deep copy of config_opts for the build file
-        self.options = deepcopy(config_opts)
 
         # Metadata includes known sections in a config recipe (pre/post_run, env)
         # These should all be validated for type, format, by the schema validator
@@ -372,7 +372,7 @@ class BuilderBase:
 
         # Derive the path to the test script
         self.metadata["testpath"] = "%s.%s" % (
-            os.path.join(self.options["build"]["testdir"], self.name, self.build_id),
+            os.path.join(self.testdir, self.name, self.build_id),
             self.get_test_extension(),
         )
         self.metadata["testdir"] = os.path.dirname(self.metadata["testpath"])
@@ -392,6 +392,9 @@ class BuilderBase:
         """Run the builder associated with the loaded recipe.
            This parent class handles shared starting functions for each step
            and then calls the subclass function (_run) if it exists.
+
+           Parameters:
+           testdir: the directory to write tests to. Defaults to os.getcwd()
         """
         # Create test directory and run folder they don't exist
         self._create_test_folders()

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -97,6 +97,12 @@ class BuildTestParser:
         )
 
         parser_build.add_argument(
+            "-t",
+            "--testdir",
+            help="specify a custom test directory. By default, use .buildtest in $PWD.",
+        )
+
+        parser_build.add_argument(
             "-d",
             "--dry",
             help="dry-run mode, buildtest will not write the test scripts but print "

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -75,9 +75,6 @@ def func_build_subcmd(args):
 
     :rtype: None
     """
-    if args.clear:
-        clear_builds()
-        sys.exit(0)
 
     # Discover list of one or more config files based on path provided
     config_files = discover_configs(args.config)

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -83,7 +83,6 @@ def func_build_subcmd(args):
     config_files = discover_configs(args.config)
 
     # Read in all config files here, loading each will validate the entire file
-    # TODO: allow some level of skipping invalid files, an argument?
     for config_file in config_files:
         bc = BuildConfig(config_file)
 

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -95,7 +95,7 @@ def func_build_subcmd(args):
         bc = BuildConfig(config_file)
 
         # And builders parsed through for each
-        for builder in bc.get_builders():
+        for builder in bc.get_builders(testdir=args.testdir):
 
             # Keep track of total number of tests run
             total_tests += 1


### PR DESCRIPTION
Currently, we generate a testing directory in a global location, which is both hard to find/ interact with, and makes it much more likely to have name conflicts. For this pull request, we update the structure to (by default) generate a .buidltest directory in the $PWD where buildtest is being called. Here is an example, I'm running this from the examples folder with slurm-hello.yml

```.
# slurm-hello.yml
$ buildtest build -c slurm-hello-yml
```

That generates .buildtest in my local directory with the associated files:

```bash
$ tree .buildtest/
.buildtest/
└── slurm-hello
    ├── hello_dinosaur
    │   ├── hello_dinosaur_script_03-19-2020-17-44-S.sh
    │   ├── log
    │   │   └── hello_dinosaur_script_03-19-2020-17-44-S.log
    │   └── run
    │       └── hello_dinosaur_script_03-19-2020-17-44-S.out
    └── slurm_check
        ├── log
        │   └── slurm_check_script_03-19-2020-17-44-S.log
        ├── run
        │   └── slurm_check_script_03-19-2020-17-44-S.out
        └── slurm_check_script_03-19-2020-17-44-S.sh
```

Notice that it's organized by file name, then section name, and then contents. We can discuss the contents in more detail in another PR, this change mainly is to address our discussion about the global location of the test directory. Also note that I can supply an argument on the command line to make it somewhere else. Here would use the original testdir:

```bash
buildtest build -c slurm-hello.yml --testdir /home/vanessa/.buildtest/testdir
```
This will close #199 