### PR TITLE
updating url checker name and version to use latest

### DIFF
--- a/.github/workflows/urlchecker.yml
+++ b/.github/workflows/urlchecker.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: URLs-checker
-      uses: urlstechie/URLs-checker@0.1.6
+      uses: urlstechie/urlchecker-action@0.1.7
       with:
         # check this subfolder only
         subfolder: docs


### PR DESCRIPTION
This is a quick PR to update the name for the (renamed repository) for the url checker action! I am also bumping the version - this one has supposed for white_listed_files in case we need it.

Signed-off-by: vsoch <vsochat@stanford.edu>