### PR TITLE
Removing config show for global configuration

### DIFF
--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -15,7 +15,7 @@ from buildtest.menu.config import (
     func_config_restore,
 )
 
-from buildtest.menu.show import func_show_subcmd, show_schema_layout
+from buildtest.menu.show import show_schema_layout
 from buildtest.menu.status import show_status_report
 
 
@@ -168,13 +168,6 @@ class BuildTestParser:
 
         # -------------------------- buildtest show options ------------------------------
         parser_show = self.subparsers.add_parser("show")
-        parser_show.add_argument(
-            "-c",
-            "--config",
-            help="show buildtest global configuration",
-            action="store_true",
-        )
-        parser_show.set_defaults(func=func_show_subcmd)
 
         # -------------------------- buildtest show schemas ------------------------------
         subparsers_show = parser_show.add_subparsers(

--- a/buildtest/menu/config.py
+++ b/buildtest/menu/config.py
@@ -30,36 +30,3 @@ def func_config_restore(args=None):
         print(f"Restoring from default configuration: {DEFAULT_CONFIG_FILE}")
         copy(DEFAULT_CONFIG_FILE, BUILDTEST_CONFIG_FILE)
         copy(DEFAULT_CONFIG_FILE, BUILDTEST_CONFIG_BACKUP_FILE)
-
-
-def show_configuration():
-    """This method display buildtest configuration to terminal and this
-       implements command buildtest show --config.
-    """
-    exclude_list = ["BUILDTEST_VERSION"]
-
-    for key in sorted(config_opts):
-        if key in exclude_list:
-            continue
-
-        if key == "BUILDTEST_MODULEPATH":
-            tree = ""
-            for mod_tree in config_opts[key]:
-                tree += mod_tree + ":"
-
-            # remove last colon
-            tree = tree[:-1]
-            print((f"{key} \t =").expandtabs(50), tree)
-        # print all keys in module dictionary
-        elif key in ["module", "build"]:
-            module_keys = config_opts[key].keys()
-
-            for m in module_keys:
-                if isinstance(config_opts[key][m], dict):
-                    for k, v in config_opts[key][m].items():
-                        print((f"{key}[{m}][{k}] \t =").expandtabs(50), v)
-                else:
-                    print((f"{key}[{m}] \t =").expandtabs(50), config_opts[key][m])
-
-        else:
-            print((f"{key} \t =").expandtabs(50), f"{config_opts[key]}")

--- a/buildtest/menu/show.py
+++ b/buildtest/menu/show.py
@@ -2,22 +2,11 @@ import json
 import sys
 
 from buildtest.defaults import supported_schemas
-from buildtest.menu.config import show_configuration
 from buildtest.buildsystem.schemas.utils import (
     load_schema,
     get_schemas_available,
     get_schema_fullpath,
 )
-
-
-def func_show_subcmd(args):
-    """Entry point to ``buildtest show`` sub command.
-
-    :param args: command line arguments to buildtest
-    :type args: dict, required
-    """
-    if args.config:
-        show_configuration()
 
 
 def show_schema_layout(args):

--- a/tests/menu/test_config.py
+++ b/tests/menu/test_config.py
@@ -3,17 +3,12 @@ import pytest
 from jsonschema import validate, ValidationError
 from buildtest.defaults import BUILDTEST_CONFIG_BACKUP_FILE, DEFAULT_CONFIG_SCHEMA
 from buildtest.menu.config import (
-    show_configuration,
     func_config_view,
     func_config_restore,
 )
 from buildtest.buildsystem.schemas.utils import load_schema
 
 pytest_root = os.path.dirname(os.path.dirname(__file__))
-
-
-def test_show_config():
-    show_configuration()
 
 
 def test_view_configuration():


### PR DESCRIPTION
This will remove the `buildtest show --config` which I forgot to do in #237. Sorry about that @shahzebsiddiqui ! Hopefully this makes it right :)

Signed-off-by: vsoch <vsochat@stanford.edu>