### PR TITLE
Adding zenodo.json to devel

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,21 @@
+{
+  "creators": [
+    {
+      "name": "Siddiqui, Shahzeb",
+      "orcid": "0000-0002-2342-6974"
+    },
+    {
+      "affiliation": "Stanford University Research Computing Center, Stanford University, Stanford CA USA",
+      "name": "Sochat, Vanessa",
+      "orcid": "0000-0002-4387-3819"
+    },
+  ],
+  "keywords": [
+    "build testing",
+    "high performance computing",
+    "testing",
+  ],
+  "access_right": "open",
+  "license": "MIT",
+  "upload_type": "software"
+}


### PR DESCRIPTION
This will add a zenodo.json to the development branch. @shahzebsiddiqui I left your affiliation off (which is valid to do, you technically don't need to add this or the orcid id!).

Signed-off-by: vsoch <vsochat@stanford.edu>