### PR TITLE
adding basic steps for a local (base) executor

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -251,6 +251,9 @@ class BuilderBase:
                 % (self.type, self.recipe.get("type"))
             )
 
+        # Start with just terminal logger (changes to file on run)
+        self._init_logger(to_file=False)
+
     def __str__(self):
         return "[builder-%s-%s]" % (self.type, self.name)
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -103,6 +103,9 @@ class BuildExecutor:
         # Run each step defined for dry run
         for step in executor.steps:
             if getattr(executor, step, None):
+                executor.builder.logger.debug(
+                    "Running %s for executor %s" % (step, executor)
+                )
                 getattr(executor, step)()
         return executor.result
 
@@ -135,7 +138,7 @@ class BaseExecutor:
        executors must have a listing of steps and dryrun_steps
     """
 
-    steps = ["setup", "build"]
+    steps = ["setup", "run"]
     dryrun_steps = ["setup", "dry"]
     type = "base"
 
@@ -156,7 +159,7 @@ class BaseExecutor:
         self._settings = settings
         self.load(name)
         self.builder = None
-        self.result = None
+        self.result = {}
 
     def load(self, name=None):
         """Load a particular configuration based on the name. This method
@@ -169,6 +172,7 @@ class BaseExecutor:
         """Setup the executor, meaning we check that the builder is defined,
            the only step needed for a local (base) executor.
         """
+        print(self.builder)
         if not self.builder:
             sys.exit("Builder is not defined for executor.")
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -7,7 +7,6 @@ import os
 import sys
 
 from buildtest.config import config_opts
-from buildtest.log import init_logfile, init_log
 
 
 class BuildExecutor:
@@ -20,13 +19,15 @@ class BuildExecutor:
        provided, we use reasonable defaults.
     """
 
-    def __init__(self, config_opts):
+    def __init__(self, config_opts, default=None):
         """initiate executors, meaning that we provide the config_opts
            that are validated, and can instantiate each executor to be available
            
-           Parameters:
-
-           config_opts: the validated config opts provided by buildtest.
+           :param config_opts: the validated config opts provided by buildtest.
+           :type config_opts: dictionary
+           :param default: the name of the default executor. If not set (or undefined)
+           we fall back to buildtest defaults (see set_default).
+           :type default: str
         """
         self.executors = {}
 
@@ -37,6 +38,8 @@ class BuildExecutor:
             elif executor["type"] == "slurm":
                 self.executors[name] = SlurmExecutor(name, executor)
 
+        self.set_default(default)
+
     def __str__(self):
         return "[buildtest-executor]"
 
@@ -45,14 +48,96 @@ class BuildExecutor:
 
     def get(self, name):
         """Given the name of an executor return the executor for running 
-           a buildtest build.
+           a buildtest build, or get the default.
         """
-        return self.executors.get(name)
+        return self.executors.get(name) or self.executors.get("default")
+
+    def _choose_executor(self, builder):
+        """Choose executor is called at the onset of a run or dryrun. We
+           look at the builder metadata to determine if a default
+           is set for the executor, and fall back to the default.
+
+           :param builder: the builder with the loaded test configuration.
+           :type builder: buildtest.buildsystem.BuilderBase (or subclass).
+        """
+        executor = builder.metadata.get("executor", "default")
+
+        # The executor (or a default) must be define
+        if executor not in self.executors:
+            builder.logger.warning(
+                "executor %s is not defined in default.yml" % executor
+            )
+            sys.exit(1)
+
+        # Get the executor by name, and add the builder to it
+        executor = self.executors.get(executor)
+        executor.builder = builder
+        return executor
+
+    def dry_run(self, builder):
+        """A dry run typically includes all of the steps up to run
+
+           :param builder: the builder with the loaded test configuration.
+           :type builder: buildtest.buildsystem.BuilderBase (or subclass).
+        """
+        # Choose the executor based on the builder provided
+        executor = self._choose_executor(builder)
+
+        # Run each step defined for dry run
+        for step in executor.dryrun_steps:
+            if getattr(executor, step, None):
+                getattr(executor, step)()
+        return executor.result
+
+    def run(self, builder):
+        """Given a buildtest.buildsystem.BuildConfig (subclass) go through the
+           steps defined for the executor to run the build. This should
+           be instantiated by the subclass. For a simple script run, we expect a 
+           setup, build, and finish.
+
+           :param builder: the builder with the loaded test configuration.
+           :type builder: buildtest.buildsystem.BuilderBase (or subclass).
+        """
+        executor = self._choose_executor(builder)
+
+        # Run each step defined for dry run
+        for step in executor.steps:
+            if getattr(executor, step, None):
+                getattr(executor, step)()
+        return executor.result
+
+    def set_default(self, name=None):
+        """Set a particular name as the default executor (defaults to default).
+           In the case that no executors are defined, we return a base (local)
+           executor. If executors are defined, we return the first in the list.
+
+           :param name: the name for the key to set as default, if it exists.
+           :type name: string
+        """
+
+        # If a default is not defined
+        if "default" not in self.executors:
+
+            # If no executors are defined, return a base (local)
+            if not self.executors:
+                self.executors["default"] = BaseExecutor("default", {})
+
+            # Otherwise return the first in the list
+            else:
+                if name in self.executors:
+                    self.executors["default"] = self.executors[name]
+                else:
+                    self.executors["default"] = list(self.executors.values())[0]
 
 
 class BaseExecutor:
-    """The BaseExecutor is an abstract base class for all executors
+    """The BaseExecutor is an abstract base class for all executors. All
+       executors must have a listing of steps and dryrun_steps
     """
+
+    steps = ["setup", "build"]
+    dryrun_steps = ["setup", "dry"]
+    type = "base"
 
     def __init__(self, name, settings):
         """Initiate a base executor, meaning we provide a name (also held
@@ -63,14 +148,15 @@ class BaseExecutor:
            :type name: string (required)
            :param settings: the original config opts to extract variables from.
            :type settings: dict (required)
+           :param builder: the builder object for the executor to control.
+           :type builder: buildtest.buildsystem.base.BuilderBase (or subclass).
         """
 
         self.name = name
         self._settings = settings
-
-        # Set defaults based on provided config
-        self.type = self._settings.get("type")
         self.load(name)
+        self.builder = None
+        self.result = None
 
     def load(self, name=None):
         """Load a particular configuration based on the name. This method
@@ -78,6 +164,25 @@ class BaseExecutor:
            class.
         """
         pass
+
+    def setup(self):
+        """Setup the executor, meaning we check that the builder is defined,
+           the only step needed for a local (base) executor.
+        """
+        if not self.builder:
+            sys.exit("Builder is not defined for executor.")
+
+    def run(self):
+        """The run step basically runs the build. This is run after setup
+           so we are sure that the builder is defined. This is also where
+           we set the result to return.
+        """
+        self.result = self.builder.run()
+
+    def dryrun(self):
+        """The dry run step defines the result based on a dry run.
+        """
+        self.result = self.builder.dry_run()
 
     def __str__(self):
         return "[executor-%s-%s]" % (self.type, self.name)
@@ -91,7 +196,20 @@ class LocalExecutor(BaseExecutor):
 
 
 class SlurmExecutor(BaseExecutor):
+    """The slurm executor is optimized to setup, run, and check jobs, so it
+       has subclass functions to handle these operations. This code is not
+       yet written by will be done so by 
+
+       setup: write slurm job scripts
+       check: check if slurm partition is available for accepting jobs.
+       dispatch: dispatch jobs to scheduler
+       poll: wait for jobs to finish
+       gather: gather all job data, exit codes and output
+       close: clean up any generated files
+    """
+
     type = "slurm"
+    steps = ["setup", "check", "dispatch", "poll", "gather", "close"]
 
     def load(self, name):
         """Load the executor preferences from the provided config, which is

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -102,6 +102,12 @@ class BuildTestParser:
         )
 
         parser_build.add_argument(
+            "-e",
+            "--executor",
+            help='specify a named executor to use (defaults to "default" key, first in list, then local (base) executor',
+        )
+
+        parser_build.add_argument(
             "-d",
             "--dry",
             help="dry-run mode, buildtest will not write the test scripts but print "

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -9,7 +9,6 @@ import shutil
 import sys
 
 from buildtest.defaults import (
-    DEFAULT_CONFIG_FILE,
     BUILDTEST_BUILD_LOGFILE,
     TESTCONFIG_ROOT,
 )

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -9,11 +9,14 @@ import shutil
 import sys
 
 from buildtest.defaults import (
+    DEFAULT_CONFIG_FILE,
     BUILDTEST_BUILD_LOGFILE,
     TESTCONFIG_ROOT,
 )
 
 from buildtest.buildsystem.base import BuildConfig
+from buildtest.config import config_opts
+from buildtest.executors.base import BuildExecutor
 from buildtest.utils.file import walk_tree
 
 
@@ -87,6 +90,9 @@ def func_build_subcmd(args):
     failed_tests = 0
     passed_tests = 0
 
+    # Load BuildExecutors
+    executor = BuildExecutor(config_opts, default=args.executor)
+
     # Each configuration file can have multiple tests
     for config_file in config_files:
 
@@ -99,7 +105,7 @@ def func_build_subcmd(args):
             # Keep track of total number of tests run
             total_tests += 1
             if not args.dry:
-                result = builder.run()
+                result = executor.run(builder)
 
                 # Update results
                 if result["RETURN_CODE"] == 0:
@@ -107,7 +113,7 @@ def func_build_subcmd(args):
                 else:
                     failed_tests += 1
             else:
-                result = builder.dry_run()
+                result = executor.dry_run(builder)
 
     if not args.dry:
         print(f"Finished running {total_tests} total tests.")

--- a/tests/executors/test_base.py
+++ b/tests/executors/test_base.py
@@ -25,9 +25,9 @@ def test_build_executor():
     # Load BuildExecutor
     be = BuildExecutor(example)
 
-    # We should have loaded a local and slurm executor
+    # We should have loaded a local and slurm executor, and one defualt
     # {'local': [executor-local-local], 'slurm': [executor-slurm-slurm]}
-    assert len(be.executors) == 2
+    assert len(be.executors) == 3
 
     # Each should have
     for name, executor in be.executors.items():


### PR DESCRIPTION
This pull request adds the basic interaction of an executor with the builders produced by the BuildTestConfig class. Basically, we create the BuildExecutors (executor) based on the config_opts
(the users loaded configuration file) and then parse through the builders and hand each one off to it. In the case of defining an --executor on the command line, we honor and use that choice. In the case of finding the executor as a metadata value in the config schema, we also honor that. In the case of no command option or no default, we either use the first in the file OR the base class (which is basically a local executor). This example should be sufficient to show how to set up the same for slurm - each of steps and dryrun_steps and the subsequent functions would need to
be defined. I'll probably need to update this PR with fixes to testing (didn't try locally).

Signed-off-by: vsoch <vsochat@stanford.edu>