### PR TITLE
Add support for specifying buildtest settings from cli 

### DIFF
--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -9,7 +9,7 @@ from buildtest.defaults import (
     BUILDTEST_CONFIG_FILE,
     BUILDTEST_ROOT,
     DEFAULT_CONFIG_FILE,
-    DEFAULT_CONFIG_SCHEMA,
+    DEFAULT_CONFIG_SCHEMA
 )
 from buildtest.buildsystem.schemas.utils import load_schema
 
@@ -53,7 +53,7 @@ def init():
     create_logfile()
 
 
-def check_configuration():
+def check_configuration(config_path=None):
     """Checks all keys in configuration file (settings/default.yml) are valid
        keys and ensure value of each key matches expected type . For some keys
        special logic is taken to ensure values are correct and directory path
@@ -64,12 +64,19 @@ def check_configuration():
        :rtype: exit code 1 if checks failed
     """
 
+    user_schema = load_schema(config_path)
     config_schema = load_schema(DEFAULT_CONFIG_SCHEMA)
-    validate(instance=config_opts, schema=config_schema)
+    validate(instance=user_schema, schema=config_schema)
 
 
 def load_configuration(config_path=None):
-    """Load the default configuration file."""
+    """Load the default configuration file if no argument is specified.
+
+       Parameters:
+
+       :param config_path: Path to buildtest configuration file
+       :type config_path: str, optional
+    """
 
     init()
 
@@ -79,5 +86,7 @@ def load_configuration(config_path=None):
     return load_schema(config_path)
 
 
-# Run on init, so we only load once
-config_opts = load_configuration()
+def get_default_configuration():
+    """Load and return the default buildtest configuration file. """
+
+    return load_configuration()

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -5,7 +5,6 @@ from jsonschema import validate
 
 from buildtest.utils.file import create_dir
 from buildtest.defaults import (
-    BUILDTEST_BUILD_LOGFILE,
     BUILDTEST_CONFIG_FILE,
     BUILDTEST_ROOT,
     DEFAULT_CONFIG_FILE,
@@ -19,15 +18,6 @@ def create_config_files():
 
     if not os.path.exists(BUILDTEST_CONFIG_FILE):
         shutil.copy(DEFAULT_CONFIG_FILE, BUILDTEST_CONFIG_FILE)
-
-
-def create_logfile():
-    """Create a logfile to keep track of messages for the user, if doesn't exist."""
-
-    if not os.path.exists(BUILDTEST_BUILD_LOGFILE):
-        build_dict = {"build": {}}
-        with open(BUILDTEST_BUILD_LOGFILE, "w") as outfile:
-            json.dump(build_dict, outfile, indent=2)
 
 
 def init():
@@ -44,13 +34,11 @@ def init():
         os.mkdir(BUILDTEST_ROOT)
 
     # Create subfolders for var and root
-    create_dir(os.path.join(BUILDTEST_ROOT, "var"))
     create_dir(os.path.join(BUILDTEST_ROOT, "root"))
     create_dir(os.path.join(BUILDTEST_ROOT, "site"))
 
     # Create config files, module files, and log file
     create_config_files()
-    create_logfile()
 
 
 def check_configuration(config_path=None):

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -8,7 +8,7 @@ from buildtest.defaults import (
     BUILDTEST_CONFIG_FILE,
     BUILDTEST_ROOT,
     DEFAULT_CONFIG_FILE,
-    DEFAULT_CONFIG_SCHEMA
+    DEFAULT_CONFIG_SCHEMA,
 )
 from buildtest.buildsystem.schemas.utils import load_schema
 

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -13,7 +13,7 @@ from buildtest.defaults import (
 from buildtest.buildsystem.schemas.utils import load_schema
 
 
-def create_config_files():
+def create_config_file():
     """If default config files don't exist, copy the default configuration provided by buildtest."""
 
     if not os.path.exists(BUILDTEST_CONFIG_FILE):
@@ -38,7 +38,7 @@ def init():
     create_dir(os.path.join(BUILDTEST_ROOT, "site"))
 
     # Create config files, module files, and log file
-    create_config_files()
+    create_config_file()
 
 
 def check_configuration(config_path=None):
@@ -52,7 +52,7 @@ def check_configuration(config_path=None):
        :rtype: exit code 1 if checks failed
     """
 
-    user_schema = load_schema(config_path)
+    user_schema = load_configuration(config_path)
     config_schema = load_schema(DEFAULT_CONFIG_SCHEMA)
     validate(instance=user_schema, schema=config_schema)
 

--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -26,9 +26,6 @@ root = os.path.dirname(os.path.abspath(__file__))
 BUILDTEST_ROOT = os.path.join(userhome, ".buildtest")
 BUILDTEST_SHELL = os.environ.get("SHELL", "/bin/bash")
 
-# json file used by buildtest to write build meta-data
-BUILDTEST_BUILD_LOGFILE = os.path.join(BUILDTEST_ROOT, "var", "build.json")
-
 # dictionary used for storing status of builds
 BUILDTEST_CONFIG_FILE = os.path.join(BUILDTEST_ROOT, "settings.yml")
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -6,6 +6,7 @@ Copyright (C) 2020 Vanessa Sochat.
 import os
 import sys
 
+
 class BuildExecutor:
     """A BuildExector is a base class some type of executor, defined under
        the buildtest/settings/default-config.json schema. For example,

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -6,9 +6,6 @@ Copyright (C) 2020 Vanessa Sochat.
 import os
 import sys
 
-from buildtest.config import config_opts
-
-
 class BuildExecutor:
     """A BuildExector is a base class some type of executor, defined under
        the buildtest/settings/default-config.json schema. For example,

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -7,7 +7,6 @@ os.environ["COLUMNS"] = "120"
 def main():
     """Entry point to buildtest."""
 
-    from buildtest.config import check_configuration
     from buildtest.menu import BuildTestParser
     from buildtest.system import BuildTestSystem
 
@@ -15,7 +14,6 @@ def main():
     buildtest_system = BuildTestSystem()
     buildtest_system.check_system_requirements()
 
-    check_configuration()
     parser = BuildTestParser()
     parser.parse_options()
 

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -114,6 +114,12 @@ class BuildTestParser:
             action="store_true",
         )
 
+        parser_build.add_argument(
+            "--settings",
+            help="Specify an alternate buildtest settings file to use",
+            action="store_true",
+        )
+
         parser_build.set_defaults(func=func_build_subcmd)
 
     def get_menu(self):

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -117,7 +117,6 @@ class BuildTestParser:
         parser_build.add_argument(
             "--settings",
             help="Specify an alternate buildtest settings file to use",
-            action="store_true",
         )
 
         parser_build.set_defaults(func=func_build_subcmd)

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -115,8 +115,7 @@ class BuildTestParser:
         )
 
         parser_build.add_argument(
-            "--settings",
-            help="Specify an alternate buildtest settings file to use",
+            "--settings", help="Specify an alternate buildtest settings file to use",
         )
 
         parser_build.set_defaults(func=func_build_subcmd)

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -8,10 +8,7 @@ import os
 import shutil
 import sys
 
-from buildtest.defaults import (
-    TESTCONFIG_ROOT,
-    BUILDTEST_CONFIG_FILE
-)
+from buildtest.defaults import TESTCONFIG_ROOT, BUILDTEST_CONFIG_FILE
 
 from buildtest.buildsystem.base import BuildConfig
 from buildtest.config import load_configuration, check_configuration

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -9,8 +9,8 @@ import shutil
 import sys
 
 from buildtest.defaults import (
-    BUILDTEST_BUILD_LOGFILE,
     TESTCONFIG_ROOT,
+    BUILDTEST_CONFIG_FILE
 )
 
 from buildtest.buildsystem.base import BuildConfig
@@ -77,13 +77,14 @@ def func_build_subcmd(args):
     :rtype: None
     """
 
-    # if custom user configuration specified, it would be in args.settings otherwise set to None
-    config_file = args.settings or None
-    # if config_opts is None it will load the default configuration
+    # if buildtest settings specified on CLI, it would be in args.settings otherwise set
+    # to default configuration (BUILDTEST_CONFIG_FILE)
+    config_file = args.settings or BUILDTEST_CONFIG_FILE
+
+    # load the configuration file
     config_opts = load_configuration(config_file)
 
     check_configuration(config_file)
-
 
     # Discover list of one or more config files based on path provided
     config_files = discover_configs(args.config)

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -14,7 +14,7 @@ from buildtest.defaults import (
 )
 
 from buildtest.buildsystem.base import BuildConfig
-from buildtest.config import config_opts
+from buildtest.config import load_configuration, check_configuration
 from buildtest.executors.base import BuildExecutor
 from buildtest.utils.file import walk_tree
 
@@ -76,6 +76,14 @@ def func_build_subcmd(args):
 
     :rtype: None
     """
+
+    # if custom user configuration specified, it would be in args.settings otherwise set to None
+    config_file = args.settings or None
+    # if config_opts is None it will load the default configuration
+    config_opts = load_configuration(config_file)
+
+    check_configuration(config_file)
+
 
     # Discover list of one or more config files based on path provided
     config_files = discover_configs(args.config)

--- a/buildtest/menu/config.py
+++ b/buildtest/menu/config.py
@@ -1,6 +1,6 @@
 import os
 from shutil import copy
-from buildtest.config import config_opts
+from buildtest.config import get_default_configuration
 from buildtest.defaults import (
     BUILDTEST_CONFIG_FILE,
     DEFAULT_CONFIG_FILE,
@@ -10,6 +10,7 @@ from buildtest.defaults import (
 def func_config_edit(args=None):
     """Edit buildtest configuration in editor. This implements ``buildtest config edit``"""
 
+    config_opts = get_default_configuration()
     os.system(f"{config_opts['editor']} {BUILDTEST_CONFIG_FILE}")
 
 

--- a/tests/menu/test_config.py
+++ b/tests/menu/test_config.py
@@ -15,7 +15,7 @@ def test_view_configuration():
     func_config_view()
 
 
-def test_config_restore():
+def test_config_reset():
 
     # removing config file and testing if reset works
     os.remove(BUILDTEST_CONFIG_FILE)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,42 @@
+import os
+import shutil
+from buildtest.defaults import BUILDTEST_CONFIG_FILE, BUILDTEST_ROOT
+from buildtest.config import (
+    load_configuration,
+    check_configuration,
+    get_default_configuration,
+    create_config_file,
+    init,
+)
+
+
+def test_load_and_check_configuration():
+
+    load_configuration(BUILDTEST_CONFIG_FILE)
+    assert os.path.exists(BUILDTEST_CONFIG_FILE)
+
+    check_configuration()
+
+
+def test_get_default_configuration():
+
+    config_opts = get_default_configuration()
+    assert isinstance(config_opts, dict)
+
+    assert "editor" in config_opts.keys()
+    assert "executors" in config_opts.keys()
+
+
+def test_create_config_file():
+
+    os.remove(BUILDTEST_CONFIG_FILE)
+    create_config_file()
+    assert os.path.exists(BUILDTEST_CONFIG_FILE)
+
+
+def test_init_creation_of_buildtest_dir():
+
+    shutil.rmtree(BUILDTEST_ROOT)
+    init()
+    assert os.path.exists(os.path.join(BUILDTEST_ROOT, "root"))
+    assert os.path.exists(os.path.join(BUILDTEST_ROOT, "site"))

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,6 +1,0 @@
-import os
-from buildtest.defaults import BUILDTEST_CONFIG_FILE
-
-
-def test_config_file_exists():
-    assert os.path.exists(BUILDTEST_CONFIG_FILE)


### PR DESCRIPTION
This PR will fix #258 
- It will add ``--settings`` option
- I had to move the Check Configuration (``check_configuration``)  after we got to entry point to ``buildtest build`` method. This was to ensure we can check the settings file if specified from command line or use the default one.
- I removed BUILDTEST_BUILD_LOGFILE for reasons specified in commit message
- I removed ``config_opts`` from buildtest/config.py and now this can be retrieved via ``get_default_configuration`` note this is only used in ``buildtest config edit`` for time being and only one reference is made to method ``get_default_configuration``. 
-It seems okay for me to pass the variable ``config_opts`` to other class instead of importing from ``buildtest/config``.   