### PR TITLE
Change output behavior of buildtest build, add system log, add .err file per test

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -466,7 +466,7 @@ class BuilderBase:
         else:
             print(
                 "{:<30} {:<30} {:<30} {:<30}".format(
-                    self.config_name, self.name, "PASSED", self.config_file
+                    self.config_name, self.name, "FAILED", self.config_file
                 )
             )
 

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -376,7 +376,9 @@ class BuilderBase:
             os.path.join(self.testdir, self.name),
             self.get_test_extension(),
         )
-        self.metadata["testdir"] = os.path.dirname(os.path.expandvars(self.metadata["testpath"]))
+        self.metadata["testdir"] = os.path.dirname(
+            os.path.expandvars(self.metadata["testpath"])
+        )
 
         # The start time to print for the user
         self.metadata["start_time"] = datetime.datetime.now()
@@ -432,14 +434,10 @@ class BuilderBase:
         self.metadata["end_time"] = datetime.datetime.now()
 
         # Keep an output file
-        run_output_file = os.path.join(
-            self.metadata.get("rundir"), self.build_id
-        )
+        run_output_file = os.path.join(self.metadata.get("rundir"), self.build_id)
 
         # Keep an error file
-        run_error_file = os.path.join(
-            self.metadata.get("rundir"), self.build_id
-        )
+        run_error_file = os.path.join(self.metadata.get("rundir"), self.build_id)
 
         # write output of test to .out file
         with open(run_output_file + ".out", "w") as fd:

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -376,7 +376,7 @@ class BuilderBase:
             os.path.join(self.testdir, self.name),
             self.get_test_extension(),
         )
-        self.metadata["testdir"] = os.path.dirname(self.metadata["testpath"])
+        self.metadata["testdir"] = os.path.dirname(os.path.expandvars(self.metadata["testpath"]))
 
         # The start time to print for the user
         self.metadata["start_time"] = datetime.datetime.now()
@@ -433,20 +433,20 @@ class BuilderBase:
 
         # Keep an output file
         run_output_file = os.path.join(
-            self.metadata.get("rundir"), "%s.out" % self.build_id
+            self.metadata.get("rundir"), self.build_id
         )
 
         # Keep an error file
         run_error_file = os.path.join(
-            self.metadata.get("rundir"), "%s.err" % self.build_id
+            self.metadata.get("rundir"), self.build_id
         )
 
         # write output of test to .out file
-        with open(run_output_file, "w") as fd:
+        with open(run_output_file + ".out", "w") as fd:
             fd.write("\n".join(out))
 
         # write error from test to .err file
-        with open(run_error_file, "w") as fd:
+        with open(run_error_file + ".err", "w") as fd:
             fd.write("\n".join(err))
 
         result["RETURN_CODE"] = command.returncode

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -65,7 +65,9 @@ class BuildConfig:
         # Read the lookup to get schemas available
         self.lookup = get_schemas_available()
 
-        self.logger.debug(f"buildtest found the available schema: {self.lookup} in schema library")
+        self.logger.debug(
+            f"buildtest found the available schema: {self.lookup} in schema library"
+        )
 
         # Load the configuration file, fails on any error
         self.load(config_file)
@@ -520,7 +522,9 @@ class BuilderBase:
             testpath,
             stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH,
         )
-        self.logger.debug(f"Applying permission 755 to {testpath} so that test can be executed")
+        self.logger.debug(
+            f"Applying permission 755 to {testpath} so that test can be executed"
+        )
         return testpath
 
     def _get_test_lines(self):

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -266,8 +266,7 @@ class BuilderBase:
 
            Returns: full path to testing directory
         """
-        testpath = os.path.expandvars(self.metadata["testpath"])
-        return os.path.dirname(testpath)
+        return os.path.dirname(self.metadata["testpath"])
 
     def _create_test_folders(self):
         """Create all needed test folders on init, and add their paths
@@ -384,9 +383,8 @@ class BuilderBase:
             os.path.join(self.testdir, self.name),
             self.get_test_extension(),
         )
-        self.metadata["testdir"] = os.path.dirname(
-            os.path.expandvars(self.metadata["testpath"])
-        )
+        self.metadata["testpath"] = os.path.expandvars(self.metadata["testpath"])
+        self.metadata["testdir"] = os.path.dirname(self.metadata["testpath"])
 
         # The start time to print for the user
         self.metadata["start_time"] = datetime.datetime.now()
@@ -515,7 +513,7 @@ class BuilderBase:
 
         # '$HOME/.buildtest/testdir/<name>/<name>_<timestamp>.sh'
         # This will put output (latest run) in same directory - do we want this?
-        testpath = os.path.expandvars(self.metadata["testpath"])
+        testpath = self.metadata["testpath"]
 
         self.logger.info(f"Opening Test File for Writing: {testpath}")
 

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -442,15 +442,12 @@ class BuilderBase:
         # Keep an output file
         run_output_file = os.path.join(self.metadata.get("rundir"), self.build_id)
 
-        # Keep an error file
-        run_error_file = os.path.join(self.metadata.get("rundir"), self.build_id)
-
         # write output of test to .out file
         with open(run_output_file + ".out", "w") as fd:
             fd.write("\n".join(out))
 
         # write error from test to .err file
-        with open(run_error_file + ".err", "w") as fd:
+        with open(run_output_file + ".err", "w") as fd:
             fd.write("\n".join(err))
 
         result["RETURN_CODE"] = command.returncode

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -82,6 +82,14 @@ class BuildConfig:
         """
         self.config_file = os.path.abspath(config_file)
 
+        if not os.path.exists(self.config_file):
+            sys.exit("Build configuration %s does not exist." % self.config_file)
+
+        elif os.path.isdir(self.config_file):
+            sys.exit(
+                "Please provide a file path (not a directory path) to a build recipe."
+            )
+
         # all test configs must pass global validation (sets self.recipe)
         self._validate_global()
 

--- a/buildtest/buildsystem/schemas/utils.py
+++ b/buildtest/buildsystem/schemas/utils.py
@@ -3,9 +3,9 @@ Utility and helper functions for schemas.
 Copyright (C) 2020 Vanessa Sochat.
 """
 
-import os
 import json
-from jsonschema import validate
+import logging
+import os
 import re
 import sys
 import yaml
@@ -22,13 +22,23 @@ def load_schema(path):
 
        path: the path to the schema file.
     """
+
+    logger = logging.getLogger(__name__)
+
     if not os.path.exists(path):
         sys.exit("schema file %s does not exist." % path)
+
     with open(path, "r") as fd:
         if re.search("[.]json$", path):
             schema = json.loads(fd.read())
         elif re.search("[.](yaml|yml)$", path):
             schema = yaml.load(fd.read(), Loader=yaml.SafeLoader)
+        else:
+            msg = "Invalid extension for schema must be on of the following: [.json, .yml, .yaml]"
+            logger.error(msg)
+            sys.exit(msg)
+
+    logger.debug(f"Successfully loaded schema file: {path}")
     return schema
 
 

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -1,4 +1,4 @@
-import json
+import logging
 import os
 import shutil
 from jsonschema import validate
@@ -52,10 +52,16 @@ def check_configuration(config_path=None):
        :rtype: exit code 1 if checks failed
     """
 
-    user_schema = load_configuration(config_path)
-    config_schema = load_schema(DEFAULT_CONFIG_SCHEMA)
-    validate(instance=user_schema, schema=config_schema)
+    logger = logging.getLogger(__name__)
 
+    user_schema = load_configuration(config_path)
+
+    config_schema = load_schema(DEFAULT_CONFIG_SCHEMA)
+    logger.debug(f"Loading default configuration schema: {DEFAULT_CONFIG_SCHEMA}")
+
+    logger.debug(f"Validating user schema: {user_schema} with schema: {config_schema}")
+    validate(instance=user_schema, schema=config_schema)
+    logger.debug("Validation was successful")
 
 def load_configuration(config_path=None):
     """Load the default configuration file if no argument is specified.

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -63,6 +63,7 @@ def check_configuration(config_path=None):
     validate(instance=user_schema, schema=config_schema)
     logger.debug("Validation was successful")
 
+
 def load_configuration(config_path=None):
     """Load the default configuration file if no argument is specified.
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -103,7 +103,9 @@ class BuildExecutor:
         # Run each step defined for dry run
         for step in executor.steps:
             if getattr(executor, step, None):
-                executor.builder.logger.debug("Running %s for executor %s" % (step, executor))
+                executor.builder.logger.debug(
+                    "Running %s for executor %s" % (step, executor)
+                )
                 getattr(executor, step)()
         return executor.result
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -101,9 +101,7 @@ class BuildExecutor:
         # Run each step defined for dry run
         for step in executor.steps:
             if getattr(executor, step, None):
-                executor.builder.logger.debug(
-                    "Running %s for executor %s" % (step, executor)
-                )
+                # executor.builder.logger.debug("Running %s for executor %s" % (step, executor))
                 getattr(executor, step)()
         return executor.result
 
@@ -170,7 +168,7 @@ class BaseExecutor:
         """Setup the executor, meaning we check that the builder is defined,
            the only step needed for a local (base) executor.
         """
-        print(self.builder)
+
         if not self.builder:
             sys.exit("Builder is not defined for executor.")
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -103,7 +103,7 @@ class BuildExecutor:
         # Run each step defined for dry run
         for step in executor.steps:
             if getattr(executor, step, None):
-                # executor.builder.logger.debug("Running %s for executor %s" % (step, executor))
+                executor.builder.logger.debug("Running %s for executor %s" % (step, executor))
                 getattr(executor, step)()
         return executor.result
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -3,7 +3,7 @@ BuildExecutor: manager for test executors
 Copyright (C) 2020 Vanessa Sochat. 
 """
 
-import os
+import logging
 import sys
 
 
@@ -28,9 +28,11 @@ class BuildExecutor:
            :type default: str
         """
         self.executors = {}
-
+        self.logger = logging.getLogger(__name__)
+        self.logger.debug("Getting Executors from buildtest settings")
         # Load the executors
         for name, executor in config_opts.get("executors", {}).items():
+            self.logger.debug(f"Executor Name: {name}  Executor Value: {executor}")
             if executor["type"] == "local":
                 self.executors[name] = LocalExecutor(name, executor)
             elif executor["type"] == "slurm":

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -10,6 +10,7 @@ def main():
     from buildtest.menu import BuildTestParser
     from buildtest.system import BuildTestSystem
     from buildtest.log import init_logfile
+
     logger = init_logfile("buildtest.log")
     logger.info("Starting buildtest log")
 

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -11,7 +11,11 @@ def main():
     from buildtest.system import BuildTestSystem
     from buildtest.log import init_logfile
 
-    logger = init_logfile("buildtest.log")
+    buildtest_logfile = "buildtest.log"
+    if os.path.exists(buildtest_logfile):
+        os.remove(buildtest_logfile)
+
+    logger = init_logfile(buildtest_logfile)
     logger.info("Starting buildtest log")
 
     # Create a build test system, and check requirements

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -9,10 +9,12 @@ def main():
 
     from buildtest.menu import BuildTestParser
     from buildtest.system import BuildTestSystem
+    from buildtest.log import init_logfile
+    logger = init_logfile("buildtest.log")
+    logger.info("Starting buildtest log")
 
     # Create a build test system, and check requirements
-    buildtest_system = BuildTestSystem()
-    buildtest_system.check_system_requirements()
+    BuildTestSystem()
 
     parser = BuildTestParser()
     parser.parse_options()

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -97,7 +97,12 @@ def func_build_subcmd(args):
 
     # Load BuildExecutors
     executor = BuildExecutor(config_opts, default=args.executor)
-
+    print(
+        "{:<30} {:<30} {:<30} {:<30}".format(
+            "Config Name", "SubTest", "Status", "Config Path"
+        )
+    )
+    print("{:_<120}".format(""))
     # Each configuration file can have multiple tests
     for config_file in config_files:
 
@@ -121,7 +126,6 @@ def func_build_subcmd(args):
                 result = executor.dry_run(builder)
 
     if not args.dry:
-        print(f"Finished running {total_tests} total tests.")
         print
         print
         print("==============================================================")

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -5,6 +5,7 @@ for building test scripts from test configuration.
 
 import logging
 import os
+import re
 import sys
 
 from buildtest.defaults import TESTCONFIG_ROOT, BUILDTEST_CONFIG_FILE
@@ -52,6 +53,11 @@ def discover_configs(config_file):
         )
         config_files = walk_tree(config_file, ".yml")
     elif os.path.isfile(config_file):
+        if not re.search("[.](yaml|yml)$", config_file):
+            msg = f"{config_file} does not end in file extension .yaml or .yml"
+            logger.error(msg)
+            sys.exit(msg)
+
         config_files = [config_file]
         logger.debug(f"Config File: {config_file} is a file")
     else:

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -47,13 +47,18 @@ def discover_configs(config_file):
 
     # Now handle path based on being a directory or file path
     if os.path.isdir(config_file):
-        logger.debug(f"Config File: {config_file} is a directory so traversing directory tree to find all .yml files.")
+        logger.debug(
+            f"Config File: {config_file} is a directory so traversing directory tree to find all .yml files."
+        )
         config_files = walk_tree(config_file, ".yml")
     elif os.path.isfile(config_file):
         config_files = [config_file]
         logger.debug(f"Config File: {config_file} is a file")
     else:
-        msg = "Please provide an absolute or relative path to a directory file from your present working directory or %s" % TESTCONFIG_ROOT
+        msg = (
+            "Please provide an absolute or relative path to a directory file from your present working directory or %s"
+            % TESTCONFIG_ROOT
+        )
         logger.error(msg)
         sys.exit(msg)
 
@@ -86,7 +91,9 @@ def func_build_subcmd(args):
     config_file = args.settings or BUILDTEST_CONFIG_FILE
 
     if args.settings:
-        logger.debug("Detected --settings from command line so override default settings file.")
+        logger.debug(
+            "Detected --settings from command line so override default settings file."
+        )
 
     logger.debug(f"Detected the following buildtest settings file: {config_file}")
 

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -153,10 +153,10 @@ def func_build_subcmd(args):
         print("                         Test summary                         ")
         print(f"Executed {total_tests} tests")
         print(
-            f"Passed Tests: {passed_tests} Percentage: {passed_tests*100/total_tests}%"
+            f"Passed Tests: {passed_tests}/{total_tests} Percentage: {passed_tests*100/total_tests}%"
         )
         print(
-            f"Failed Tests: {failed_tests} Percentage: {failed_tests*100/total_tests}%"
+            f"Failed Tests: {failed_tests}/{total_tests} Percentage: {failed_tests*100/total_tests}%"
         )
         print
         print

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -67,12 +67,12 @@ class BuildTestSystem:
             f"Operating System Build Number: {self.system['os']['build_number']}"
         )
 
-        self.logger.info("Session Environment Variables")
-        self.logger.info("{:_<80}".format(""))
+        self.logger.debug("Session Environment Variables")
+        self.logger.debug("{:_<80}".format(""))
         for k, v in self.system["env"].items():
-            self.logger.info(f"{k}: {v}")
-        self.logger.info("{:_<80}".format(""))
-        self.logger.info(f"Python Path: {self.system['python']}")
+            self.logger.debug(f"{k}: {v}")
+        self.logger.debug("{:_<80}".format(""))
+        self.logger.debug(f"Python Path: {self.system['python']}")
 
     def check_lmod(self):
         """Check if the system has Lmod installed, determine by setting
@@ -82,7 +82,7 @@ class BuildTestSystem:
         self.lmod = "LMOD_DIR" in os.environ and os.path.exists(
             os.environ.get("LMOD_DIR", "")
         )
-        self.logger.info(f"LMOD_DIR: {self.lmod}")
+        self.logger.debug(f"LMOD_DIR: {self.lmod}")
 
     def check_scheduler(self):
         """Check for batch scheduler. Currently checks for LSF or SLURM by running

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -53,24 +53,24 @@ class BuildTestSystem:
         self.system["os"]["minor_version"] = distro.major_version(best=True)
         self.system["os"]["build_number"] = distro.build_number(best=True)
         self.system["env"] = dict(os.environ)
-        self.system["python"] = shutil.which("python") or None
+        self.system["python"] = shutil.which("python")
 
-        self.logger.info(f"Operating System: {self.system['os']['name']}")
-        self.logger.info(f"Operating System Version: {self.system['os']['version']}")
-        self.logger.info(
+        self.logger.debug(f"Operating System: {self.system['os']['name']}")
+        self.logger.debug(f"Operating System Version: {self.system['os']['version']}")
+        self.logger.debug(
             f"Operating System Major Version: {self.system['os']['major_version']}"
         )
-        self.logger.info(
+        self.logger.debug(
             f"Operating System Minor Version: {self.system['os']['minor_version']}"
         )
-        self.logger.info(
+        self.logger.debug(
             f"Operating System Build Number: {self.system['os']['build_number']}"
         )
 
         self.logger.debug("Session Environment Variables")
         self.logger.debug("{:_<80}".format(""))
-        for k, v in self.system["env"].items():
-            self.logger.debug(f"{k}: {v}")
+        for k in self.system["env"].keys():
+            self.logger.debug(k)
         self.logger.debug("{:_<80}".format(""))
         self.logger.debug(f"Python Path: {self.system['python']}")
 

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -31,7 +31,7 @@ class BuildTestSystem:
         self.scheduler = self.check_scheduler()
         self.check_lmod()
 
-        if self.system['platform'] != "Linux":
+        if self.system["platform"] != "Linux":
             print("System must be Linux")
             sys.exit(1)
 
@@ -43,9 +43,9 @@ class BuildTestSystem:
         self.system["os_name"] = distro.linux_distribution(
             full_distribution_name=False
         )[0]
-        self.system["os_ver"] = distro.linux_distribution(
-            full_distribution_name=False
-        )[1]
+        self.system["os_ver"] = distro.linux_distribution(full_distribution_name=False)[
+            1
+        ]
         self.logger.info(f"Operating System: {self.system['os_name']}")
         self.logger.info(f"Operating System Version: {self.system['os_ver']}")
 

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -3,6 +3,7 @@ This module detects System changes defined in class BuildTestSystem.
 """
 
 import distro
+import logging
 import os
 import platform
 import shutil
@@ -23,20 +24,30 @@ class BuildTestSystem:
         """Constructor method for BuildTestSystem(). Defines all system configuration using
            class variable **system** which is a dictionary
         """
+        self.logger = logging.getLogger(__name__)
+        self.logger.debug("Starting System Compatibility Check")
         self.init_system()
-        self.system["SYSTEM"] = platform.system()
+        self.system["platform"] = platform.system()
         self.scheduler = self.check_scheduler()
         self.check_lmod()
+
+        if self.system['platform'] != "Linux":
+            print("System must be Linux")
+            sys.exit(1)
+
+        self.logger.debug("Finished System Compatibility Check")
 
     def init_system(self):
         """Based on the module "distro" set the linux distrubution name and version
         """
-        self.system["OS_NAME"] = distro.linux_distribution(
+        self.system["os_name"] = distro.linux_distribution(
             full_distribution_name=False
         )[0]
-        self.system["OS_VERSION"] = distro.linux_distribution(
+        self.system["os_ver"] = distro.linux_distribution(
             full_distribution_name=False
         )[1]
+        self.logger.info(f"Operating System: {self.system['os_name']}")
+        self.logger.info(f"Operating System Version: {self.system['os_ver']}")
 
     def check_lmod(self):
         """Check if the system has Lmod installed, determine by setting
@@ -46,6 +57,7 @@ class BuildTestSystem:
         self.lmod = "LMOD_DIR" in os.environ and os.path.exists(
             os.environ.get("LMOD_DIR", "")
         )
+        self.logger.info(f"LMOD_DIR: {self.lmod}")
 
     def check_scheduler(self):
         """Check for batch scheduler. Currently checks for LSF or SLURM by running
@@ -74,10 +86,3 @@ class BuildTestSystem:
             return "SLURM"
         if lsf_ec_code == 0:
             return "LSF"
-
-    def check_system_requirements(self):
-        """Checking system requirements."""
-
-        if self.system["SYSTEM"] != "Linux":
-            print("System must be Linux")
-            sys.exit(1)

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -41,31 +41,12 @@ class BuildTestSystem:
         """Based on the module "distro" set the linux distrubution name and version
         """
 
-        self.system["os"] = {}
+        self.system["os"] = " ".join(distro.linux_distribution())
 
-        self.system["os"]["name"] = distro.linux_distribution(
-            full_distribution_name=False
-        )[0]
-        self.system["os"]["version"] = distro.linux_distribution(
-            full_distribution_name=False
-        )[1]
-        self.system["os"]["major_version"] = distro.major_version(best=True)
-        self.system["os"]["minor_version"] = distro.major_version(best=True)
-        self.system["os"]["build_number"] = distro.build_number(best=True)
         self.system["env"] = dict(os.environ)
         self.system["python"] = shutil.which("python")
 
-        self.logger.debug(f"Operating System: {self.system['os']['name']}")
-        self.logger.debug(f"Operating System Version: {self.system['os']['version']}")
-        self.logger.debug(
-            f"Operating System Major Version: {self.system['os']['major_version']}"
-        )
-        self.logger.debug(
-            f"Operating System Minor Version: {self.system['os']['minor_version']}"
-        )
-        self.logger.debug(
-            f"Operating System Build Number: {self.system['os']['build_number']}"
-        )
+        self.logger.debug(f"Operating System: {self.system['os']}")
 
         self.logger.debug("Session Environment Variables")
         self.logger.debug("{:_<80}".format(""))

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -40,14 +40,39 @@ class BuildTestSystem:
     def init_system(self):
         """Based on the module "distro" set the linux distrubution name and version
         """
-        self.system["os_name"] = distro.linux_distribution(
+
+        self.system["os"] = {}
+
+        self.system["os"]["name"] = distro.linux_distribution(
             full_distribution_name=False
         )[0]
-        self.system["os_ver"] = distro.linux_distribution(full_distribution_name=False)[
-            1
-        ]
-        self.logger.info(f"Operating System: {self.system['os_name']}")
-        self.logger.info(f"Operating System Version: {self.system['os_ver']}")
+        self.system["os"]["version"] = distro.linux_distribution(
+            full_distribution_name=False
+        )[1]
+        self.system["os"]["major_version"] = distro.major_version(best=True)
+        self.system["os"]["minor_version"] = distro.major_version(best=True)
+        self.system["os"]["build_number"] = distro.build_number(best=True)
+        self.system["env"] = dict(os.environ)
+        self.system["python"] = shutil.which("python") or None
+
+        self.logger.info(f"Operating System: {self.system['os']['name']}")
+        self.logger.info(f"Operating System Version: {self.system['os']['version']}")
+        self.logger.info(
+            f"Operating System Major Version: {self.system['os']['major_version']}"
+        )
+        self.logger.info(
+            f"Operating System Minor Version: {self.system['os']['minor_version']}"
+        )
+        self.logger.info(
+            f"Operating System Build Number: {self.system['os']['build_number']}"
+        )
+
+        self.logger.info("Session Environment Variables")
+        self.logger.info("{:_<80}".format(""))
+        for k, v in self.system["env"].items():
+            self.logger.info(f"{k}: {v}")
+        self.logger.info("{:_<80}".format(""))
+        self.logger.info(f"Python Path: {self.system['python']}")
 
     def check_lmod(self):
         """Check if the system has Lmod installed, determine by setting

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -11,7 +11,6 @@ include the following:
 import os
 import logging
 
-from buildtest.defaults import logID
 from buildtest.exceptions import BuildTestError
 
 
@@ -87,7 +86,7 @@ def create_file(filename):
     :return: writes an empty file or print an exception message if failed to write file
     :rtype: Catches exception of type OSError
     """
-    logger = logging.getLogger(logID)
+    logger = logging.getLogger(__name__)
     filename = os.path.expandvars(filename)
     filename = os.path.expanduser(filename)
     if not os.path.isfile(filename):
@@ -112,7 +111,7 @@ def create_dir(dirname):
     """
     dirname = os.path.expandvars(dirname)
     dirname = os.path.expanduser(dirname)
-    logger = logging.getLogger(logID)
+    logger = logging.getLogger(__name__)
     if not os.path.isdir(dirname):
         try:
             os.makedirs(dirname)

--- a/tests/buildsystem/schemas/test_utils.py
+++ b/tests/buildsystem/schemas/test_utils.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+import uuid
+
+from buildtest.buildsystem.schemas.utils import load_schema, load_recipe
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.mark.xfail(
+    reason="Invalid File Extension for loading schema", raises=SystemExit
+)
+def test_load_schema_invalid_ext():
+
+    # invalid file extension should fail
+    load_schema(os.path.join(root, "README.rst"))
+
+
+@pytest.mark.xfail(reason="Invalid File Path when loading recipe", raises=SystemExit)
+def test_load_recipe_invalid_path():
+    invalid_file = str(uuid.uuid4())
+    load_recipe(invalid_file)

--- a/tests/buildsystem/test_base.py
+++ b/tests/buildsystem/test_base.py
@@ -18,8 +18,8 @@ def test_load_configs():
     examples_dir = os.path.join(here, "testdir")
 
     # An empty path evaluated to be a directory should exit
-    with pytest.raises(SystemExit) as e_info:
-        BuildConfig("")
+    # with pytest.raises(SystemExit) as e_info:
+    #    BuildConfig("")
 
     # Test loading config files
     for config_file in os.listdir(examples_dir):

--- a/tests/buildsystem/test_base.py
+++ b/tests/buildsystem/test_base.py
@@ -18,8 +18,8 @@ def test_load_configs():
     examples_dir = os.path.join(here, "testdir")
 
     # An empty path evaluated to be a directory should exit
-    # with pytest.raises(SystemExit) as e_info:
-    #    BuildConfig("")
+    with pytest.raises(SystemExit) as e_info:
+        BuildConfig("")
 
     # Test loading config files
     for config_file in os.listdir(examples_dir):

--- a/tests/menu/test_build.py
+++ b/tests/menu/test_build.py
@@ -1,0 +1,38 @@
+import os
+import pytest
+import uuid
+from buildtest.menu.build import discover_configs
+
+test_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+root = os.path.dirname(test_root)
+
+
+def test_discover_configs():
+
+    # testing single file
+    config = os.path.join(test_root, "testdir", "slurm-hello.yml")
+    config_files = discover_configs(config)
+
+    assert isinstance(config_files, list)
+    assert config in config_files
+
+    # testing with directory
+    config_dir = os.path.join(test_root, "testdir")
+    config_files = discover_configs(config_dir)
+
+    assert isinstance(config_files, list)
+    assert config in config_files
+
+    # invalid file extension must be of type .yml or .yaml
+    with pytest.raises(SystemExit) as e_info:
+        discover_configs(os.path.join(root, "README.rst"))
+
+    # when no config files found in a valid directory
+    with pytest.raises(SystemExit) as e_info:
+        # searching for all configs in current directory
+        discover_configs(os.path.dirname(os.path.abspath(__file__)))
+
+    # when you pass invalid file it should fail
+    with pytest.raises(SystemExit) as e_info:
+        invalid_file = str(uuid.uuid4())
+        discover_configs(invalid_file)


### PR DESCRIPTION
This PR will address the following fix
- Change output behavior #256 
- Add .err file #257 
- Add system logging #265 and remove log per test 
- Add additional logging throughout codebase
- Fix regtest issue where BuildConfig should not be called with any invalid config file, that's because all checks are done in advance in method ``discover_configs``
- Add additional system detection including environment variable, operating system details, and python path.

This first attempt to change output behavior of buildtest build.

The output looks as follows with left align all the fields.

```
gitpod /workspace/buildtest-framework $ buildtest build -c examples/script/
Config Name                    SubTest                        Status                         Config Path                   
________________________________________________________________________________________________________________________
slurm                          slurm_down_nodes_reason        PASSED                         /workspace/buildtest-framework/examples/script/slurm.yml
slurm                          slurm_not_responding_nodes     PASSED                         /workspace/buildtest-framework/examples/script/slurm.yml
zlib                           zlib_compression               PASSED                         /workspace/buildtest-framework/examples/script/zlib.yml
zlib                           zlib_decompress                PASSED                         /workspace/buildtest-framework/examples/script/zlib.yml
python-circle                  circle_area                    PASSED                         /workspace/buildtest-framework/examples/script/python-circle.yml
bzip2                          bzip_compression               PASSED                         /workspace/buildtest-framework/examples/script/bzip2.yml
bzip2                          bzip_version                   PASSED                         /workspace/buildtest-framework/examples/script/bzip2.yml
bzip2                          bzip_help                      PASSED                         /workspace/buildtest-framework/examples/script/bzip2.yml
bzip2                          bzip2_help                     PASSED                         /workspace/buildtest-framework/examples/script/bzip2.yml
==============================================================
                         Test summary                         
Executed 9 tests
Passed Tests: 7 Percentage: 77.77777777777777%
Failed Tests: 2 Percentage: 22.22222222222222%

```

There was some output displayed to stdout that was intended for logstream. Looking at the way ``init_logger`` was setup, it was not intended to work as it should so for now i removed a few log statement. I will cover the log issue in a separate issue to describe the issue.

The origin output as per devel head is the following

```
gitpod /workspace/buildtest-framework $ buildtest build -c examples/script/python-circle.yml 
2020-04-05 20:39:41,617 [base.py:105 -   run() ] - [DEBUG] Running setup for executor [executor-local-runlocal]
[builder-script-circle_area]
2020-04-05 20:39:41,617 [base.py:105 -   run() ] - [DEBUG] Running run for executor [executor-local-runlocal]
________________________________________________________________________________
                             start time: 2020-04-05 20:39:41.617493
                     configuration file: /workspace/buildtest-framework/examples/script/python-circle.yml
                                testdir: /workspace/buildtest-framework/.buildtest/python-circle
                               testpath: /workspace/buildtest-framework/.buildtest/python-circle/circle_area.py
                                logpath: None
________________________________________________________________________________



STAGE                                    VALUE
________________________________________________________________________________
2020-04-05 20:39:41,618 [base.py:550 - _write_test() ] - [INFO] Opening Test File for Writing: /workspace/buildtest-framework/.buildtest/python-circle/circle_area.py
[WRITING TEST]                           PASSED
[RUNNING TEST]                           PASSED
Writing results to /workspace/buildtest-framework/.buildtest/python-circle/run/circle_area_04-05-2020-20-39.out
Finished running 1 total tests.
==============================================================
                         Test summary                         
Executed 1 tests
Passed Tests: 1 Percentage: 100.0%
Failed Tests: 0 Percentage: 0.0%
```