### PR TITLE
exclude config option

### DIFF
--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -74,7 +74,7 @@ class BuildTestParser:
         """
         args, extra = self.parser.parse_known_args()
         self.extra = extra
-        
+
         if args.subcommands and args.func:
             args.func(args)
 
@@ -121,7 +121,7 @@ class BuildTestParser:
         parser_build.add_argument(
             "-x",
             "--exclude",
-            action='append',
+            action="append",
             help="Exclude one or more configs from processing. Configs can be files or directories.",
         )
         parser_build.set_defaults(func=func_build_subcmd)

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -74,7 +74,7 @@ class BuildTestParser:
         """
         args, extra = self.parser.parse_known_args()
         self.extra = extra
-
+        
         if args.subcommands and args.func:
             args.func(args)
 
@@ -118,6 +118,12 @@ class BuildTestParser:
             "--settings", help="Specify an alternate buildtest settings file to use",
         )
 
+        parser_build.add_argument(
+            "-x",
+            "--exclude",
+            action='append',
+            help="Exclude one or more configs from processing. Configs can be files or directories.",
+        )
         parser_build.set_defaults(func=func_build_subcmd)
 
     def get_menu(self):

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -15,6 +15,8 @@ from buildtest.config import load_configuration, check_configuration
 from buildtest.executors.base import BuildExecutor
 from buildtest.utils.file import walk_tree, resolve_path
 
+logger = logging.getLogger(__name__)
+
 
 def discover_configs(config_file):
     """Given a config file specified by the user with buildtest build -c,
@@ -34,7 +36,7 @@ def discover_configs(config_file):
        # relative directory path in build test root (returns multiple)
        buildtest build -c github.com/HPC-buildtest/tutorials/hello-world/
     """
-    logger = logging.getLogger(__name__)
+
     config_files = []
 
     # If no config file provided, assume discovering across buildtest/site
@@ -96,8 +98,6 @@ def include_file(file_path, white_list_patterns):
        :rtype: bool or str
     """
 
-    logger = logging.getLogger(__name__)
-
     if not white_list_patterns:
         logger.debug("No white list patterns provided, returning True")
         return True
@@ -127,9 +127,6 @@ def func_build_subcmd(args):
        :rtype: None
     """
 
-    # buildtest logger
-    logger = logging.getLogger(__name__)
-
     # if buildtest settings specified on CLI, it would be in args.settings otherwise set
     # to default configuration (BUILDTEST_CONFIG_FILE)
     config_file = args.settings or BUILDTEST_CONFIG_FILE
@@ -152,16 +149,11 @@ def func_build_subcmd(args):
     # if no files discovered let's stop now
     if not config_files:
         msg = "There are no config files to process."
-        logger.error(msg)
         sys.exit(msg)
 
-    print("\n")
-    print("{:^45}".format("Discovered Files"))
-    print("\n")
-    for config in config_files:
-        print(config)
-    print("\n")
-    print("\n")
+    print("\n {:^45} \n".format("Discovered Files"))
+    [print(config) for config in config_files]
+    print("\n\n")
 
     logger.debug(
         f"Based on input argument: -c {args.config} buildtest discovered the following configuration {config_files}"
@@ -169,14 +161,10 @@ def func_build_subcmd(args):
 
     if args.exclude:
         logger.debug(f"The exclude config pattern are the following: -e {args.exclude}")
-
-    config_files = [
-        config for config in config_files if include_file(config, args.exclude)
-    ]
-
-    logger.debug(
-        f"Normalized configuration list that buildtest will process are the following: {config_files}"
-    )
+        config_files = [
+            config for config in config_files if include_file(config, args.exclude)
+        ]
+        logger.debug(f"Configuration List after applying exclusion: {config_files}")
 
     # Keep track of total metrics
     total_tests = 0
@@ -214,9 +202,7 @@ def func_build_subcmd(args):
                 result = executor.dry_run(builder)
 
     if not args.dry:
-        print("\n")
-        print("\n")
-        print("{:=<60}".format(""))
+        print("\n\n{:=<60}".format(""))
         print("{:^60}".format("Test summary"))
         print("{:=<60}".format(""))
         print(f"Executed {total_tests} tests")

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -86,14 +86,14 @@ def include_file(file_path, white_list_patterns):
        provided method will return ``True``. Otherwise it will return the list of files that don't
        match the regular expression
 
-    Parameters:
+       Parameters:
 
-    :param file_path: file path to run regular expression upon
-    :type file_path: str, required
-    :param white_list_patterns: the exclude list provided on command line option
-    :type white_list_patterns: list, required
-    :return: Returns True or a list of files that don't match regular expression
-    :rtype: bool or str
+       :param file_path: file path to run regular expression upon
+       :type file_path: str, required
+       :param white_list_patterns: the exclude list provided on command line option
+       :type white_list_patterns: list, required
+       :return: Returns True or a list of files that don't match regular expression
+       :rtype: bool or str
     """
 
     logger = logging.getLogger(__name__)
@@ -116,13 +116,15 @@ def include_file(file_path, white_list_patterns):
 
 def func_build_subcmd(args):
     """Entry point for ``buildtest build`` sub-command. Depending on the command
-    arguments, buildtest will set values in dictionary ``config_opts`` that is used
-    to trigger the appropriate build action.
+       arguments, buildtest will set values in dictionary ``config_opts`` that is used
+       to trigger the appropriate build action.
 
-    :param args: arguments passed from command line
-    :type args: dict, required
+       Parameters:
 
-    :rtype: None
+       :param args: arguments passed from command line
+       :type args: dict, required
+
+       :rtype: None
     """
 
     # buildtest logger
@@ -147,6 +149,20 @@ def func_build_subcmd(args):
     # Discover list of one or more config files based on path provided
     config_files = discover_configs(args.config)
 
+    # if no files discovered let's stop now
+    if not config_files:
+        msg = "There are no config files to process."
+        logger.error(msg)
+        sys.exit(msg)
+
+    print ("\n")
+    print ("{:^45}".format("Discovered Files"))
+    print ("\n")
+    for config in config_files:
+        print(config)
+    print ("\n")
+    print ("\n")
+
     logger.debug(
         f"Based on input argument: -c {args.config} buildtest discovered the following configuration {config_files}"
     )
@@ -162,12 +178,7 @@ def func_build_subcmd(args):
         f"Normalized configuration list that buildtest will process are the following: {config_files}"
     )
 
-    # config_files = exclude_configs(config_files, args.exclude)
 
-    if not config_files:
-        msg = "There are no config files to process."
-        logger.error(msg)
-        sys.exit(msg)
 
     # Keep track of total metrics
     total_tests = 0
@@ -205,16 +216,18 @@ def func_build_subcmd(args):
                 result = executor.dry_run(builder)
 
     if not args.dry:
-        print
-        print
-        print("==============================================================")
-        print("                         Test summary                         ")
+        print ("\n")
+        print ("\n")
+        print("{:=<60}".format(""))
+        print("{:^60}".format("Test summary"))
+        print("{:=<60}".format(""))
         print(f"Executed {total_tests} tests")
-        print(
-            f"Passed Tests: {passed_tests}/{total_tests} Percentage: {passed_tests*100/total_tests}%"
-        )
-        print(
-            f"Failed Tests: {failed_tests}/{total_tests} Percentage: {failed_tests*100/total_tests}%"
-        )
+
+        pass_rate = passed_tests * 100 / total_tests
+        fail_rate = failed_tests * 100 / total_tests
+
+        print(f"Passed Tests: {passed_tests}/{total_tests} Percentage: {pass_rate:.3f}%")
+
+        print(f"Failed Tests: {failed_tests}/{total_tests} Percentage: {fail_rate:.3f}%")
         print
         print

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -13,7 +13,7 @@ from buildtest.defaults import TESTCONFIG_ROOT, BUILDTEST_CONFIG_FILE
 from buildtest.buildsystem.base import BuildConfig
 from buildtest.config import load_configuration, check_configuration
 from buildtest.executors.base import BuildExecutor
-from buildtest.utils.file import walk_tree
+from buildtest.utils.file import walk_tree, resolve_path
 
 
 def discover_configs(config_file):
@@ -103,13 +103,8 @@ def exclude_configs(config_files, exclude_list):
         return config_files
 
     # check all configs exist and return a list of configs with absolute path with shell expansion.
-    tmp = [
-        os.path.expandvars(os.path.abspath(config))
-        for config in exclude_list
-        if os.path.exists(os.path.expandvars(os.path.abspath(config)))
-    ]
+    tmp = [resolve_path(config) for config in exclude_list]
     exclude_list = tmp
-
 
     # empty list to store all exclude config files
     exclude_config_files = []

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -75,11 +75,12 @@ def discover_configs(config_file):
         sys.exit(msg)
 
     # return all configs with absolute path
-    tmp = [ os.path.abspath(config) for config in config_files ]
+    tmp = [os.path.abspath(config) for config in config_files]
     config_files = tmp
 
     logger.info(f"Found the following config files: {config_files}")
     return config_files
+
 
 def exclude_configs(config_files, exclude_list):
     """This method will exclude configs from being processed after discovery and
@@ -102,8 +103,13 @@ def exclude_configs(config_files, exclude_list):
         return config_files
 
     # check all configs exist and return a list of configs with absolute path with shell expansion.
-    tmp = [ os.path.expandvars(os.path.abspath(config)) for config in exclude_list if os.path.exists(os.path.expandvars(os.path.abspath(config))) ]
+    tmp = [
+        os.path.expandvars(os.path.abspath(config))
+        for config in exclude_list
+        if os.path.exists(os.path.expandvars(os.path.abspath(config)))
+    ]
     exclude_list = tmp
+
 
     # empty list to store all exclude config files
     exclude_config_files = []
@@ -125,6 +131,7 @@ def exclude_configs(config_files, exclude_list):
             config_files.remove(config)
 
     return config_files
+
 
 def func_build_subcmd(args):
     """Entry point for ``buildtest build`` sub-command. Depending on the command
@@ -164,7 +171,6 @@ def func_build_subcmd(args):
     if not config_files:
         msg = "There are no config files to process."
         sys.exit(msg)
-
 
     # Keep track of total metrics
     total_tests = 0

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -155,13 +155,13 @@ def func_build_subcmd(args):
         logger.error(msg)
         sys.exit(msg)
 
-    print ("\n")
-    print ("{:^45}".format("Discovered Files"))
-    print ("\n")
+    print("\n")
+    print("{:^45}".format("Discovered Files"))
+    print("\n")
     for config in config_files:
         print(config)
-    print ("\n")
-    print ("\n")
+    print("\n")
+    print("\n")
 
     logger.debug(
         f"Based on input argument: -c {args.config} buildtest discovered the following configuration {config_files}"
@@ -177,8 +177,6 @@ def func_build_subcmd(args):
     logger.debug(
         f"Normalized configuration list that buildtest will process are the following: {config_files}"
     )
-
-
 
     # Keep track of total metrics
     total_tests = 0
@@ -216,8 +214,8 @@ def func_build_subcmd(args):
                 result = executor.dry_run(builder)
 
     if not args.dry:
-        print ("\n")
-        print ("\n")
+        print("\n")
+        print("\n")
         print("{:=<60}".format(""))
         print("{:^60}".format("Test summary"))
         print("{:=<60}".format(""))
@@ -226,8 +224,12 @@ def func_build_subcmd(args):
         pass_rate = passed_tests * 100 / total_tests
         fail_rate = failed_tests * 100 / total_tests
 
-        print(f"Passed Tests: {passed_tests}/{total_tests} Percentage: {pass_rate:.3f}%")
+        print(
+            f"Passed Tests: {passed_tests}/{total_tests} Percentage: {pass_rate:.3f}%"
+        )
 
-        print(f"Failed Tests: {failed_tests}/{total_tests} Percentage: {fail_rate:.3f}%")
+        print(
+            f"Failed Tests: {failed_tests}/{total_tests} Percentage: {fail_rate:.3f}%"
+        )
         print
         print

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -122,7 +122,7 @@ def create_dir(dirname):
 
 
 def resolve_path(path):
-    """This method will resolve a file path with accounts for shell expansion and resolve paths in
+    """This method will resolve a file path to account for shell expansion and resolve paths in
        when a symlink is provided in the file. This method assumes file already exists.
 
        Parameter:

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -132,7 +132,11 @@ def resolve_path(path):
        :return: return realpath to file if found otherwise return None
        :rtype: str or None
     """
-    shell_expansion = os.path.expandvars(path)
-    real_path = os.path.realpath(shell_expansion)
+    # apply shell expansion  when file includes something like $HOME/example
+    path = os.path.expandvars(path)
+    # apply user expansion when file includes something like  ~/example
+    path = os.path.expanduser(path)
+
+    real_path = os.path.realpath(path)
     if os.path.exists(real_path):
         return real_path

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -136,5 +136,3 @@ def resolve_path(path):
     real_path = os.path.realpath(shell_expansion)
     if os.path.exists(real_path):
         return real_path
-    else:
-        return None

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -119,3 +119,22 @@ def create_dir(dirname):
         except OSError as err:
             print(err)
             raise
+
+
+def resolve_path(path):
+    """This method will resolve a file path with accounts for shell expansion and resolve paths in
+       when a symlink is provided in the file. This method assumes file already exists.
+
+       Parameter:
+
+       :param path: file path to resolve
+       :type path: str, required
+       :return: return realpath to file if found otherwise return None
+       :rtype: str or None
+    """
+    shell_expansion = os.path.expandvars(path)
+    real_path = os.path.realpath(shell_expansion)
+    if os.path.exists(real_path):
+        return real_path
+    else:
+        return None

--- a/examples/script/bzip2.yml
+++ b/examples/script/bzip2.yml
@@ -11,8 +11,8 @@ bzip_compression:
     dd if=/dev/zero of=${FILE} bs=1M count=1
     tar cvjf ${TARFILE} ${FILE}
     ls -l ${TARFILE}
-    rm $TARFILE
-    rm $FILE
+    rm ${TARFILE}
+    rm ${FILE}
 
 bzip_help:
   type: script

--- a/examples/script/bzip2.yml
+++ b/examples/script/bzip2.yml
@@ -8,9 +8,9 @@ bzip_compression:
     TARFILE: 1mb_bzip2.txt.bz2
   shell: bash
   run: |
-    dd if=/dev/zero of="$FILE" bs=1M count=1
-    tar cvjf "$TARFILE" "$FILE"
-    ls -l "$TARFILE"
+    dd if=/dev/zero of=${FILE} bs=1M count=1
+    tar cvjf ${TARFILE} ${FILE}
+    ls -l ${TARFILE}
     rm $TARFILE
     rm $FILE
 

--- a/examples/script/bzip2.yml
+++ b/examples/script/bzip2.yml
@@ -11,12 +11,8 @@ bzip_compression:
     dd if=/dev/zero of="$FILE" bs=1M count=1
     tar cvjf "$TARFILE" "$FILE"
     ls -l "$TARFILE"
-
-bzip_version:
-  type: script
-  description: "bzip2 version"
-  shell: sh
-  run: "bzip2 --version"
+    rm $TARFILE
+    rm $FILE
 
 bzip_help:
   type: script

--- a/examples/script/zlib.yml
+++ b/examples/script/zlib.yml
@@ -6,11 +6,11 @@ zlib_compression:
     FILE: 1mb.txt
     TARFILE: 1mb.tar.gz
   run: |
-    dd if=/dev/zero of=$FILE bs=1M count=1
-    tar cvzf $TARFILE $FILE
-    ls -lh $TARFILE
-    gzip -l $TARFILE
-    rm $TARFILE $FILE
+    dd if=/dev/zero of=${FILE} bs=1M count=1
+    tar cvzf ${TARFILE} ${FILE}
+    ls -lh ${TARFILE}
+    gzip -l ${TARFILE}
+    rm ${TARFILE} ${FILE}
 
 
 zlib_decompress:
@@ -19,11 +19,11 @@ zlib_decompress:
     FILE: 1mb.txt
     TARFILE: 1mb.tar.gz
   run: |
-    dd if=/dev/zero of=$FILE bs=1M count=1
-    tar cvzf $TARFILE $FILE
-    ls -l $TARFILE
-    gzip -l $TARFILE
-    gzip -d $TARFILE
-    rm $FILE
+    dd if=/dev/zero of=${FILE} bs=1M count=1
+    tar cvzf ${TARFILE} ${FILE}
+    ls -l ${TARFILE}
+    gzip -l ${TARFILE}
+    gzip -d ${TARFILE}
+    rm ${FILE}
     rm 1mb.tar
     

--- a/examples/script/zlib.yml
+++ b/examples/script/zlib.yml
@@ -2,18 +2,28 @@ version: 0.0.1
 
 zlib_compression:
   type: script
+  env:
+    FILE: 1mb.txt
+    TARFILE: 1mb.tar.gz
   run: |
-    dd if=/dev/zero of=1mb.txt bs=1M count=1
-    tar cvzf 1mb.tar.gz 1mb.txt
-    ls -lh 1mb.tar.gz
-    gzip -l 1mb.tar.gz
+    dd if=/dev/zero of=$FILE bs=1M count=1
+    tar cvzf $TARFILE $FILE
+    ls -lh $TARFILE
+    gzip -l $TARFILE
+    rm $TARFILE $FILE
+
 
 zlib_decompress:
   type: script
+  env:
+    FILE: 1mb.txt
+    TARFILE: 1mb.tar.gz
   run: |
-    dd if=/dev/zero of=1mb.txt bs=1M count=1
-    tar cvzf 1mb.tar.gz 1mb.txt
-    ls -l 1mb.tar.gz
-    gzip -l 1mb.tar.gz
-    gzip -d 1mb.tar.gz
+    dd if=/dev/zero of=$FILE bs=1M count=1
+    tar cvzf $TARFILE $FILE
+    ls -l $TARFILE
+    gzip -l $TARFILE
+    gzip -d $TARFILE
+    rm $FILE
+    rm 1mb.tar
     

--- a/tests/menu/test_build.py
+++ b/tests/menu/test_build.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 import uuid
-from buildtest.menu.build import discover_configs, exclude_configs
+from buildtest.menu.build import discover_configs
 
 test_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 root = os.path.dirname(test_root)
@@ -36,30 +36,3 @@ def test_discover_configs():
     with pytest.raises(SystemExit) as e_info:
         invalid_file = str(uuid.uuid4())
         discover_configs(invalid_file)
-
-
-def test_exclude_configs():
-
-    config = os.path.join(root, "examples", "script")
-    detected_config_files = discover_configs(config)
-
-    exclude_list = None
-    # nothing to exclude so normalized_config_files should be same as detected_config_files
-    normalized_config_files = exclude_configs(detected_config_files, exclude_list)
-    assert detected_config_files == normalized_config_files
-
-    remove_config = os.path.join(config, "zlib.yml")
-    remove_list = [remove_config]
-
-    # check if examples/script/zlib.yml is detected
-    assert remove_config in detected_config_files
-    # now attempting to exclude examples/script/zlib.yml and checking if it is removed after exclusion
-    normalized_config_files = exclude_configs(detected_config_files, remove_list)
-    assert remove_config not in normalized_config_files
-
-    remove_config = config
-    remove_list = [remove_config]
-    # this will do a directory exclusion in examples/script and since we are searching for same directory
-    # this should return an empty list
-    normalized_config_files = exclude_configs(detected_config_files, remove_list)
-    assert not normalized_config_files

--- a/tests/menu/test_build.py
+++ b/tests/menu/test_build.py
@@ -37,18 +37,18 @@ def test_discover_configs():
         invalid_file = str(uuid.uuid4())
         discover_configs(invalid_file)
 
+
 def test_exclude_configs():
 
-    config = os.path.join(root,"examples","script")
+    config = os.path.join(root, "examples", "script")
     detected_config_files = discover_configs(config)
-
 
     exclude_list = None
     # nothing to exclude so normalized_config_files should be same as detected_config_files
     normalized_config_files = exclude_configs(detected_config_files, exclude_list)
     assert detected_config_files == normalized_config_files
 
-    remove_config = os.path.join(config,"zlib.yml")
+    remove_config = os.path.join(config, "zlib.yml")
     remove_list = [remove_config]
 
     # check if examples/script/zlib.yml is detected
@@ -62,5 +62,4 @@ def test_exclude_configs():
     # this will do a directory exclusion in examples/script and since we are searching for same directory
     # this should return an empty list
     normalized_config_files = exclude_configs(detected_config_files, remove_list)
-
     assert not normalized_config_files

--- a/tests/menu/test_build.py
+++ b/tests/menu/test_build.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 import uuid
-from buildtest.menu.build import discover_configs
+from buildtest.menu.build import discover_configs, exclude_configs
 
 test_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 root = os.path.dirname(test_root)
@@ -36,3 +36,23 @@ def test_discover_configs():
     with pytest.raises(SystemExit) as e_info:
         invalid_file = str(uuid.uuid4())
         discover_configs(invalid_file)
+
+def test_exclude_configs():
+
+    config = os.path.join(root,"examples","script")
+    detected_config_files = discover_configs(config)
+
+
+    exclude_list = None
+    # nothing to exclude so normalized_config_files should be same as detected_config_files
+    normalized_config_files = exclude_configs(detected_config_files, exclude_list)
+    assert detected_config_files == normalized_config_files
+
+    remove_config = os.path.join(config,"zlib.yml")
+    remove_list = [remove_config]
+
+    # check if examples/script/zlib.yml is detected
+    assert remove_config in detected_config_files
+    # now attempting to exclude examples/script/zlib.yml and checking if it is removed after exclusion
+    normalized_config_files = exclude_configs(detected_config_files, remove_list)
+    assert remove_config not in normalized_config_files

--- a/tests/menu/test_build.py
+++ b/tests/menu/test_build.py
@@ -56,3 +56,11 @@ def test_exclude_configs():
     # now attempting to exclude examples/script/zlib.yml and checking if it is removed after exclusion
     normalized_config_files = exclude_configs(detected_config_files, remove_list)
     assert remove_config not in normalized_config_files
+
+    remove_config = config
+    remove_list = [remove_config]
+    # this will do a directory exclusion in examples/script and since we are searching for same directory
+    # this should return an empty list
+    normalized_config_files = exclude_configs(detected_config_files, remove_list)
+
+    assert not normalized_config_files


### PR DESCRIPTION
This PR will address #267 
- The option is ``-x`` and long option ``--exclude``
- The exclude can be passed multiple times and it can be a file or directory or both and works with shell expansion
- If -x is not specified then nothing to exclude
- Exclusion happens after configs are discovered
- If no configs are to be processed after exclusion then buildtest will stop since nothing is to be done
- Exclusion happens after ``discover_configs``
- There is a regtest to cover exclude
- Also updated a few example configs so that all test run to completion whether they PASS/FAIL 

Here are few examples to illustrate how it works

Undo detection example
```
(buildtest-framework) ssi29@ag-mxg-hulk090> buildtest build -c examples -x examples/
There are no config files to process.
```

Example removing two configs  file from exclusion
```

(buildtest-framework) ssi29@ag-mxg-hulk090> buildtest build -c examples/script/ -x examples/script/bzip2.yml -x examples/script/slurm.yml
Config Name                    SubTest                        Status                         Config Path              
________________________________________________________________________________________________________________________
python-circle                  circle_area                    PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/python-circle.yml
zlib                           zlib_compression               PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/zlib.yml
zlib                           zlib_decompress                PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/zlib.yml
==============================================================
                         Test summary
Executed 3 tests
Passed Tests: 3/3 Percentage: 100.0%
Failed Tests: 0/3 Percentage: 0.0%
```

Exclude by directory in this case everything is skipped under ``examples/script`` 

```
(buildtest-framework) ssi29@ag-mxg-hulk090> buildtest build -c examples/ -x examples/script/
Config Name                    SubTest                        Status                         Config Path              
________________________________________________________________________________________________________________________
stream                         stream_uniprocess_c            PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml
stream                         stream_openmp_c                PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml
==============================================================
                         Test summary
Executed 2 tests
Passed Tests: 2/2 Percentage: 100.0%
Failed Tests: 0/2 Percentage: 0.0%

```


Here is an example where one directory and file is passed. Notice in this case we exclude the whole benchmark sub-directory  in this case only contains stream test and we exclude bzip2 as well.

```
(buildtest-framework) ssi29@ag-mxg-hulk090> buildtest build -c examples/ -x examples/benchmarks/ -x examples/script/bzip2.yml
Config Name                    SubTest                        Status                         Config Path              
________________________________________________________________________________________________________________________
python-circle                  circle_area                    PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/python-circle.yml
zlib                           zlib_compression               PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/zlib.yml
zlib                           zlib_decompress                PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/zlib.yml
slurm                          slurm_down_nodes_reason        FAILED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/slurm.yml
slurm                          slurm_not_responding_nodes     FAILED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/slurm.yml
==============================================================
                         Test summary
Executed 5 tests
Passed Tests: 3/5 Percentage: 60.0%
Failed Tests: 2/5 Percentage: 40.0%

```

