### PR TITLE
Redefinition of buildtest terms 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,24 +12,12 @@ For more details on buildtest check :ref:`summary_of_buildtest`
 
 This documentation was last rebuild on |today| and is intended for version |version|.
 
-Terminology
--------------
-
-As you go through the documentation, we wanted to define a few terminology often used through the docs so
-its clear to the reader.
-
-- **Test Configuration:** - A YAML file that is complaint to one of the buildtest **Schema**. The configuration is used to describe how test is to be generated. The YAML file is passed to ``buildtest`` to generate the test-script.
-
-- **Testscript:** This refers to the generated test script (shell-script) by buildtest
-
-- **Schema:** This refers to the YAML schema defined for writing **Test Configuration** in buildtest.
-
-
 .. toctree::
    :maxdepth: 2
    :caption: Background
 
    what_is_buildtest.rst
+   terminology.rst
    getting_started.rst
 
 .. toctree::

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -1,0 +1,22 @@
+.. _terminology:
+
+Terminology
+===========
+
+
+.. csv-table:: Core Concepts
+    :header: "name", "Description"
+    :widths: 30, 150
+
+    **SpecFile**,"A ``SpecFile`` is a YAML file that buildtest interprets when generating the test. The SpecFile may contain one or more specs."
+    **Spec**,"A Spec is the basic building block for writing a test specification that is compatible with one of the Spec Schema.",
+    **Spec Schema**,"A Spec Schema is a JSON file defining the schema with valid key/value pairs that are acceptable for the schema."
+    **Schema Library**,"A Schema Library is a collection of one or more ``Spec Schema`` provided by buildtest."
+    **TestScript**,"A TestScript is a generated shell script by buildtest as a result of processing one of the SpecFile."
+    **Settings**,"Settings is a buildtest configuration file that can be in YAML/JSON that configures buildtest at your site. The Settings file must be compatible with the Settings Schema."
+    **Settings Schema**,"A schema definition that dictates how to validate a ``Settings`` file."
+    **Executor**,"An ``Executor`` defines how a **TestScript** is executed. An executor can be of several types such as ``local``, ``slurm`` which defines if test is run locally of via scheduler.  The executors are defined in the ``Settings`` file."
+
+
+
+

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -8,15 +8,15 @@ Terminology
     :header: "Name", "Description"
     :widths: 30, 60
 
-    **Buildspec**,"``Buildspec`` is a YAML file that buildtest interprets when generating the test. A Buildspec may
+    **Buildspec**," is a YAML file that buildtest interprets when generating the test. A Buildspec may
     contain one or more test blocks that is validated by a ``Buildspec Schema``."
     **Buildspec Schema**,"is a JSON file defining  valid/invalid key value pairs and formatting for the file"
-    **Schema Library**,"A Schema Library is a collection of one or more ``Buildspec Schema`` provided by buildtest."
-    **Test Script**,"A Test Script is a generated shell script by buildtest as a result of processing one of the Buildspec."
-    **Settings**,"Settings is a buildtest configuration file that can be in YAML/JSON that configures buildtest at your
+    **Schema Library**," is a collection of one or more ``Buildspec Schema`` provided by buildtest."
+    **Test Script**," is a generated shell script by buildtest as a result of processing one of the Buildspec."
+    **Settings**," is a buildtest configuration file that can be in YAML/JSON that configures buildtest at your
     site. The Settings file must be compatible with the Settings Schema."
-    **Settings Schema**,"A schema definition that dictates how to validate a ``Settings`` file."
-    **Executor**,"An ``Executor`` defines how a **TestScript** is executed. An executor can be of several types such as
+    **Settings Schema**," is a schema definition that dictates how to validate a ``Settings`` file."
+    **Executor**," defines how a **TestScript** is to be executed. An executor can be of several types such as
     ``local``, ``slurm`` which defines if test is run locally of via scheduler. The executors are defined in the
     ``Settings`` file."
 

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -8,11 +8,11 @@ Terminology
     :header: "Name", "Description"
     :widths: 30, 60
 
-    **BuildSpec**,"``BuildSpec`` is a YAML file that buildtest interprets when generating the test. A BuildSpec may
-    contain one or more test blocks that is validated by a ``BuildSpec Schema``."
-    **BuildSpec Schema**,"is a JSON file defining  valid/invalid key value pairs and formatting for the file"
-    **Schema Library**,"A Schema Library is a collection of one or more ``BuildSpec Schema`` provided by buildtest."
-    **Test Script**,"A Test Script is a generated shell script by buildtest as a result of processing one of the BuildSpec."
+    **Buildspec**,"``Buildspec`` is a YAML file that buildtest interprets when generating the test. A Buildspec may
+    contain one or more test blocks that is validated by a ``Buildspec Schema``."
+    **Buildspec Schema**,"is a JSON file defining  valid/invalid key value pairs and formatting for the file"
+    **Schema Library**,"A Schema Library is a collection of one or more ``Buildspec Schema`` provided by buildtest."
+    **Test Script**,"A Test Script is a generated shell script by buildtest as a result of processing one of the Buildspec."
     **Settings**,"Settings is a buildtest configuration file that can be in YAML/JSON that configures buildtest at your
     site. The Settings file must be compatible with the Settings Schema."
     **Settings Schema**,"A schema definition that dictates how to validate a ``Settings`` file."

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -5,17 +5,23 @@ Terminology
 
 
 .. csv-table:: Core Concepts
-    :header: "name", "Description"
-    :widths: 30, 150
+    :header: "Name", "Description"
+    :widths: 30, 60
 
-    **SpecFile**,"A ``SpecFile`` is a YAML file that buildtest interprets when generating the test. The SpecFile may contain one or more specs."
-    **Spec**,"A Spec is the basic building block for writing a test specification that is compatible with one of the Spec Schema.",
-    **Spec Schema**,"A Spec Schema is a JSON file defining the schema with valid key/value pairs that are acceptable for the schema."
+    **SpecFile**,"A ``SpecFile`` is a YAML file that buildtest interprets when generating the test. The SpecFile may
+    contain one or more specs."
+    **Spec**,"A Spec is the basic building block for writing a test specification that is compatible with one of the
+    Spec Schema."
+    **Spec Schema**,"A Spec Schema is a JSON file defining the schema with valid key/value pairs that are acceptable
+    for the schema."
     **Schema Library**,"A Schema Library is a collection of one or more ``Spec Schema`` provided by buildtest."
-    **TestScript**,"A TestScript is a generated shell script by buildtest as a result of processing one of the SpecFile."
-    **Settings**,"Settings is a buildtest configuration file that can be in YAML/JSON that configures buildtest at your site. The Settings file must be compatible with the Settings Schema."
+    **Test Script**,"A Test Script is a generated shell script by buildtest as a result of processing one of the SpecFile."
+    **Settings**,"Settings is a buildtest configuration file that can be in YAML/JSON that configures buildtest at your
+    site. The Settings file must be compatible with the Settings Schema."
     **Settings Schema**,"A schema definition that dictates how to validate a ``Settings`` file."
-    **Executor**,"An ``Executor`` defines how a **TestScript** is executed. An executor can be of several types such as ``local``, ``slurm`` which defines if test is run locally of via scheduler.  The executors are defined in the ``Settings`` file."
+    **Executor**,"An ``Executor`` defines how a **TestScript** is executed. An executor can be of several types such as
+    ``local``, ``slurm`` which defines if test is run locally of via scheduler. The executors are defined in the
+    ``Settings`` file."
 
 
 

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -8,14 +8,11 @@ Terminology
     :header: "Name", "Description"
     :widths: 30, 60
 
-    **SpecFile**,"A ``SpecFile`` is a YAML file that buildtest interprets when generating the test. The SpecFile may
-    contain one or more specs."
-    **Spec**,"A Spec is the basic building block for writing a test specification that is compatible with one of the
-    Spec Schema."
-    **Spec Schema**,"A Spec Schema is a JSON file defining the schema with valid key/value pairs that are acceptable
-    for the schema."
-    **Schema Library**,"A Schema Library is a collection of one or more ``Spec Schema`` provided by buildtest."
-    **Test Script**,"A Test Script is a generated shell script by buildtest as a result of processing one of the SpecFile."
+    **BuildSpec**,"``BuildSpec`` is a YAML file that buildtest interprets when generating the test. A BuildSpec may
+    contain one or more test blocks that is validated by a ``BuildSpec Schema``."
+    **BuildSpec Schema**,"is a JSON file defining  valid/invalid key value pairs and formatting for the file"
+    **Schema Library**,"A Schema Library is a collection of one or more ``BuildSpec Schema`` provided by buildtest."
+    **Test Script**,"A Test Script is a generated shell script by buildtest as a result of processing one of the BuildSpec."
     **Settings**,"Settings is a buildtest configuration file that can be in YAML/JSON that configures buildtest at your
     site. The Settings file must be compatible with the Settings Schema."
     **Settings Schema**,"A schema definition that dictates how to validate a ``Settings`` file."


### PR DESCRIPTION
This PR address some term definition that buildtest can adopt when referencing the docs and most importantly refactor the code with the appropriate names. Since there is a lot of confusion between using the right term, we should get this approved first before refactor the code. 

Once the terms are approved, this would imply some of the following changes 
- rename method names as needed
- rewrite log message
- rename options 
- rewrite docs 

All of these would be scoped for separate PR.

his how the page looks like built locally

![image](https://user-images.githubusercontent.com/12942230/79015448-bf897e00-7b3a-11ea-9bdd-1b5121096687.png)
