### PR TITLE
fixing saving of output for BuildTestCommand

### DIFF
--- a/buildtest/utils/command.py
+++ b/buildtest/utils/command.py
@@ -38,11 +38,16 @@ class BuildTestCommand:
         :return: Output and Error from shell command
         :rtype: two str objects
         """
-        # The executable must be found.
+        # Reset the output and error records
+        self.out = []
+        self.err = []
+
+        # The executable must be found, return code 1 if not
         executable = shutil.which(self.cmd[0])
         if not executable:
-            err = ["%s not found." % self.cmd[0]]
-            return (self.out, err)
+            self.err = ["%s not found." % self.cmd[0]]
+            self.returncode = 1
+            return (self.out, self.err)
 
         # remove the original executable
         args = self.cmd[1:]


### PR DESCRIPTION
This will fix the saving out output (out) and error (err) by the BuildTestCommand. Specifically, let's say we have a script.sh file that looks like this:

```bash
#!/bin/bash

for i in 1 2 3 4 5 6; do
    echo "LOOP ${i}"
    sleep 2
done
```
We can then create a BuildTestCommand to run it:

```python
from buildtest.utils.command import BuildTestCommand
cmd = BuildTestCommand(['/bin/bash', 'script.sh'])
```
And then execute the command:

```python
cmd.execute()
```
The out and err is now saved with the command, which was previously missing (and returned with the execute function above as a tuple)

```python
cmd.execute()                                                           
(['LOOP 1\n', 'LOOP 2\n', 'LOOP 3\n', 'LOOP 4\n', 'LOOP 5\n', 'LOOP 6\n'], [])

cmd.out                                                                 
['LOOP 1\n', 'LOOP 2\n', 'LOOP 3\n', 'LOOP 4\n', 'LOOP 5\n', 'LOOP 6\n']

cmd.err                                                                 
[]
```

This will fix #263 

Signed-off-by: vsoch <vsochat@stanford.edu>