### PR TITLE
add support for passing --buildspec multiple times

### DIFF
--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -91,6 +91,7 @@ class BuildTestParser:
             "-b",
             "--buildspec",
             help="Specify a Buildspec (YAML) file to build and run the test.",
+            action="append",
         )
 
         parser_build.add_argument(

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -146,8 +146,14 @@ def func_build_subcmd(args):
 
     check_settings(settings_file)
 
-    # Discover list of one or more buildspec files based on path provided
-    buildspecs = discover_buildspecs(args.buildspec)
+    buildspecs = []
+    # Discover list of one or more buildspec files based on path provided. Since --buildspec can be provided multiple
+    # times we need to invoke discover_buildspecs one per argument.
+    for buildtest_argument in args.buildspec:
+        buildspecs += discover_buildspecs(buildtest_argument)
+
+    # remove any duplicates from list by converting to set and then back to list
+    buildspecs = list(set(buildspecs))
 
     # if no files discovered let's stop now
     if not buildspecs:

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -34,16 +34,18 @@ def test_directory_expansion():
     assert is_dir(dir1)
     assert is_dir(dir2)
 
+
 def test_create_dir(tmp_path):
     # since tmp_path creates a directory we will create a subdirectory "test" in tmp_path using create_dir
     assert is_dir(tmp_path)
-    dirname = os.path.join(tmp_path,"test")
+    dirname = os.path.join(tmp_path, "test")
     # check we dont have a directory before creation
     assert not is_dir(dirname)
     # creating directory
     create_dir(dirname)
     # check if directory is created  after invoking create_dir
     assert is_dir(dirname)
+
 
 @pytest.mark.xfail(
     reason="This test is expected to fail due to insufficient privileges",


### PR DESCRIPTION
This PR adds support for passing ``--buildspec`` multiple times to specify more than one buildspec. 

Here is a demo, where we build benchmark directory and slurm.yml

```
(buildtest-framework) ssi29@ag-mxg-hulk090> buildtest build -b examples/benchmarks/ -b examples/script/slurm.yml

            Discovered Buildspecs

/mxg-hpc/users/ssi29/buildtest-framework/examples/script/slurm.yml
/mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml



Buildspec Name                 SubTest                        Status                         Buildspec Path
________________________________________________________________________________________________________________________
slurm                          slurm_down_nodes_reason        FAILED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/slurm.yml
slurm                          slurm_not_responding_nodes     FAILED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/slurm.yml
stream                         stream_uniprocess_c            PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml
stream                         stream_openmp_c                PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml


============================================================
                        Test summary
============================================================
Executed 4 tests
Passed Tests: 2/4 Percentage: 50.000%
Failed Tests: 2/4 Percentage: 50.000%

```

After discovery buildtest will convert all Buildspec to a set and back to list so that we dont have duplicate items in Buildspec list.

For example if we have the following test, note each test is run once in all files in ``examples`` directory and duplicates are not shown in ``benchmark`` sub-directory.

```
(buildtest-framework) ssi29@ag-mxg-hulk090> buildtest build -b examples/ -b examples/benchmarks/

            Discovered Buildspecs

/mxg-hpc/users/ssi29/buildtest-framework/examples/script/zlib.yml
/mxg-hpc/users/ssi29/buildtest-framework/examples/script/slurm.yml
/mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml
/mxg-hpc/users/ssi29/buildtest-framework/examples/script/python-circle.yml
/mxg-hpc/users/ssi29/buildtest-framework/examples/script/bzip2.yml



Buildspec Name                 SubTest                        Status                         Buildspec Path
________________________________________________________________________________________________________________________
zlib                           zlib_compression               PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/zlib.yml
zlib                           zlib_decompress                PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/zlib.yml
slurm                          slurm_down_nodes_reason        FAILED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/slurm.yml
slurm                          slurm_not_responding_nodes     FAILED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/slurm.yml
stream                         stream_uniprocess_c            PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml
stream                         stream_openmp_c                PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml
python-circle                  circle_area                    PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/python-circle.yml
bzip2                          bzip_compression               PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/bzip2.yml
bzip2                          bzip_help                      PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/bzip2.yml
bzip2                          bzip2_help                     PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/bzip2.yml


============================================================
                        Test summary
============================================================
Executed 10 tests
Passed Tests: 8/10 Percentage: 80.000%
Failed Tests: 2/10 Percentage: 20.000%
```

The exclude works after discovery and is supported with multiple buildspec arguments. Here is a more sophisticated example showing how we can do multiple buildspecs and exclude at same time. In this example we want to exclude ``slurm.yml`` and ``bzip2.yml`` but build everything in ``examples/script`` and ``examples/benchmark``.

```
(buildtest-framework) ssi29@ag-mxg-hulk090> buildtest build -b examples/script/ -b examples/benchmarks/ -x examples/script/slurm.yml  -x examples/script/bzip2.yml

            Discovered Buildspecs

/mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml
/mxg-hpc/users/ssi29/buildtest-framework/examples/script/zlib.yml
/mxg-hpc/users/ssi29/buildtest-framework/examples/script/python-circle.yml



Buildspec Name                 SubTest                        Status                         Buildspec Path
________________________________________________________________________________________________________________________
stream                         stream_uniprocess_c            PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml
stream                         stream_openmp_c                PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/benchmarks/stream.yml
zlib                           zlib_compression               PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/zlib.yml
zlib                           zlib_decompress                PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/zlib.yml
python-circle                  circle_area                    PASSED                         /mxg-hpc/users/ssi29/buildtest-framework/examples/script/python-circle.yml


============================================================
                        Test summary
============================================================
Executed 5 tests
Passed Tests: 5/5 Percentage: 100.000%
Failed Tests: 0/5 Percentage: 0.000%

```

