### PR TITLE
Making some general fixs

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -29,7 +29,7 @@ from buildtest.defaults import (
     variable_sections,
 )
 from buildtest.utils.command import BuildTestCommand
-from buildtest.utils.file import create_dir, is_file, is_dir
+from buildtest.utils.file import create_dir, is_file, is_dir, resolve_path
 
 known_sections = variable_sections + build_sections
 
@@ -82,15 +82,14 @@ class BuildspecParser:
            :param buildspec: the pull path to the configuration file, must exist.
            :type buildspec: str, required
         """
-        self.buildspec = os.path.abspath(buildspec)
 
-        if not is_file(self.buildspec):
-            sys.exit("Buildspec File: %s does not exist." % self.buildspec)
+        self.buildspec = resolve_path(buildspec)
 
-        elif is_dir(self.buildspec):
-            sys.exit(
-                "Please provide a file path (not a directory path) to a Buildspec file."
-            )
+        if not self.buildspec:
+            sys.exit("Can't process input: %s " % buildspec)
+
+        if is_dir(self.buildspec):
+            sys.exit(f"Detected {self.buildspec} is a directory, please provide a file path (not a directory path) to BuildspecParser.")
 
         # Buildspec must pass global validation (sets self.recipe)
         self._validate_global()

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -89,7 +89,9 @@ class BuildspecParser:
             sys.exit("Can't process input: %s " % buildspec)
 
         if is_dir(self.buildspec):
-            sys.exit(f"Detected {self.buildspec} is a directory, please provide a file path (not a directory path) to BuildspecParser.")
+            sys.exit(
+                f"Detected {self.buildspec} is a directory, please provide a file path (not a directory path) to BuildspecParser."
+            )
 
         # Buildspec must pass global validation (sets self.recipe)
         self._validate_global()

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -82,6 +82,9 @@ class BuildspecParser:
            :param buildspec: the pull path to the configuration file, must exist.
            :type buildspec: str, required
         """
+        # if invalid input for buildspec
+        if not buildspec:
+            sys.exit("Invalid input type for Buildspec, must be of type 'string'.")
 
         self.buildspec = resolve_path(buildspec)
 

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -3,38 +3,43 @@ import os
 import shutil
 from jsonschema import validate
 
-from buildtest.utils.file import create_dir
+from buildtest.buildsystem.schemas.utils import load_schema
 from buildtest.defaults import (
     BUILDTEST_SETTINGS_FILE,
     BUILDTEST_ROOT,
     DEFAULT_SETTINGS_FILE,
     DEFAULT_SETTINGS_SCHEMA,
 )
-from buildtest.buildsystem.schemas.utils import load_schema
+from buildtest.utils.file import create_dir, is_dir, is_file
+
+logger = logging.getLogger(__name__)
 
 
 def create_settings_file():
     """If default settings file don't exist, copy the default settings provided by buildtest."""
 
-    if not os.path.exists(BUILDTEST_SETTINGS_FILE):
+    if not is_file(BUILDTEST_SETTINGS_FILE):
+        logger.debug(f"Detected File: {BUILDTEST_SETTINGS_FILE} is not present")
         shutil.copy(DEFAULT_SETTINGS_FILE, BUILDTEST_SETTINGS_FILE)
+        logger.debug(
+            f"Copying file: {DEFAULT_SETTINGS_FILE} to {BUILDTEST_SETTINGS_FILE}"
+        )
 
 
 def init():
     """Buildtest init should check that the buildtest user root exists,
        and that dependency files are created. This is called by 
-       ``load_settings``."""
+       ``load_settings``.
+    """
 
     # check if $HOME/.buildtest exists, if not create directory
-    if not os.path.exists(BUILDTEST_ROOT):
-        print(
-            f"Creating buildtest configuration directory: \
-                 {BUILDTEST_ROOT}"
-        )
-        os.mkdir(BUILDTEST_ROOT)
+    if not is_dir(BUILDTEST_ROOT):
+        create_dir(BUILDTEST_ROOT)
+        msg = f"Creating buildtest settings directory: {BUILDTEST_ROOT}"
+        print(msg)
+        logger.debug(msg)
 
-    # Create subfolders for root, site
-    create_dir(os.path.join(BUILDTEST_ROOT, "root"))
+    # Create subfolders site
     create_dir(os.path.join(BUILDTEST_ROOT, "site"))
 
     # Create settings files
@@ -48,16 +53,20 @@ def check_settings(settings_path=None):
        exists.       
 
        If any error is found buildtest will terminate immediately.
+
+       Parameters:
+
+       :param settings_path: Path to buildtest settings file
+       :type settings_path: str, optional
+
        :return: returns gracefully if all checks passes otherwise terminate immediately
        :rtype: exit code 1 if checks failed
     """
 
-    logger = logging.getLogger(__name__)
-
     user_schema = load_settings(settings_path)
 
     config_schema = load_schema(DEFAULT_SETTINGS_SCHEMA)
-    logger.debug(f"Loading default configuration schema: {DEFAULT_SETTINGS_SCHEMA}")
+    logger.debug(f"Loading default settings schema: {DEFAULT_SETTINGS_SCHEMA}")
 
     logger.debug(f"Validating user schema: {user_schema} with schema: {config_schema}")
     validate(instance=user_schema, schema=config_schema)
@@ -77,7 +86,7 @@ def load_settings(settings_path=None):
 
     settings_path = settings_path or BUILDTEST_SETTINGS_FILE
 
-    # load the configuration file
+    # load the settings file into a schema object
     return load_schema(settings_path)
 
 

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -37,8 +37,7 @@ def init(settings_path):
     if not is_dir(dirname):
         create_dir(dirname)
         msg = f"Creating buildtest settings directory: {dirname}"
-        print(msg)
-        logger.debug(msg)
+        logger.info(msg)
 
     # Create subfolders site
     create_dir(os.path.join(dirname, "site"))

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -15,35 +15,36 @@ from buildtest.utils.file import create_dir, is_dir, is_file
 logger = logging.getLogger(__name__)
 
 
-def create_settings_file():
+def create_settings_file(settings_file):
     """If default settings file don't exist, copy the default settings provided by buildtest."""
 
-    if not is_file(BUILDTEST_SETTINGS_FILE):
-        logger.debug(f"Detected File: {BUILDTEST_SETTINGS_FILE} is not present")
-        shutil.copy(DEFAULT_SETTINGS_FILE, BUILDTEST_SETTINGS_FILE)
-        logger.debug(
-            f"Copying file: {DEFAULT_SETTINGS_FILE} to {BUILDTEST_SETTINGS_FILE}"
-        )
+    if not is_file(settings_file):
+        logger.debug(f"Detected File: {settings_file} is not present")
+        shutil.copy(DEFAULT_SETTINGS_FILE, settings_file)
+        logger.debug(f"Copying file: {DEFAULT_SETTINGS_FILE} to {settings_file}")
 
 
-def init():
+def init(settings_path):
     """Buildtest init should check that the buildtest user root exists,
        and that dependency files are created. This is called by 
        ``load_settings``.
     """
 
+    # if settings_path is not defined dirname is equivalent to BUILDTEST_ROOT, since BUILDTEST_SETTINGS_FILE is in BUILDTEST_ROOT
+    dirname = os.path.dirname(settings_path)
+
     # check if $HOME/.buildtest exists, if not create directory
-    if not is_dir(BUILDTEST_ROOT):
-        create_dir(BUILDTEST_ROOT)
-        msg = f"Creating buildtest settings directory: {BUILDTEST_ROOT}"
+    if not is_dir(dirname):
+        create_dir(dirname)
+        msg = f"Creating buildtest settings directory: {dirname}"
         print(msg)
         logger.debug(msg)
 
     # Create subfolders site
-    create_dir(os.path.join(BUILDTEST_ROOT, "site"))
+    create_dir(os.path.join(dirname, "site"))
 
     # Create settings files
-    create_settings_file()
+    create_settings_file(settings_path)
 
 
 def check_settings(settings_path=None):
@@ -82,9 +83,9 @@ def load_settings(settings_path=None):
        :type settings_path: str, optional
     """
 
-    init()
-
     settings_path = settings_path or BUILDTEST_SETTINGS_FILE
+
+    init(settings_path)
 
     # load the settings file into a schema object
     return load_schema(settings_path)

--- a/buildtest/menu/get.py
+++ b/buildtest/menu/get.py
@@ -45,7 +45,18 @@ def func_get_subcmd(args):
 
 
 def clone(url, dest, branch="master"):
-    """clone a repository from Github"""
+    """Clone a repository from Github
+
+       Parameters:
+
+       :param url: URL to Github repository to clone
+       :type url: str, required
+       :param dest: location where to clone repo
+       :type dest: str, required
+       :param branch: select which branch to clone, defaults to 'master' branch
+       :type branch: str, optional
+    """
+
     name = os.path.basename(url).replace(".git", "")
     dest = os.path.join(dest, name)
 

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -81,7 +81,10 @@ def walk_tree(root_dir, ext):
     """
 
     list_files = []
-    is_dir(root_dir)
+    # if directory doesn't exist let's return empty list before doing a directory traversal since no files to traverse
+    if not is_dir(root_dir):
+        return list_files
+
     for root, subdir, files in os.walk(root_dir):
         for fname in files:
             if fname.endswith(ext):

--- a/tests/buildsystem/test_base.py
+++ b/tests/buildsystem/test_base.py
@@ -21,6 +21,14 @@ def test_BuildspecParser():
     with pytest.raises(SystemExit) as e_info:
         BuildspecParser("")
 
+    # Passing 'None' will raise an error
+    with pytest.raises(SystemExit) as e_info:
+        BuildspecParser(None)
+
+    # A directory is not allowed either, this will raise an error.
+    with pytest.raises(SystemExit) as e_info:
+        BuildspecParser(examples_dir)
+
     # Test loading Buildspec files
     for buildspec in os.listdir(examples_dir):
         buildspec = os.path.join(examples_dir, buildspec)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,5 +39,4 @@ def test_init_creation_of_buildtest_dir():
 
     shutil.rmtree(BUILDTEST_ROOT)
     init()
-    assert is_dir(os.path.join(BUILDTEST_ROOT, "root"))
     assert is_dir(os.path.join(BUILDTEST_ROOT, "site"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,15 +28,20 @@ def test_get_default_settings():
     assert "executors" in loaded_settings.keys()
 
 
-def test_create_settings_file():
+def test_create_settings_file(tmp_path):
 
-    os.remove(BUILDTEST_SETTINGS_FILE)
-    create_settings_file()
-    assert is_file(BUILDTEST_SETTINGS_FILE)
+    settings = os.path.join(tmp_path, "settings.yml")
+    print(f"Creating buildtest settings file: {settings}")
+    create_settings_file(settings)
+    print(f"Checking if file: {settings} is valid")
+    assert is_file(settings)
 
 
-def test_init_creation_of_buildtest_dir():
+def test_init_creation_of_buildtest_dir(tmp_path):
 
-    shutil.rmtree(BUILDTEST_ROOT)
-    init()
-    assert is_dir(os.path.join(BUILDTEST_ROOT, "site"))
+    settings = os.path.join(tmp_path, "settings.yml")
+    init(settings)
+    print(f"Checking buildtest settings file: {settings}")
+    print(f"Checking if 'site' sub-directory: {os.path.join(tmp_path,'site')} exists")
+    assert is_file(settings)
+    assert is_dir(os.path.join(tmp_path, "site"))

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -57,12 +57,24 @@ def test_fail_create_dir():
 
 def test_walk_tree():
     list_of_files = walk_tree(here, ".py")
+    print(f"Detected {len(list_of_files)} .py files found in directory: {here}")
     assert len(list_of_files) > 0
 
 
-@pytest.mark.xfail(
-    reason="This test is expected to fail since we passed invalid path for directory traversal",
-    raises=BuildTestError,
-)
-def test_walk_tree_invalid_dir():
-    walk_tree("/xyz", ".py")
+def test_walk_tree_no_files(tmp_path):
+    list_of_files = walk_tree(tmp_path, ".py")
+    print(f"Detected {len(list_of_files)} .py files found in directory: {here}")
+    assert 0 == len(list_of_files)
+
+
+def test_walk_tree_invalid_dir(tmp_path):
+    # we want to test an invalid directory so we remove temporary directory created by tmp_path
+    shutil.rmtree(tmp_path)
+    print(
+        f"Removing directory: {tmp_path} first before doing directory traversal on invalid directory"
+    )
+    list_of_files = walk_tree(tmp_path, ".py")
+    print(
+        f"Returned following files: {list_of_files} with .py extension for path: {tmp_path}"
+    )
+    assert not list_of_files

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -63,7 +63,7 @@ def test_walk_tree():
 
 def test_walk_tree_no_files(tmp_path):
     list_of_files = walk_tree(tmp_path, ".py")
-    print(f"Detected {len(list_of_files)} .py files found in directory: {here}")
+    print(f"Detected {len(list_of_files)} .py files found in directory: {tmp_path}")
     assert 0 == len(list_of_files)
 
 


### PR DESCRIPTION
- Update docstring where parameters are missing
- Reorder imports such that they are listed in alphabetical order
- Add some more logging during configuration check, and build process.
- Make use of is_file, is_dir when applicable for checking file path as
  pose to 'os' library
- In walk_tree if directory doesn't exist, we return with empty list
- Remove sub-directory "root"  in BUILDTEST_ROOT since it's not being
  used for anything, and refactor test
- Refactor test for walk_tree, add some print statement for
  troubleshooting, and test when invalid path is set. Also walk_tree is
  not going to raise an error for invalid directory it just returns an
  empty list