### PR TITLE
add unique id as part of test directory.

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -247,7 +247,7 @@ class BuilderBase:
         self.buildspec = buildspec
         self.config_name = re.sub("[.](yml|yaml)", "", os.path.basename(buildspec))
         self.testdir = testdir or os.path.join(
-            os.getcwd(), ".buildtest", str(uuid.uuid4()), self.config_name
+            os.getcwd(), ".buildtest", self.config_name + "-" + str(uuid.uuid4())[:8]
         )
         self.logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR will create a unique uuid in test directory, this avoids having test written in same location during repetition, furthermore we can use uuid as part of test identification as part of reporting.

The uuid is invoked per test block so for instance a Buildspec [hello.yml](https://github.com/HPC-buildtest/tutorials/blob/master/apps/serial/hello.yml) has three test block, each one will have a unique uuid. This avoids any name conflicts with same test block or Buildspec name named across different directories. 

For now it was logical to invoke ``uuid.uuid4()`` at the time of getting test directory, if unique id was to be done earlier, we would have to define the uuid much earlier in the code and pass the variable to the appropriate class. This would seem a bit confusing if variable is declared in one class just so that it is used much later down the code.

```
(buildtest-framework) ssi29@ag-mxg-hulk090> buildtest build -b apps/serial/hello.yml

            Discovered Buildspecs

/mxg-hpc/users/ssi29/tutorials/apps/serial/hello.yml



Buildspec Name                 SubTest                        Status                         Buildspec Path
________________________________________________________________________________________________________________________
hello                          fortan_hello                   PASSED                         /mxg-hpc/users/ssi29/tutorials/apps/serial/hello.yml
hello                          c_hello                        PASSED                         /mxg-hpc/users/ssi29/tutorials/apps/serial/hello.yml
hello                          cplusplus_hello                PASSED                         /mxg-hpc/users/ssi29/tutorials/apps/serial/hello.yml


============================================================
                        Test summary
============================================================
Executed 3 tests
Passed Tests: 3/3 Percentage: 100.000%
Failed Tests: 0/3 Percentage: 0.000%

(buildtest-framework) ssi29@ag-mxg-hulk090> tree .buildtest/
.buildtest/
├── 28b58e56-2ec2-4020-a432-f73a0d601533
│   └── hello
│       ├── fortan_hello.sh
│       ├── hello_f90
│       └── run
│           ├── fortan_hello_04-18-2020-14-20.err
│           └── fortan_hello_04-18-2020-14-20.out
├── 2e104f9d-be1a-4cba-8647-a56eaa5b0b94
│   └── hello
│       ├── c_hello.sh
│       ├── hello_c
│       └── run
│           ├── c_hello_04-18-2020-14-20.err
│           └── c_hello_04-18-2020-14-20.out
└── a3c1750c-3ad4-4149-9a2a-ca610f1dc0ff
    └── hello
        ├── cplusplus_hello.sh
        ├── hello_cpp
        └── run
            ├── cplusplus_hello_04-18-2020-14-20.err
            └── cplusplus_hello_04-18-2020-14-20.out

9 directories, 12 files

```