### PR TITLE
update org and repo  name 

### DIFF
--- a/.github/workflows/urlchecker.yml
+++ b/.github/workflows/urlchecker.yml
@@ -24,4 +24,4 @@ jobs:
         retry_count: 3
 
         # Cannot check private GitHub settings
-        white_listed_patterns: https://github.com/HPC-buildtest/buildtest-framework/settings
+        white_listed_patterns: https://github.com/buildtesters/buildtest-framework/settings

--- a/.github/workflows/urlchecker.yml
+++ b/.github/workflows/urlchecker.yml
@@ -24,4 +24,4 @@ jobs:
         retry_count: 3
 
         # Cannot check private GitHub settings
-        white_listed_patterns: https://github.com/buildtesters/buildtest-framework/settings
+        white_listed_patterns: https://github.com/buildtesters/buildtest/settings

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ v0.8.0 (Mar xxx, 2020)
 
  - Add pre-commit hook to automate python format via ``black``. Add ``black --check`` as automated check see #172, #179
  - Remove CLI option ``buildtest build [run|log|test]`` see #163
- - Remove all module operations and cli menu ``buildtest module``. This is now moved to an API lmodule at https://github.com/HPC-buildtest/lmodule
+ - Remove all module operations and cli menu ``buildtest module``. This is now moved to an API lmodule at https://github.com/buildtesters/lmodule
  - removing extra dependencies argcomplete and termcolor
  - removing dependency of Lmod, only needed if modules specified in configs
  - replace ``toolkit/suite`` with ``site`` directory  in code and documentation examples
@@ -63,7 +63,7 @@ v0.7.4 (Dec 11th, 2019)
 - change path to output/error files in ``buildtest module loadtest`` and print actual ``module load`` command
 - adding github stalebot configuration see ``.github/stale.yml``
 - adding github sponsor page ``.github/FUNDING.yml``
-- add stream benchmark test see https://github.com/HPC-buildtest/buildtest-framework/commit/d2a2a4dc2e71c5921b211d4df4d68b7f52cbbf52
+- add stream benchmark test see https://github.com/buildtesters/buildtest/commit/d2a2a4dc2e71c5921b211d4df4d68b7f52cbbf52
 - adding github workflow ``black`` to format all python code base see ``.github/workflow/black.yml``
 - install lmod and its dependency in travis build
 
@@ -74,7 +74,7 @@ v0.7.3 (Nov 25th, 2019)
 - enable ``cuda``, ``intel``, ``pgi`` compilation, this can be set via ``compilers`` key
 - Define shell variables ``CC``, ``FC``, ``CXX`` to be used to reference builds
 - Define shell variable ``EXECUTABLE`` to reference generated executable
-- Fix Code Style issues reported by CodeFactor (https://www.codefactor.io/repository/github/hpc-buildtest/buildtest-framework)
+- Fix Code Style issues reported by CodeFactor (https://www.codefactor.io/repository/github/buildtesters/buildtest)
 - Add , hust-19 slides, buildtest architecture and workflow diagram in documentation
 - Simplify output of ``buildtest module --easybuild`` and ``buildtest module --spack``
 - Add ``module purge`` or ``module --force purge`` in test (#122)
@@ -86,7 +86,7 @@ v0.7.3 (Nov 25th, 2019)
 v0.7.2 (Nov 8th, 2019)
 ----------------------
 - automate documentation test generation using python script
-- add support for coverage see https://codecov.io/gh/HPC-buildtest/buildtest-framework
+- add support for coverage see https://codecov.io/gh/buildtesters/buildtest
 - adding dry option when building tests (short: ``-d`` or long option:``--dry``)
 - automate buildtest testing process via pytest. Add initial support with 25+ regression tests
 - adding directory expansion support when files or directory are references such as $HOME or tilde (~) operation
@@ -127,7 +127,7 @@ v0.7.0 (Aug 22, 2019)
 - Rename main program **_buildtest** to **buildtest** and changed source code directory layout
 - Add option ``-b`` or ``--binary`` for native support for sanity check on binary commands in framework without using yaml files
 - Update requirements.txt
-- Migrate documentation to buildtest-framework
+- Migrate documentation to buildtest
 - Create subcommand **find** and move option ``-ft`` and ``-fc`` to this menu
 - Add logo for license, version, download, status to README.rst
 - Type checking support for buildtest configuration file
@@ -166,8 +166,8 @@ v0.6.0 (Oct 18, 2018)
 - Add test count, passed and failed test after each test run when using ``_buildtest run``.
 - option ``--rebuild`` and ``--overwrite`` will work with ``--all-software`` and ``--all-package`` in yaml subcommand to automate rebuilding of yaml files
 -  Move option `--module-naming-scheme`  to build subcommand
-- **bug fix:** directory issue for running buildtest first time https://github.com/HPC-buildtest/buildtest-framework/issues/81
-- **bug fix:** print error https://github.com/HPC-buildtest/buildtest-framework/issues/80
+- **bug fix:** directory issue for running buildtest first time https://github.com/buildtesters/buildtest/issues/81
+- **bug fix:** print error https://github.com/buildtesters/buildtest/issues/80
 
 v0.5.0 (Oct 8, 2018)
 -----------------------
@@ -200,11 +200,11 @@ v0.5.0 (Oct 8, 2018)
    - ``--testname``
 - Added basic error handling support
 - Add ``description`` key in all yaml files
--  Tests have permission ``755`` so they can run automatically as any user see https://github.com/HPC-buildtest/buildtest-framework/pull/79/commits/6a2570e9d547b0fb3ab81a14770583a192092224
-- Options for ``--ebyaml`` now generates date-time stamp for ``command.yaml`` see https://github.com/HPC-buildtest/buildtest-framework/pull/79/commits/a5968263e4faeac0b65386b22d9b1d5cff604185
+-  Tests have permission ``755`` so they can run automatically as any user see https://github.com/buildtesters/buildtest/pull/79/commits/6a2570e9d547b0fb3ab81a14770583a192092224
+- Options for ``--ebyaml`` now generates date-time stamp for ``command.yaml`` see https://github.com/buildtesters/buildtest/pull/79/commits/a5968263e4faeac0b65386b22d9b1d5cff604185
 - Add script ``check.sh`` to automate testing of buildtest features and package building for verification
-- **bug fix:** https://github.com/HPC-buildtest/buildtest-framework/pull/79/commits/8017d48c10cee706669ae5b56077640722442571
-- **bug fix:** https://github.com/HPC-buildtest/buildtest-framework/pull/79/commits/8dfe78bce930e23eb2242e4e4666f926bf60131f
+- **bug fix:** https://github.com/buildtesters/buildtest/pull/79/commits/8017d48c10cee706669ae5b56077640722442571
+- **bug fix:** https://github.com/buildtesters/buildtest/pull/79/commits/8dfe78bce930e23eb2242e4e4666f926bf60131f
 
 v0.4.0 (Sep 11, 2018)
 --------------------------
@@ -214,11 +214,11 @@ v0.4.0 (Sep 11, 2018)
 v0.3.0 () (Aug 7, 2018)
 ----------------------------------
 
-- Package buildtest as pypi package, now it can be installed via ``pip install buildtest-framework``
+- Package buildtest as pypi package, now it can be installed via ``pip install buildtest``
 - Rename ``buildtest`` to ``_buildtest`` and all code is now under ``buildtest``
 - All buildtest repos are now packaged as pypi package and test are moved under `buildtest` directory
 - The option `--ebyaml` is now working with auto-complete feature and ability to create yaml files for software packages
-- Binary test are now created based on unique sha256sum see https://github.com/HPC-buildtest/buildtest-framework/commit/92c012431000ff338532a899e3b5f465f18786dd
+- Binary test are now created based on unique sha256sum see https://github.com/buildtesters/buildtest/commit/92c012431000ff338532a899e3b5f465f18786dd
 - Output of `--scantest` has been fixed and added to documentation
 - Add singularity CDASH script, need some more work on getting server setup properly
 
@@ -237,8 +237,8 @@ Bug Fixes
 ~~~~~~~~~~~~~
 
 - Fix issue with `--runtest` option, it was broken at some point now it is working as expected
-- Add extra configuration option in `config_opts` to reuse variable that were needed throughout code and fix bug with `--sysyaml` see https://github.com/HPC-buildtest/buildtest-framework/commit/493b53e4cfdb5710b384409edc7c85ceb05395ba
-- Fix bug with directory not found in menu,py by moving function `check_configuration` and `override_configuration` from main.py to menu,py see https://github.com/HPC-buildtest/buildtest-framework/commit/d2c78076eb551683bf81a3a7d12ae10971460971
+- Add extra configuration option in `config_opts` to reuse variable that were needed throughout code and fix bug with `--sysyaml` see https://github.com/buildtesters/buildtest/commit/493b53e4cfdb5710b384409edc7c85ceb05395ba
+- Fix bug with directory not found in menu,py by moving function `check_configuration` and `override_configuration` from main.py to menu,py see https://github.com/buildtesters/buildtest/commit/d2c78076eb551683bf81a3a7d12ae10971460971
 
 v0.2.0 (May 18, 2018)
 ---------------------------
@@ -279,28 +279,28 @@ v0.1.8 (Feb 27, 2018)
 
 - Automate batch job submission from buildtest via **--submitjob**
 - Fix shell magic (#!/bin/sh, #!/bin/bash, #!/bin/csh) for binary test
-- Tab completion for buildtest argument using ``argcomplete`` module. See https://github.com/HPC-buildtest/buildtest-framework/pull/52/commits/ddb9e426f1b466d3e9b1957a009f0955c236f7a2
+- Tab completion for buildtest argument using ``argcomplete`` module. See https://github.com/buildtesters/buildtest/pull/52/commits/ddb9e426f1b466d3e9b1957a009f0955c236f7a2
 - autopopulate choice for ``--system``, ``--sysyaml``, and ``--software``
-- Fix output of ``-svr`` and resolve bug when 2 modules with same app/version found in different trees. Only in HMNS. See https://github.com/HPC-buildtest/buildtest-framework/pull/52/commits/7ddf91b761f88ddacf0548c7f259b2badd93bdfd for more details
+- Fix output of ``-svr`` and resolve bug when 2 modules with same app/version found in different trees. Only in HMNS. See https://github.com/buildtesters/buildtest/pull/52/commits/7ddf91b761f88ddacf0548c7f259b2badd93bdfd for more details
 - Group buildtest commands for ease of use.
-- Support for yaml keys **scheduler** and **jobslot** to enable jobscript creation from yaml files. See https://github.com/HPC-buildtest/buildtest-framework/pull/52/commits/0fe4189df0694bef586e9d8e4565ec4cc3e169c9
+- Support for yaml keys **scheduler** and **jobslot** to enable jobscript creation from yaml files. See https://github.com/buildtesters/buildtest/pull/52/commits/0fe4189df0694bef586e9d8e4565ec4cc3e169c9
 - Further support for scheduler and automatic detection. Currently supports LSF and SLURM.
 
 v0.1.7 (Feb 27, 2018)
 ------------------------
 
-- Add support for creating LSF Job scripts via templates. Use **buildtest --job-template** see https://github.com/HPC-buildtest/buildtest-framework/commit/927dc09e347fdafa7020d7cfd3016fd8f430ac10
-- Add support for creating YAML config for system package binary testing  via **buildtest --sysyaml** see https://github.com/HPC-buildtest/buildtest-framework/commit/4ab8870eddb9da5177b6c414e98f1231d14b35ab
-- adding keys envvar, procrange, threadrange in YAML https://github.com/HPC-buildtest/buildtest-framework/commit/9a2152307dbf88943618a0b7ee8f6984de3a5340 https://github.com/HPC-buildtest/buildtest-framework/commit/1524238919be638edc831df6395425f92e46bc2c   https://github.com/HPC-buildtest/buildtest-framework/commit/3d43b8a68946c4a376e1645c4ad204c7498ae6c3
--  Add support for multiple shell (csh, bash, sh) see https://github.com/HPC-buildtest/buildtest-framework/commit/aea9d6ff06dcc207e84ba0953c53e2cbd67a49fe https://github.com/HPC-buildtest/buildtest-framework/commit/c154db87f876251cc6b2985e8bfb8c2265843216
+- Add support for creating LSF Job scripts via templates. Use **buildtest --job-template** see https://github.com/buildtesters/buildtest/commit/927dc09e347fdafa7020d7cfd3016fd8f430ac10
+- Add support for creating YAML config for system package binary testing  via **buildtest --sysyaml** see https://github.com/buildtesters/buildtest/commit/4ab8870eddb9da5177b6c414e98f1231d14b35ab
+- adding keys envvar, procrange, threadrange in YAML https://github.com/buildtesters/buildtest/commit/9a2152307dbf88943618a0b7ee8f6984de3a5340 https://github.com/buildtesters/buildtest/commit/1524238919be638edc831df6395425f92e46bc2c   https://github.com/buildtesters/buildtest/commit/3d43b8a68946c4a376e1645c4ad204c7498ae6c3
+-  Add support for multiple shell (csh, bash, sh) see https://github.com/buildtesters/buildtest/commit/aea9d6ff06dcc207e84ba0953c53e2cbd67a49fe https://github.com/buildtesters/buildtest/commit/c154db87f876251cc6b2985e8bfb8c2265843216
 - remove verbose option from buildtest
-- major code refactor see https://github.com/HPC-buildtest/buildtest-framework/commit/fd8d466dc1f009f5822d2161eaf73e85f42a985e https://github.com/HPC-buildtest/buildtest-framework/commit/9d112c0e2e8c6800013eeda7968f568a749f2586
-- Fixed a bug during compiler detection when building GCC see https://github.com/HPC-buildtest/buildtest-framework/commit/f139756213a280301771214894c8f48e8bcee4e8
-- create a pretty menu for Interactive Testing via **buildtest --runtest** see https://github.com/HPC-buildtest/buildtest-framework/commit/231cfeb0cf88cbc70826a9e76697947d06f0a6e1
+- major code refactor see https://github.com/buildtesters/buildtest/commit/fd8d466dc1f009f5822d2161eaf73e85f42a985e https://github.com/buildtesters/buildtest/commit/9d112c0e2e8c6800013eeda7968f568a749f2586
+- Fixed a bug during compiler detection when building GCC see https://github.com/buildtesters/buildtest/commit/f139756213a280301771214894c8f48e8bcee4e8
+- create a pretty menu for Interactive Testing via **buildtest --runtest** see https://github.com/buildtesters/buildtest/commit/231cfeb0cf88cbc70826a9e76697947d06f0a6e1
 - replace shell commands **subprocess.Popen()** with python library equivalents
-- Add support for **--testset Tcl** see https://github.com/HPC-buildtest/buildtest-framework/commit/373cc1ea2fb2c5aedcf9ddadf105a94232cc1fa4
-- Add support for **--testset Ruby** see https://github.com/HPC-buildtest/buildtest-framework/commit/c6b7133b5fc4b0690b8040d0e437784567cc1963
-- Print software in alphabetical order for -svr option see https://github.com/HPC-buildtest/buildtest-framework/commit/fcf61019c644cd305e459234a85c5d39df06433f
+- Add support for **--testset Tcl** see https://github.com/buildtesters/buildtest/commit/373cc1ea2fb2c5aedcf9ddadf105a94232cc1fa4
+- Add support for **--testset Ruby** see https://github.com/buildtesters/buildtest/commit/c6b7133b5fc4b0690b8040d0e437784567cc1963
+- Print software in alphabetical order for -svr option see https://github.com/buildtesters/buildtest/commit/fcf61019c644cd305e459234a85c5d39df06433f
 
 v0.1.6 (Feb 27, 2018)
 -------------------------
@@ -321,7 +321,7 @@ v0.1.6 (Feb 27, 2018)
 v0.1.5 (Feb 27, 2018)
 ------------------------------
 
-The buildtest repo has been moved from http://github.com/shahzebsiddiqui to http://github.com/HPC-buildtest
+The buildtest repo has been moved from http://github.com/shahzebsiddiqui to http://github.com/buildtesters
 
 - Report what tests can be generated from buildtest through YAML files by using **--scantest**
 - Fixed a bug with flag **-svr** that was related to structure of easybuild repo, now no dependency on easybuild repo. Also added pretty output

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ If you don't have a GitHub account please `register <http://github.com/join>`_ y
 Fork the repo
 --------------
 
-First, you'll need to fork the repo https://github.com/HPC-buildtest/buildtest-framework
+First, you'll need to fork the repo https://github.com/buildtesters/buildtest
 
 You might need to setup your SSH keys in your git profile if you are using ssh option for cloning. For more details on
 setting up SSH keys in your profile, follow instruction found in
@@ -17,7 +17,7 @@ https://help.github.com/articles/connecting-to-github-with-ssh/
 
 SSH key will help you pull and push to repository without requesting for password for every commit. Once you have forked the repo, clone your local repo::
 
-  git clone git@github.com:YOUR\_GITHUB\_LOGIN/buildtest-framework.git
+  git clone git@github.com:YOUR\_GITHUB\_LOGIN/buildtest.git
 
 
 Adding Upstream Remote
@@ -26,7 +26,7 @@ Adding Upstream Remote
 First you need to add the ``upstream`` repo, to do this you can issue the
 following::
 
- git remote add upstream git@github.com/HPC-buildtest/buildtest-framework.git
+ git remote add upstream git@github.com/buildtesters/buildtest.git
 
 The ``upstream`` tag is used to sync changes from upstream repo to keep your
 repo in sync before you contribute back.
@@ -45,7 +45,7 @@ Sync your branch from upstream
 The ``devel`` from upstream will get Pull Requests from other contributors, in-order
 to sync your forked repo with upstream, run the commands below::
 
- cd buildtest-framework
+ cd buildtest
  git checkout devel
  git fetch upstream devel
  git pull upstream devel
@@ -71,7 +71,7 @@ push to ``master`` or ``devel`` branch on your fork or upstream.
 
 Create a new branch from ``devel`` as follows::
 
-  cd buildtest-framework
+  cd buildtest
   git checkout devel
   git checkout -b featureX
 
@@ -82,7 +82,7 @@ Once you are ready to push to your fork repo do the following::
 
 
 Once the branch is created in your fork, you can create a PR for the ``devel``
-branch for ``upstream`` repo (https://github.com/HPC-buildtest/buildtest-framework)
+branch for ``upstream`` repo (https://github.com/buildtesters/buildtest)
 
 Review
 -------
@@ -194,18 +194,18 @@ The following apps are configured with buildtest.
 
 - **CodeCov** - Codecov provides highly integrated tools to group, merge, archive and compare coverage reports
 
-  - Link: https://codecov.io/gh/HPC-buildtest/buildtest-framework
+  - Link: https://codecov.io/gh/buildtesters/buildtest
 - **GuardRails** - GuardRails provides continuous security feedback for modern development teams
 
-  - Link: https://dashboard.guardrails.io/default/gh/HPC-buildtest
+  - Link: https://dashboard.guardrails.io/default/gh/buildtesters
 
 - **Travis CI** - Test and deploy with confidence. Trusted by over 800,000 users, Travis CI is the leading hosted continuous integration system.
 
-  - Link: https://travis-ci.com/HPC-buildtest/buildtest-framework
+  - Link: https://travis-ci.com/buildtesters/buildtest
 
 - **Snyk** - Snyk tracks vulnerabilities in over 800,000 open source packages, and helps protect over 25,000 applications.
 
-  - Link: https://app.snyk.io/org/hpc-buildtest/
+  - Link: https://app.snyk.io/org/buildtesters/
 
 When contributing back to buildtest, please consider checking the following GitHub apps, most important being **Travis-CI**
 as it will test your pull request before merging to ``devel`` branch.
@@ -232,9 +232,9 @@ We have created the tag locally, next we must push the tag to the upstream repo 
 
   git push origin v.1.2.3
 
-Every release must have a release note that is maintained in file `CHANGELOG.rst <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/CHANGELOG.rst>`_
+Every release must have a release note that is maintained in file `CHANGELOG.rst <https://github.com/buildtesters/buildtest/blob/devel/CHANGELOG.rst>`_
 
-Under buildtest `releases <https://github.com/HPC-buildtest/buildtest-framework/releases>`_ a new release can be created that
+Under buildtest `releases <https://github.com/buildtesters/buildtest/releases>`_ a new release can be created that
 corresponds to the git tag. In the release summary, just direct with a message stating **refer to CHANGELOG.rst for more details**
 
 Formatting Code
@@ -244,7 +244,7 @@ buildtest is using `black  <https://github.com/psf/black>`_ to format Python cod
 formatting the entire project so you can focus more time in development. buildtest has a GitHub action trigger in
 ``.github/workflows/black.yml`` that formats code upon **push** and **pull request**.
 
-You can see the status of all GitHub actions at https://github.com/HPC-buildtest/buildtest-framework/actions
+You can see the status of all GitHub actions at https://github.com/buildtesters/buildtest/actions
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -6,18 +6,18 @@
     :target: https://buildtest.readthedocs.io/en/latest/?badge=latest
 
 .. |slack| image:: http://hpcbuildtest.herokuapp.com/badge.svg
-.. |license| image:: https://img.shields.io/github/license/HPC-buildtest/buildtest-framework.svg
+.. |license| image:: https://img.shields.io/github/license/buildtesters/buildtest.svg
 .. |core_infrastructure| image:: https://bestpractices.coreinfrastructure.org/projects/3469/badge
-.. |tags| image:: https://img.shields.io/github/v/tag/HPC-buildtest/buildtest-framework.svg
-.. |codecov| image:: https://codecov.io/gh/HPC-buildtest/buildtest-framework/branch/devel/graph/badge.svg
-    :target: https://codecov.io/gh/HPC-buildtest/buildtest-framework
-.. |coveralls| image:: https://coveralls.io/repos/github/HPC-buildtest/buildtest-framework/badge.svg?branch=devel
-    :target: https://coveralls.io/github/HPC-buildtest/buildtest-framework?branch=devel
-.. |codefactor| image:: https://www.codefactor.io/repository/github/hpc-buildtest/buildtest-framework/badge
-   :target: https://www.codefactor.io/repository/github/hpc-buildtest/buildtest-framework
+.. |tags| image:: https://img.shields.io/github/v/tag/buildtesters/buildtest.svg
+.. |codecov| image:: https://codecov.io/gh/buildtesters/buildtest/branch/devel/graph/badge.svg
+    :target: https://codecov.io/gh/buildtesters/buildtest
+.. |coveralls| image:: https://coveralls.io/repos/github/buildtesters/buildtest/badge.svg?branch=devel
+    :target: https://coveralls.io/github/buildtesters/buildtest?branch=devel
+.. |codefactor| image:: https://www.codefactor.io/repository/github/buildtesters/buildtest/badge
+   :target: https://www.codefactor.io/repository/github/buildtesters/buildtest
    :alt: CodeFactor
-.. |travis| image:: https://travis-ci.com/HPC-buildtest/buildtest-framework.svg?branch=devel
-    :target: https://travis-ci.com/HPC-buildtest/buildtest-framework
+.. |travis| image:: https://travis-ci.com/buildtesters/buildtest.svg?branch=devel
+    :target: https://travis-ci.com/buildtesters/buildtest
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
 
@@ -38,15 +38,15 @@ References
 
 - ReadTheDocs: https://readthedocs.org/projects/buildtest/
 
-- Travis: https://travis-ci.com/HPC-buildtest/buildtest-framework
+- Travis: https://travis-ci.com/buildtesters/buildtest
 
-- CodeCov: https://codecov.io/gh/HPC-buildtest/buildtest-framework
+- CodeCov: https://codecov.io/gh/buildtesters/buildtest
 
-- Coveralls: https://coveralls.io/github/HPC-buildtest/buildtest-framework
+- Coveralls: https://coveralls.io/github/buildtesters/buildtest
 
-- CodeFactor: https://www.codefactor.io/repository/github/hpc-buildtest/buildtest-framework
+- CodeFactor: https://www.codefactor.io/repository/github/buildtesters/buildtest
 
-- Snyk: https://app.snyk.io/org/hpc-buildtest/
+- Snyk: https://app.snyk.io/org/buildtesters/
 
 Why buildtest?
 ---------------
@@ -58,7 +58,7 @@ Documentation
 -------------
 
 buildtest `documentation <http://buildtest.readthedocs.io/en/latest/>`_  is your source for getting help with buildtest.
-If you get stuck check out the `current issues <https://github.com/HPC-buildtest/buildtest-framework/issues>`_ to see
+If you get stuck check out the `current issues <https://github.com/buildtesters/buildtest/issues>`_ to see
 if you face similar issue. If all else fails please create a ticket.
 
 Source Code
@@ -90,4 +90,4 @@ LICENSE
 --------
 
 buildtest is released under the MIT License. See
-`LICENSE <https://github.com/HPC-buildtest/buildtest-framework/blob/master/LICENSE>`_ for more details
+`LICENSE <https://github.com/buildtesters/buildtest/blob/master/LICENSE>`_ for more details

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -38,7 +38,7 @@ class BuildspecParser:
     """A BuildspecParser is a base class for loading and validating a Buildspec file.
        The type (e.g., script) and version are derived from reading in
        the file, and then matching to a Buildspec schema, each of which is
-       developed at https://github.com/HPC-buildtest/schemas and added to
+       developed at https://github.com/buildtesters/schemas and added to
        subfolders named accordingly under buildtest/buildsystem/schemas.
        The schema object can load in a general Buildspec file
        to validate it, and then match it to a Buildspec Schema available.

--- a/buildtest/buildsystem/schemas/global.schema.json
+++ b/buildtest/buildsystem/schemas/global.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://HPC-buildtest.github.io/schemas/global/global.schema.json",
+  "$id": "https://buildtesters.github.io/schemas/global/global.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "BuildTest Wrapper for Test Configurations",
   "type": "object",

--- a/buildtest/buildsystem/schemas/script/script-v0.0.1.schema.json
+++ b/buildtest/buildsystem/schemas/script/script-v0.0.1.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://HPC-buildtest.github.io/schemas/script/script-v0.0.1.schema.json",
+  "$id": "https://buildtesters.github.io/schemas/script/script-v0.0.1.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "BuildTest Test Configuration for Script",
   "type": "object",

--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -22,7 +22,7 @@ known_sections = variable_sections + build_sections
 userhome = pwd.getpwuid(os.getuid())[5]
 root = os.path.dirname(os.path.abspath(__file__))
 
-# root of buildtest-framework user home, default shell
+# root of buildtest user home, default shell
 BUILDTEST_ROOT = os.path.join(userhome, ".buildtest")
 BUILDTEST_SHELL = os.environ.get("SHELL", "/bin/bash")
 

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -28,13 +28,13 @@ def discover_buildspecs(buildspec):
        buildtest build --buildspec relative-folder/hello.sh.yml
 
        # A relative path to a file in build test root (returns single)
-       buildtest build --buildspec github.com/HPC-buildtest/tutorials/hello-world/hello.sh.yml
+       buildtest build --buildspec github.com/buildtesters/tutorials/hello-world/hello.sh.yml
 
        # relative directory path (returns multiple)
        buildtest build --buildspec hello-world
 
        # relative directory path in build test root (returns multiple)
-       buildtest build --buildspec github.com/HPC-buildtest/tutorials/hello-world/
+       buildtest build --buildspec github.com/buildtesters/tutorials/hello-world/
     """
 
     buildspecs = []

--- a/buildtest/settings/settings.schema.json
+++ b/buildtest/settings/settings.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://HPC-buildtest.github.io/schemas/settings/settings.schema.json",
+  "$id": "https://buildtesters.github.io/schemas/settings/settings.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Buildtest Settings Schema",
   "type": "object",

--- a/docs/api/buildtest.menu.rst
+++ b/docs/api/buildtest.menu.rst
@@ -10,7 +10,6 @@ Submodules
    buildtest.menu.config
    buildtest.menu.get
    buildtest.menu.show
-   buildtest.menu.status
 
 Module contents
 ---------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,7 @@ html_static_path = ["_static"]
 html_context = {
     # "display_github": True,  # Integrate GitHub
     # "github_user": "shahzebmsiddiqui",  # Username
-    # "github_repo": "buildtest-framework",  # Repo name
+    # "github_repo": "buildtest",  # Repo name
     # "github_version": "master",  # Version
     "css_files": ["_static/theme_overrides.css"]  # override wide tables in RTD theme
 }

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -3,7 +3,7 @@ Contributing Guide
 
 There are many ways you can help contribute to buildtest that may include
 
-- File an `issue <https://github.com/HPC-buildtest/buildtest-framework/issues>`_ with the framework
+- File an `issue <https://github.com/buildtesters/buildtest/issues>`_ with the framework
 - Proofread documentation and report or fix issues
 - Participate in discussions and join the slack `channel <http://hpcbuildtest.slack.com>`_
 - Share your tests

--- a/docs/contributing/github_integration.rst
+++ b/docs/contributing/github_integration.rst
@@ -2,16 +2,16 @@ GitHub Integrations
 ====================
 
 buildtest has several github integration, including automated checks during PR that maintainers will check
-during the PR review. You should check results from the `buildtest actions <https://github.com/HPC-buildtest/buildtest-framework/actions>`_
+during the PR review. You should check results from the `buildtest actions <https://github.com/buildtesters/buildtest/actions>`_
 that are also typically linked as part of the pull request testing suite.
 
-It's good practice to check Travis `builds <https://travis-ci.com/HPC-buildtest/buildtest-framework>`_ since we use Travis
+It's good practice to check Travis `builds <https://travis-ci.com/buildtesters/buildtest>`_ since we use Travis
 to run regression test and Codecov and Coveralls depend on Travis to pass all checks.
 
 You will want to make sure code is formatted via black as we have automated checks for python formatting. If you have not
 setup the black hook check out :ref:`black_hook`
 
-If you notice the black linter step in `GitHub Actions <https://github.com/HPC-buildtest/buildtest-framework/actions>`_ is
+If you notice the black linter step in `GitHub Actions <https://github.com/buildtesters/buildtest/actions>`_ is
 failing, make sure you have the right version of black installation.
 
 GitHub Apps
@@ -19,24 +19,24 @@ GitHub Apps
 
 The following apps are configured with buildtest.
 
-- `Travis CI <https://travis-ci.com/HPC-buildtest/buildtest-framework>`_ - Test and deploy with confidence. Trusted by over 800,000 users, Travis CI is the leading hosted continuous integration system.
+- `Travis CI <https://travis-ci.com/buildtesters/buildtest>`_ - Test and deploy with confidence. Trusted by over 800,000 users, Travis CI is the leading hosted continuous integration system.
 
-- `CodeCov <https://codecov.io/gh/HPC-buildtest/buildtest-framework>`_ - Codecov provides highly integrated tools to group, merge, archive and compare coverage reports
+- `CodeCov <https://codecov.io/gh/buildtesters/buildtest>`_ - Codecov provides highly integrated tools to group, merge, archive and compare coverage reports
 
-- `Coveralls <https://coveralls.io/github/HPC-buildtest/buildtest-framework>`_ - Coveralls is a web service to help you track your code coverage over time, and ensure that all your new code is fully covered.
+- `Coveralls <https://coveralls.io/github/buildtesters/buildtest>`_ - Coveralls is a web service to help you track your code coverage over time, and ensure that all your new code is fully covered.
 
-- `CodeFactor <https://www.codefactor.io/repository/github/hpc-buildtest/buildtest-framework>`_ - CodeFactor instantly performs Code Review with every GitHub Commit or PR. Zero setup time. Get actionable feedback within seconds. Customize rules, get refactoring tips and ignore irrelevant issues.
+- `CodeFactor <https://www.codefactor.io/repository/github/buildtesters/buildtest>`_ - CodeFactor instantly performs Code Review with every GitHub Commit or PR. Zero setup time. Get actionable feedback within seconds. Customize rules, get refactoring tips and ignore irrelevant issues.
 
-- `Snyk <https://app.snyk.io/org/hpc-buildtest/>`_  - Snyk tracks vulnerabilities in over 800,000 open source packages, and helps protect over 25,000 applications.
+- `Snyk <https://app.snyk.io/org/buildtesters/>`_  - Snyk tracks vulnerabilities in over 800,000 open source packages, and helps protect over 25,000 applications.
 
 GitHub Actions
 --------------
 
 buildtest runs a few automated checks via GitHub Actions that can be found in ``.github/workflows``
 
-- `Black  <https://github.com/psf/black>`_ - Black auto-formats Python code, so we let **black** take care of formatting the entire project so you can focus more time in development. The workflow is defined in `black.yml <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/.github/workflows/black.yml>`_.
+- `Black  <https://github.com/psf/black>`_ - Black auto-formats Python code, so we let **black** take care of formatting the entire project so you can focus more time in development. The workflow is defined in `black.yml <https://github.com/buildtesters/buildtest/blob/devel/.github/workflows/black.yml>`_.
 
-- `urlchecker-action <https://github.com/marketplace/actions/urlchecker-action>`_ - is a GitHub action to collect and check URLs in project code and documentation. There is an automated check for every issued PR and the workflow is defined in `urlchecker.yml <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/.github/workflows/urlchecker.yml>`_
+- `urlchecker-action <https://github.com/marketplace/actions/urlchecker-action>`_ - is a GitHub action to collect and check URLs in project code and documentation. There is an automated check for every issued PR and the workflow is defined in `urlchecker.yml <https://github.com/buildtesters/buildtest/blob/devel/.github/workflows/urlchecker.yml>`_
 
 .. _black_hook:
 
@@ -64,7 +64,7 @@ what the pre-commit hook will do ::
 
     $ git commit -m "test black on one of the regtest"
     Black is installed
-    reformatted /mxg-hpc/users/ssi29/buildtest-framework/tests/test_inspect.py
+    reformatted /mxg-hpc/users/ssi29/buildtest/tests/test_inspect.py
     All done! ✨ 🍰 ✨
     1 file reformatted, 39 files left unchanged.
     [test_black_hook 008fc62] test black on one of the regtest

--- a/docs/contributing/maintainer_guide.rst
+++ b/docs/contributing/maintainer_guide.rst
@@ -44,9 +44,9 @@ We have created the tag locally, next we must push the tag to the upstream repo 
 
   git push origin v.1.2.3
 
-Every release must have a release note that is maintained in file `CHANGELOG.rst <https://github.com/HPC-buildtest/buildtest-framework/blob/master/CHANGELOG.rst>`_
+Every release must have a release note that is maintained in file `CHANGELOG.rst <https://github.com/buildtesters/buildtest/blob/master/CHANGELOG.rst>`_
 
-Under buildtest `releases <https://github.com/HPC-buildtest/buildtest-framework/releases>`_ a new release can be created that
+Under buildtest `releases <https://github.com/buildtesters/buildtest/releases>`_ a new release can be created that
 corresponds to the git tag. In the release summary, just direct with a message stating **refer to CHANGELOG.rst for more details**
 
 Once the release is published, make sure to open a pull request from ``devel`` --> ``master`` and **Rebase and Merge**
@@ -61,7 +61,7 @@ The ``master`` branch should be setup as the default branch.
 Branch Settings
 ----------------
 
-All maintainers are encouraged to view branch `settings <https://github.com/HPC-buildtest/buildtest-framework/settings/branches>`_
+All maintainers are encouraged to view branch `settings <https://github.com/buildtesters/buildtest/settings/branches>`_
 for ``devel`` and ``master``. If something is not correct please consult with the maintainers.
 
 The master and devel branches should be protected branches and master should be enabled as default branch. Shown

--- a/docs/contributing/regression_testing.rst
+++ b/docs/contributing/regression_testing.rst
@@ -18,8 +18,8 @@ Writing Regression Tests
 -------------------------
 
 If you want to write a new regression test, you would want to get familiar with the coverage report gather in codecov and
-coveralls. The coverage report for codecov (https://codecov.io/gh/HPC-buildtest/buildtest-framework) or coveralls
-(https://coveralls.io/github/HPC-buildtest/buildtest-framework) will give a detailed line-line coverage detail of source
+coveralls. The coverage report for codecov (https://codecov.io/gh/buildtesters/buildtest) or coveralls
+(https://coveralls.io/github/buildtesters/buildtest) will give a detailed line-line coverage detail of source
 code HIT/MISS when running the regression test. Increasing coverage report would be great way to write a new regression test.
 
 The ``tests`` directory is structured in a way that each source file has a corresponding test file that starts with ``test_``.

--- a/docs/contributing/setup.rst
+++ b/docs/contributing/setup.rst
@@ -12,7 +12,7 @@ If you don't have a GitHub account please `register <http://github.com/join>`_ y
 Fork the repo
 --------------
 
-First, you'll need to fork the repo https://github.com/HPC-buildtest/buildtest-framework
+First, you'll need to fork the repo https://github.com/buildtesters/buildtest
 
 You might need to setup your SSH keys in your git profile if you are using ssh option for cloning. For more details on
 setting up SSH keys in your profile, follow instruction found in
@@ -20,7 +20,7 @@ https://help.github.com/articles/connecting-to-github-with-ssh/
 
 SSH key will help you pull and push to repository without requesting for password for every commit. Once you have forked the repo, clone your local repo::
 
-  git clone git@github.com:YOUR\_GITHUB\_LOGIN/buildtest-framework.git
+  git clone git@github.com:YOUR\_GITHUB\_LOGIN/buildtest.git
 
 
 Adding Upstream Remote
@@ -29,7 +29,7 @@ Adding Upstream Remote
 First you need to add the ``upstream`` repo, to do this you can issue the
 following::
 
- git remote add upstream git@github.com/HPC-buildtest/buildtest-framework.git
+ git remote add upstream git@github.com/buildtesters/buildtest.git
 
 The ``upstream`` tag is used to sync changes from upstream repo to keep your
 repo in sync before you contribute back.
@@ -48,7 +48,7 @@ Sync your branch from upstream
 The ``devel`` from upstream will get Pull Requests from other contributors, in-order
 to sync your forked repo with upstream, run the commands below::
 
- cd buildtest-framework
+ cd buildtest
  git checkout devel
  git fetch upstream devel
  git pull upstream devel
@@ -72,7 +72,7 @@ push to ``master`` or ``devel`` branch on your fork or upstream.
 
 Create a new branch from ``devel`` as follows::
 
-  cd buildtest-framework
+  cd buildtest
   git checkout devel
   git checkout -b featureX
 
@@ -83,7 +83,7 @@ Once you are ready to push to your fork repo do the following::
 
 
 Once the branch is created in your fork, you can create a PR for the ``devel``
-branch for ``upstream`` repo (https://github.com/HPC-buildtest/buildtest-framework)
+branch for ``upstream`` repo (https://github.com/buildtesters/buildtest)
 
 Pull Request Review
 --------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -26,22 +26,22 @@ Cloning Tutorials
 To get started, let's clone a repository with tutorial tests. Since this is a group of tests,
 we can put it in our tests directory by using the "get" command::
 
-    $ buildtest get https://github.com/HPC-buildtest/tutorials.git
-    Cloning into '/home/users/vsochat/.buildtest/site/github.com/HPC-buildtest/tutorials'...
+    $ buildtest get https://github.com/buildtesters/tutorials.git
+    Cloning into '/home/users/vsochat/.buildtest/site/github.com/buildtesters/tutorials'...
 
 Which would be equivalent to doing this::
 
-    $ mkdir -p $HOME/.buildtest/site/github.com/HPC-buildtest
-    $ git clone https://github.com/HPC-buildtest/tutorials.git $HOME/.buildtest/site/github.com/HPC-buildtest/tutorials
+    $ mkdir -p $HOME/.buildtest/site/github.com/buildtesters
+    $ git clone https://github.com/buildtesters/tutorials.git $HOME/.buildtest/site/github.com/buildtesters/tutorials
 
 You can also clone a specific branch::
 
-    $ buildtest get -b add/hello-world-test https://github.com/HPC-buildtest/tutorials.git
+    $ buildtest get -b add/hello-world-test https://github.com/buildtesters/tutorials.git
 
 And in either case, if the folder already exists, you'll be told::
 
-    $ buildtest get https://github.com/HPC-buildtest/tutorials.git
-    /home/users/vsochat/.buildtest/site/github.com/HPC-buildtest/tutorials already exists. Remove and try again.
+    $ buildtest get https://github.com/buildtesters/tutorials.git
+    /home/users/vsochat/.buildtest/site/github.com/buildtesters/tutorials already exists. Remove and try again.
 
 The tests are organized by their namespace, meaning that you'll find GitHub repos organized under
 github.com, then the organization or username, and then the repository name.
@@ -54,7 +54,7 @@ We can refer to a config as a relative path to the test config root at ``$HOME/.
 we can provide a relative path to a config file anywhere on our system. Let's start
 with the latter, and change directory to interact with our test configurations::
 
-    $ cd /home/users/vsochat/.buildtest/site/github.com/HPC-buildtest/tutorials
+    $ cd /home/users/vsochat/.buildtest/site/github.com/buildtesters/tutorials
 
 
 Let's take a look at the simplest of examples - a "Hello buildtest" example! This is
@@ -113,7 +113,7 @@ Let's run our test! We could be doing this from a relative path to the test conf
 file, **or** as a relative path from the root of our testdir at ``$HOME/.buildtest/site``
 For example, either of the two would work in the case of this test::
 
-    $ buildtest build -c github.com/HPC-buildtest/tutorials/hello-world/hello.sh.yml
+    $ buildtest build -c github.com/buildtesters/tutorials/hello-world/hello.sh.yml
     $ buildtest build -c hello.sh.yml
 
 
@@ -204,7 +204,7 @@ If we look in the shell script at the top level, we see exactly what was run.::
 
 	#!/bin/bash
 	TESTDIR=/home/users/vsochat/.buildtest/testdir/build_6
-	SRCDIR=/home/users/vsochat/.buildtest/site/github.com/HPC-buildtest/tutorials/compilers/src
+	SRCDIR=/home/users/vsochat/.buildtest/site/github.com/buildtesters/tutorials/compilers/src
 	SRCFILE=$SRCDIR/hello.f90
 	FC=ifort
 	FFLAGS="-O2"
@@ -220,12 +220,12 @@ And then if we look in the logs directory, we see verbose output for the entire 
 
 	2020-03-01 10:23:39,580 [build.py:58 - func_build_subcmd() ] - [INFO] Creating Directory: /home/users/vsochat/.buildtest/testdir/build_6
 	2020-03-01 10:23:39,581 [build.py:59 - func_build_subcmd() ] - [DEBUG] Current build ID: 6
-	2020-03-01 10:23:39,586 [singlesource.py:410 - __init__() ] - [DEBUG] Source Directory: /home/users/vsochat/.buildtest/site/github.com/HPC-buildtest/tutorials/compilers/src
+	2020-03-01 10:23:39,586 [singlesource.py:410 - __init__() ] - [DEBUG] Source Directory: /home/users/vsochat/.buildtest/site/github.com/buildtesters/tutorials/compilers/src
 	2020-03-01 10:23:39,586 [singlesource.py:411 - __init__() ] - [DEBUG] Source File: hello.f90
 	2020-03-01 10:23:39,725 [singlesource.py:705 - build_test_content() ] - [DEBUG] testpath:/home/users/vsochat/.buildtest/testdir/build_6/hello.f.yml.0x741db6a9.sh
 	2020-03-01 10:23:39,725 [singlesource.py:705 - build_test_content() ] - [DEBUG] shell:['#!/bin/bash']
 	2020-03-01 10:23:39,725 [singlesource.py:705 - build_test_content() ] - [DEBUG] module:None
-	2020-03-01 10:23:39,726 [singlesource.py:705 - build_test_content() ] - [DEBUG] metavars:['TESTDIR=/home/users/vsochat/.buildtest/testdir/build_6', 'SRCDIR=/home/users/vsochat/.buildtest/site/github.com/HPC-buildtest/tutorials/compilers/src', 'SRCFILE=$SRCDIR/hello.f90', 'FC=ifort', 'FFLAGS="-O2"', 'EXECUTABLE=hello.f.yml.0x741db6a9.exec']
+	2020-03-01 10:23:39,726 [singlesource.py:705 - build_test_content() ] - [DEBUG] metavars:['TESTDIR=/home/users/vsochat/.buildtest/testdir/build_6', 'SRCDIR=/home/users/vsochat/.buildtest/site/github.com/buildtesters/tutorials/compilers/src', 'SRCFILE=$SRCDIR/hello.f90', 'FC=ifort', 'FFLAGS="-O2"', 'EXECUTABLE=hello.f.yml.0x741db6a9.exec']
 	2020-03-01 10:23:39,726 [singlesource.py:705 - build_test_content() ] - [DEBUG] envs:[]
 	2020-03-01 10:23:39,726 [singlesource.py:705 - build_test_content() ] - [DEBUG] build:['cd $TESTDIR', '$FC $FFLAGS -o $EXECUTABLE $SRCFILE']
 	2020-03-01 10:23:39,726 [singlesource.py:705 - build_test_content() ] - [DEBUG] run:['$EXECUTABLE', 'rm ./$EXECUTABLE']
@@ -265,7 +265,7 @@ in your testing root at ``$HOME/.buildtest/site``::
 The following will target a specific file path under your test config root::
 
 
-	buildtest build -c github.com/HPC-buildtest/tutorials/hello-world/hello.sh.ym
+	buildtest build -c github.com/buildtesters/tutorials/hello-world/hello.sh.ym
 
 
 If you provide a directory name as a relative path, buildtest will discover all test configurations under it::
@@ -277,7 +277,7 @@ If you provide a directory name as a relative path, buildtest will discover all 
 And if you provide a relative path under the test config root, that directory will be targeted instead::
 
 
-	buildtest build -c github.com/HPC-buildtest/tutorials/hello-world/
+	buildtest build -c github.com/buildtesters/tutorials/hello-world/
 
 
 And of course you can provide a direct path to a single file, as we showed in the examples above.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 buildtest
 ==========
 
-`buildtest <https://github.com/HPC-buildtest/buildtest-framework>`_  is
+`buildtest <https://github.com/buildtesters/buildtest>`_  is
 a testing framework designed for HPC Software Stack Testing that is compatible with Lmod module system.
 buildtest provides a set of YAML keys to write test configuration (YAML) that buildtest translates into complex test
 scripts. This allows users to focus on writing test configuration with minimal knowledge of the

--- a/docs/installing_buildtest.rst
+++ b/docs/installing_buildtest.rst
@@ -27,18 +27,18 @@ Cloning buildtest
 
 To get started, clone the buildtest repository in your local machine as follows::
 
-    $ git clone https://github.com/HPC-buildtest/buildtest-framework.git
+    $ git clone https://github.com/buildtesters/buildtest.git
 
 If you prefer the SSH method, make sure your GitHub account is configured properly, for more details see
 `Connecting to GitHub with SSH <https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh>`_
 
 Once your account is configured you can clone the repository as follows::
 
-    $ git clone git@github.com:HPC-buildtest/buildtest-framework.git
+    $ git clone git@github.com:buildtesters/buildtest.git
 
 If you prefer the latest code release, please pull the **devel** branch::
 
-    $ git clone -b devel git@github.com:HPC-buildtest/buildtest-framework.git
+    $ git clone -b devel git@github.com:buildtesters/buildtest.git
 
 Or you may switch to the **devel** branch if you already cloned it::
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -8,33 +8,33 @@ Conference
   
   - Date: Feb 2nd 2020
   
-  - Slides: [`pdf <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/docs/slides/buildtest-fosdem20.pdf>`_], [`pptx <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/docs/slides/buildtest-fosdem20.pptx>`_] [`Video <https://ftp.osuosl.org/pub/fosdem/2020/UB5.132/buildtest.webm>`_]
+  - Slides: [`pdf <https://github.com/buildtesters/buildtest/blob/devel/docs/slides/buildtest-fosdem20.pdf>`_], [`pptx <https://github.com/buildtesters/buildtest/blob/devel/docs/slides/buildtest-fosdem20.pptx>`_] [`Video <https://ftp.osuosl.org/pub/fosdem/2020/UB5.132/buildtest.webm>`_]
 
 
 - **buildtest: HPC Software Stack Testing Framework** at 5thEasybuildUserMeeting_
 
   - Date: Jan 30th 2020
   
-  - Slides: [`pdf <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/docs/slides/buildtest-fifth-easybuild-user-meeting.pdf>`_], [`pptx <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/docs/slides/buildtest-fifth-easybuild-user-meeting.pptx>`_] [`Video <https://youtu.be/YcaXjufRRgI>`_]
+  - Slides: [`pdf <https://github.com/buildtesters/buildtest/blob/devel/docs/slides/buildtest-fifth-easybuild-user-meeting.pdf>`_], [`pptx <https://github.com/buildtesters/buildtest/blob/devel/docs/slides/buildtest-fifth-easybuild-user-meeting.pptx>`_] [`Video <https://youtu.be/YcaXjufRRgI>`_]
 
 -  **buildtest: A Software Testing Framework with Module Operations for HPC systems** at HUST_ workshop in SC19_
   
   - Date: Nov 18th 2019
   
-  - Slides: [`pdf <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/docs/slides/buildtest_hust19.pdf>`_], [`pptx <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/docs/slides/buildtest_hust19.pptx>`_]
+  - Slides: [`pdf <https://github.com/buildtesters/buildtest/blob/devel/docs/slides/buildtest_hust19.pdf>`_], [`pptx <https://github.com/buildtesters/buildtest/blob/devel/docs/slides/buildtest_hust19.pptx>`_]
 
 - **Software Stack Testing with buildtest** at HPCKP18_
 
   - Date: June 22th 2018
   
-  - Slides: [`pdf <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/docs/slides/buildtest_hpckp18.pdf>`_]
+  - Slides: [`pdf <https://github.com/buildtesters/buildtest/blob/devel/docs/slides/buildtest_hpckp18.pdf>`_]
 
   
 - **HPC Application Testing Framework - buildtest** at HPCKP17_
   
   - Date: June 15th 2017
   
-  - Slides: [`pdf <https://github.com/HPC-buildtest/buildtest-framework/blob/devel/docs/slides/buildtest_hpckp17.pdf>`_]
+  - Slides: [`pdf <https://github.com/buildtesters/buildtest/blob/devel/docs/slides/buildtest_hpckp17.pdf>`_]
   
 Publications
 --------------

--- a/docs/what_is_buildtest.rst
+++ b/docs/what_is_buildtest.rst
@@ -89,5 +89,5 @@ properly when building test. buildtest was designed on the premise of reusable a
 can be shared by the HPC community sites. buildtest aims to abstract test complexity so the user can
 focus on writing test with minimal knowledge of the system.
 
-buildtest is available on Github at https://github.com/HPC-buildtest/buildtest-framework
+buildtest is available on Github at https://github.com/buildtesters/buildtest
 

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ import sys
 from buildtest import BUILDTEST_VERSION
 
 setup(
-    name="buildtest-framework",
+    name="buildtest",
     version=BUILDTEST_VERSION,
     author="Shahzeb Siddiqui",
     author_email="shahzebmsiddiqui@gmail.com",
     description="HPC Application Testing Framework",
     long_description=open("README.rst").read(),
-    url="https://github.com/HPC-buildtest/buildtest-framework",
-    license="GPLv2",
+    url="https://github.com/buildtesters/buildtest",
+    license="MIT",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/tests/menu/test_get.py
+++ b/tests/menu/test_get.py
@@ -5,7 +5,7 @@ from buildtest.utils.file import is_dir, create_dir
 
 
 def test_clone(tmp_path):
-    repo = "https://github.com/HPC-buildtest/tutorials.git"
+    repo = "https://github.com/buildtesters/tutorials.git"
 
     assert is_dir(clone(repo, tmp_path))
 


### PR DESCRIPTION
@vsoch so i have tried to update most of the integrations to the new name. I have had some issues with renaming org for CodeFactor and Snyk. I got coveralls, Travis, codecov working.

The codefactor is named to "buildntest" and i can't seem to change it. I invited you as admin i was wondering to see if there is any way to fix it. 

For snyk i tried some way to update org and it didn't let me. Now its bit weird it's url is set to my name which is odd. Any way to fix this? 
https://www.codefactor.io/repository/github/buildntest/buildtest
https://app.snyk.io/org/shahzebsiddiqui-github-marketplace/project/58109ea9-230e-4c78-a412-c577b5d24f75/

The link for snyk should go to https://app.snyk.io/org/buildtesters/ but it is not. I figured it may be we need to remove the github integration and try to add it again but didn't seem to get any luck. 