### PR TITLE
Status check for test and utility methods read_file and write_file

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -447,10 +447,7 @@ class BuilderBase:
             :rtype: bool
         """
 
-        if recipe_returncode == result_returncode:
-            return True
-
-        return False
+        return recipe_returncode == result_returncode
 
     def check_regex(self, regex):
         """ This method conducts a regular expression check using 're.search' with regular
@@ -555,21 +552,22 @@ class BuilderBase:
             # if no regex is defined we set this to True since we do a logical AND
             regex_match = True
 
-            # check returncode from result matches value defined in Buildspec recipe, self.check_returncode returns a bool
             if "returncode" in status:
                 self.logger.debug("Conducting Return Code check")
                 self.logger.debug(
                     "Status Return Code: %s   Result Return Code: %s"
                     % (status["returncode"], result["RETURN_CODE"])
                 )
+                # self.check_returncode checks if test returncode matches returncode specified in Buildspec.
+                # The return value is a bool
                 returncode_match = self.check_returncode(
                     status["returncode"], result["RETURN_CODE"]
                 )
 
-            # check regex expression in Buildspec with output or error stream. self_check_regex returns a boolean (True/False)
-            # by using re.search to check expression
             if "regex" in status.keys():
                 self.logger.debug("Conducting Regular Expression check")
+                # self.check_regex  applies regular expression check specified in Buildspec with output or error
+                # stream. self.check_regex returns a boolean (True/False) by using re.search
                 regex_match = self.check_regex(status["regex"])
 
             self.logger.info(

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -476,13 +476,12 @@ class BuilderBase:
             content = read_file(self.metadata["errfile"])
 
         # convert list to string
-        content = "\n".join(content)
-        self.logger.debug(f"Applying re.search with exp: {regex['exp']}")
-        # perform a regex search based on value of 'exp' key defined in Buildspec with content file (output or error)
-        if re.search(regex["exp"], content):
-            return True
+        # content = "\n".join(content)
 
-        return False
+        self.logger.debug(f"Applying re.search with exp: {regex['exp']}")
+
+        # perform a regex search based on value of 'exp' key defined in Buildspec with content file (output or error)
+        return re.search(regex["exp"], content) != None
 
     def run_tests(self, testfile):
         """The shared _run function will run a test file, which must be
@@ -540,7 +539,7 @@ class BuilderBase:
 
         status = self.recipe.get("status")
 
-        test_state = ""
+        test_state = "FAIL"
 
         # if status is defined in Buildspec, then check for returncode and regex
         if status:
@@ -564,7 +563,7 @@ class BuilderBase:
                     status["returncode"], result["RETURN_CODE"]
                 )
 
-            if "regex" in status.keys():
+            if "regex" in status:
                 self.logger.debug("Conducting Regular Expression check")
                 # self.check_regex  applies regular expression check specified in Buildspec with output or error
                 # stream. self.check_regex returns a boolean (True/False) by using re.search
@@ -577,15 +576,12 @@ class BuilderBase:
 
             if returncode_match and regex_match:
                 test_state = "PASS"
-            else:
-                test_state = "FAIL"
 
         # if status is not defined we check test returncode, by default 0 is PASS and any other return code is a FAIL
         else:
             if command.returncode == 0:
                 test_state = "PASS"
-            else:
-                test_state = "FAIL"
+
 
         # this variable is used later when counting all the pass/fail test in buildtest/menu/build.py
         result["TEST_STATE"] = test_state

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -582,7 +582,6 @@ class BuilderBase:
             if command.returncode == 0:
                 test_state = "PASS"
 
-
         # this variable is used later when counting all the pass/fail test in buildtest/menu/build.py
         result["TEST_STATE"] = test_state
 

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -526,7 +526,7 @@ class BuilderBase:
         self.metadata["errfile"] = run_output_file + ".err"
 
         # write output of test to .out file
-        write_file(self.metadata["outfile"],out)
+        write_file(self.metadata["outfile"], out)
 
         self.logger.debug(f"Writing run output to file: {self.metadata['outfile']}")
 
@@ -553,7 +553,7 @@ class BuilderBase:
             regex_match = True
 
             # check returncode from result matches value defined in Buildspec recipe, self.check_returncode returns a bool
-            if "returncode" in status.keys():
+            if "returncode" in status:
                 self.logger.debug("Conducting Return Code check")
                 self.logger.debug(
                     "Status Return Code: %s   Result Return Code: %s"

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -433,12 +433,40 @@ class BuilderBase:
         return result
 
     def check_returncode(self, recipe_returncode, result_returncode):
+        """ This method checks if return code from Buildspec recipe matches
+            return code from test. The return type is a bool either 'True'/'False'
+            depending if the return codes match
+
+            Parameters:
+
+            :param recipe_returncode: return code specified in recipe
+            :type recipe_returncode: int, required
+            :param result_returncode: return code from test
+            :type result_returncode: int, required
+            :return: A boolean return True/False based on conditional equality
+            :rtype: bool
+        """
+
         if recipe_returncode == result_returncode:
             return True
 
         return False
 
+
     def check_regex(self, regex):
+        """ This method conducts a regular expression check using 're.search' with regular
+            expression defined in Buildspec. User must specify an output stream (stdout, stderr)
+            to select when performing regex. In buildtest, this would read the .out or .err file
+            based on stream and run the regular expression to see if there is a match.
+
+            Parameters:
+
+            :param regex: Regular expression object defined in Buildspec file
+            :type regex: str, required
+            :return:  A boolean return True/False based on if re.search is successful or not
+            :rtype: bool
+        """
+
         if regex["stream"] == "stdout":
             self.logger.debug(
                 f"Detected regex stream 'stdout' so reading output file: {self.metadata['outfile']}"
@@ -458,6 +486,7 @@ class BuilderBase:
             return True
 
         return False
+
 
     def run_tests(self, testfile):
         """The shared _run function will run a test file, which must be

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -526,14 +526,17 @@ class BuilderBase:
         self.metadata["errfile"] = run_output_file + ".err"
 
         # write output of test to .out file
-        write_file(self.metadata["outfile"], out)
 
+        out = "\n".join(out)
+        err = "\n".join(err)
+
+        write_file(self.metadata["outfile"], out)
         self.logger.debug(f"Writing run output to file: {self.metadata['outfile']}")
 
         # write error from test to .err file
-        write_file(self.metadata["errfile"], out)
-
+        write_file(self.metadata["errfile"], err)
         self.logger.debug(f"Writing run error to file: {self.metadata['errfile']}")
+
         self.logger.debug(f"Return code: {command.returncode} for test: {testfile}")
         result["RETURN_CODE"] = command.returncode
         result["END_TIME"] = self.get_formatted_time("end_time")

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -475,9 +475,6 @@ class BuilderBase:
             )
             content = read_file(self.metadata["errfile"])
 
-        # convert list to string
-        # content = "\n".join(content)
-
         self.logger.debug(f"Applying re.search with exp: {regex['exp']}")
 
         # perform a regex search based on value of 'exp' key defined in Buildspec with content file (output or error)
@@ -526,12 +523,12 @@ class BuilderBase:
         out = "\n".join(out)
         err = "\n".join(err)
 
-        write_file(self.metadata["outfile"], out)
         self.logger.debug(f"Writing run output to file: {self.metadata['outfile']}")
+        write_file(self.metadata["outfile"], out)
 
         # write error from test to .err file
-        write_file(self.metadata["errfile"], err)
         self.logger.debug(f"Writing run error to file: {self.metadata['errfile']}")
+        write_file(self.metadata["errfile"], err)
 
         self.logger.debug(f"Return code: {command.returncode} for test: {testfile}")
         result["RETURN_CODE"] = command.returncode

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -452,7 +452,6 @@ class BuilderBase:
 
         return False
 
-
     def check_regex(self, regex):
         """ This method conducts a regular expression check using 're.search' with regular
             expression defined in Buildspec. User must specify an output stream (stdout, stderr)
@@ -486,7 +485,6 @@ class BuilderBase:
             return True
 
         return False
-
 
     def run_tests(self, testfile):
         """The shared _run function will run a test file, which must be

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -212,7 +212,7 @@ def func_build_subcmd(args):
                 result = executor.run(builder)
 
                 # Update results
-                if result["RETURN_CODE"] == 0:
+                if result["TEST_STATE"] == "PASS":
                     passed_tests += 1
                 else:
                     failed_tests += 1

--- a/buildtest/utils/command.py
+++ b/buildtest/utils/command.py
@@ -6,7 +6,7 @@ import shutil
 
 class BuildTestCommand:
     """Class method to invoke shell commands and retrieve output and error.
-       This class is inspired and derived from utils functions in 
+       This class is inspired and derived from utils functions in
        https://github.com/vsoch/scif
     """
 
@@ -32,7 +32,6 @@ class BuildTestCommand:
 
     def execute(self):
         """Execute a system command and return output and error.
-
         :param cmd: shell command to execute
         :type cmd: str, required
         :return: Output and Error from shell command
@@ -88,7 +87,7 @@ class BuildTestCommand:
         return self.returncode
 
     def decode(self, line):
-        """Given a line of output (error or regular) decode using the 
+        """Given a line of output (error or regular) decode using the
            system default, if appropriate
         """
         loc = locale.getdefaultlocale()[1]
@@ -101,14 +100,12 @@ class BuildTestCommand:
 
     def get_output(self):
         """Returns the output from shell command
-
         :rtype: str
         """
         return self.out
 
     def get_error(self):
         """Returns the error from shell command
-
         :rtype: str
         """
         return self.err

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -1,11 +1,11 @@
 """
 This module provides some generic file and directory level operation that
 include the following:
-1. Check if File and Directory exist
-2. Create File and Directory
-3. Check if string is in file
-4. Walk a directory tree based on single and multiple extension
-5. Strip Hidden file character
+1. Check if path is a File or Directory via is_file(), is_dir()
+2. Create a directory via create_dir()
+3. Walk a directory tree based on single extension using walk_tree()
+4. Resolve path including shell and user expansion along with getting realpath to file using resolve_path()
+5. Read and write a file via read_file(), write_file()
 """
 
 import os
@@ -21,7 +21,7 @@ def is_file(fname):
     :param file: file path
     :type file: str, required
 
-    :return: returns True if file exists otherwise terminates with an exception
+    :return: returns a boolean True/False depending on if input is a valid file.
     :rtype: bool
     """
 
@@ -33,10 +33,7 @@ def is_file(fname):
         return False
 
     # at this stage we know it's a valid file but we don't know if its a file or directory
-    if os.path.isfile(fname):
-        return True
-
-    return False
+    return os.path.isfile(fname)
 
 
 def is_dir(dirname):
@@ -47,7 +44,7 @@ def is_dir(dirname):
        :param dir: directory path
        :type dir: str, required
 
-       :return: returns ``True`` if directory exists otherwise returns ``False``
+       :return: returns a boolean True/False depending on if input is a valid directory.
        :rtype: bool
     """
 
@@ -58,11 +55,8 @@ def is_dir(dirname):
     if not dirname:
         return False
 
-    # at this stage we know it's a valid file but we don't know if its a file or directory
-    if os.path.isdir(dirname):
-        return True
-
-    return False
+    # at this stage we know it's a valid file, so return if file is a directory or not
+    return os.path.isdir(dirname)
 
 
 def walk_tree(root_dir, ext):
@@ -168,7 +162,9 @@ def read_file(filepath):
 
     # if it's invalid file let's raise an error
     if not filepath:
-        sys.exit(f"Unable to find input file: {input_file}. Please specify a valid file")
+        sys.exit(
+            f"Unable to find input file: {input_file}. Please specify a valid file"
+        )
 
     with open(filepath, "r") as fd:
         content = fd.read()

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -143,3 +143,80 @@ def resolve_path(path):
 
     if os.path.exists(real_path):
         return real_path
+
+def read_file(filepath):
+    """ This method provides capability to read a file.
+
+        Parameters:
+
+        :param filepath: file name to read
+        :type filepath: str, required
+        :return: return content of file
+        :rtype: list
+    """
+
+    # type check filepath to ensure its a string, if not return None
+    if not isinstance(filepath,str):
+        return None
+
+    # resolve_path will handle shell and user expansion and account for any symlinks and check for file existence.
+    # if resolve_path does not return gracefully it implies file does not exist and will return None
+    filepath = resolve_path(filepath)
+
+    # if it's invalid file let's return None
+    if not filepath:
+        return None
+
+    content = []
+    fd = open(filepath, "r")
+
+    while True:
+
+        line = fd.readline()
+        if line:
+            content.append(line)
+        else:
+            break
+
+    return content
+
+def write_file(filepath, content):
+    """ This method provides capability to write a file.
+
+        Parameters:
+
+        :param filepath: file name to write
+        :type filepath: str, required
+        :param content: content to write to file
+        :type content: list, required
+        :return: return content of file
+        :rtype: list
+    """
+
+    # type check filepath to ensure its a string, if not return None
+    if not isinstance(filepath,str):
+        return None
+
+    # if content was passed as a string, let's convert to list
+    if isinstance(content, str):
+        content = content.splitlines(True)
+
+    # shown below is equivalent to running 'resolve_path' but we can't invoke it since we expect this method
+    # to write to a new file. resolve_path assumes filepath already exists and returns realpath otherwise returns
+    # None.
+    filepath = os.path.expanduser(filepath)
+    filepath = os.path.expandvars(filepath)
+    filepath = os.path.realpath(filepath)
+
+    # if filepath is an actual file, let's not write to file and return None.
+    # also if filepath is a directory let's also return None
+    if is_file(filepath) or is_dir(filepath):
+        return None
+    
+    fd = open(filepath, "w")
+    # process each line and write to file
+    for line in content:
+        if line:
+            fd.writelines(line)
+
+    fd.close()

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -144,6 +144,7 @@ def resolve_path(path):
     if os.path.exists(real_path):
         return real_path
 
+
 def read_file(filepath):
     """ This method provides capability to read a file.
 
@@ -205,4 +206,3 @@ def write_file(filepath, content):
 
     with open(filepath, "w") as fd:
         fd.write(content)
-

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -10,6 +10,7 @@ include the following:
 
 import os
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -153,20 +154,21 @@ def read_file(filepath):
         :param filepath: file name to read
         :type filepath: str, required
         :return: return content of file
-        :rtype: list
+        :rtype: str
     """
 
     # type check filepath to ensure its a string, if not return None
     if not isinstance(filepath, str):
-        return None
+        sys.exit(f"Invalid type for file: {filepath} must be of type 'str' ")
 
+    input_file = filepath
     # resolve_path will handle shell and user expansion and account for any symlinks and check for file existence.
     # if resolve_path does not return gracefully it implies file does not exist and will return None
     filepath = resolve_path(filepath)
 
-    # if it's invalid file let's return None
+    # if it's invalid file let's raise an error
     if not filepath:
-        return None
+        sys.exit(f"Unable to find input file: {input_file}. Please specify a valid file")
 
     with open(filepath, "r") as fd:
         content = fd.read()
@@ -183,25 +185,18 @@ def write_file(filepath, content):
         :type filepath: str, required
         :param content: content to write to file
         :type content: str, required
-        :return: return content of file
-        :rtype: list
     """
 
     # type check filepath to ensure its a string, if not return None
     if not isinstance(filepath, str):
-        return None
+        sys.exit(f"Invalid type for file: {filepath} must be of type 'str' ")
+
+    #  if filepath is a directory let's, this is an error
+    if is_dir(filepath):
+        sys.exit(f"Detected {filepath} is a directory, please specify a file path.")
 
     # ensure content is of type string
     if not isinstance(content, str):
-        return None
-
-    # if filepath is an actual file, let's not write to file and return None.
-    # also if filepath is a directory let's also return None
-    if is_file(filepath) or is_dir(filepath):
-        return None
-
-    # check if parent directory is
-    if not is_dir(os.path.dirname(filepath)):
         return None
 
     with open(filepath, "w") as fd:

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -145,6 +145,23 @@ def resolve_path(path):
         return real_path
 
 
+def read(filepath):
+    with open(filepath, "r") as fd:
+        content = fd.read()
+    return content
+
+
+def write(filepath, content):
+
+    # check if parent directory where file is being written is a valid directory.
+    print(filepath)
+    if not is_dir(os.path.dirname(filepath)):
+        return None
+
+    with open(filepath, "w") as fd:
+        fd.write(content)
+
+
 def read_file(filepath):
     """ This method provides capability to read a file.
 
@@ -168,17 +185,7 @@ def read_file(filepath):
     if not filepath:
         return None
 
-    content = []
-    fd = open(filepath, "r")
-
-    while True:
-
-        line = fd.readline()
-        if line:
-            content.append(line)
-        else:
-            break
-
+    content = read(filepath)
     return content
 
 
@@ -190,7 +197,7 @@ def write_file(filepath, content):
         :param filepath: file name to write
         :type filepath: str, required
         :param content: content to write to file
-        :type content: list, required
+        :type content: str, required
         :return: return content of file
         :rtype: list
     """
@@ -199,26 +206,13 @@ def write_file(filepath, content):
     if not isinstance(filepath, str):
         return None
 
-    # if content was passed as a string, let's convert to list
-    if isinstance(content, str):
-        content = content.splitlines(True)
-
-    # shown below is equivalent to running 'resolve_path' but we can't invoke it since we expect this method
-    # to write to a new file. resolve_path assumes filepath already exists and returns realpath otherwise returns
-    # None.
-    filepath = os.path.expanduser(filepath)
-    filepath = os.path.expandvars(filepath)
-    filepath = os.path.realpath(filepath)
+    # ensure content is of type string
+    if not isinstance(content, str):
+        return None
 
     # if filepath is an actual file, let's not write to file and return None.
     # also if filepath is a directory let's also return None
     if is_file(filepath) or is_dir(filepath):
         return None
 
-    fd = open(filepath, "w")
-    # process each line and write to file
-    for line in content:
-        if line:
-            fd.writelines(line)
-
-    fd.close()
+    write(filepath, content)

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -141,13 +141,19 @@ def resolve_path(path):
 
 
 def read_file(filepath):
-    """ This method provides capability to read a file.
+    """ This method is used to read a file specified by argument ``filepath``. If filepath is not a string we raise
+        an error. We also run ``resolve_path`` to get realpath to file and account for shell or user expansion. The
+        return from ``resolve_path`` will be a valid file or ``None`` so  we check if input is an invalid file.
+        Finally we read the file and return the content of the file as a string.
 
         Parameters:
 
         :param filepath: file name to read
         :type filepath: str, required
-        :return: return content of file
+        :raises:
+          SystemError: If filepath is not a string
+          SystemError: If filepath is not valid file
+        :return: return content of file as a string
         :rtype: str
     """
 
@@ -173,7 +179,11 @@ def read_file(filepath):
 
 
 def write_file(filepath, content):
-    """ This method provides capability to write a file.
+    """ This method is used to write an input ``content`` to a file specified by ``filepath. Both filepath
+        and content must be a str. An error is raised if filepath is not a string or a directory. If ``content``
+        is not a str, we return ``None`` since we can't process the content for writing. Finally, we write the content
+        to file and return. A successful write will return nothing otherwise an exception will occur during the write
+        process.
 
         Parameters:
 
@@ -181,13 +191,18 @@ def write_file(filepath, content):
         :type filepath: str, required
         :param content: content to write to file
         :type content: str, required
+        :raises:
+          SystemError: System error if filepath is not string
+          SystemError: System error if filepath is a directory
+        :return: Return nothing if write is successful. A system error if ``filepath`` is not str or directory. If
+                 argument ``content`` is not str we return ``None``
     """
 
     # ensure filepath is a string, if not we raise an error
     if not isinstance(filepath, str):
         sys.exit(f"Invalid type for file: {filepath} must be of type 'str' ")
 
-    #  if filepath is a directory let's, this is an error
+    #  if filepath is a directory, we raise an exception noting that user must specify a filepath
     if is_dir(filepath):
         sys.exit(f"Detected {filepath} is a directory, please specify a file path.")
 

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -144,6 +144,7 @@ def resolve_path(path):
     if os.path.exists(real_path):
         return real_path
 
+
 def read_file(filepath):
     """ This method provides capability to read a file.
 
@@ -156,7 +157,7 @@ def read_file(filepath):
     """
 
     # type check filepath to ensure its a string, if not return None
-    if not isinstance(filepath,str):
+    if not isinstance(filepath, str):
         return None
 
     # resolve_path will handle shell and user expansion and account for any symlinks and check for file existence.
@@ -180,6 +181,7 @@ def read_file(filepath):
 
     return content
 
+
 def write_file(filepath, content):
     """ This method provides capability to write a file.
 
@@ -194,7 +196,7 @@ def write_file(filepath, content):
     """
 
     # type check filepath to ensure its a string, if not return None
-    if not isinstance(filepath,str):
+    if not isinstance(filepath, str):
         return None
 
     # if content was passed as a string, let's convert to list
@@ -212,7 +214,7 @@ def write_file(filepath, content):
     # also if filepath is a directory let's also return None
     if is_file(filepath) or is_dir(filepath):
         return None
-    
+
     fd = open(filepath, "w")
     # process each line and write to file
     for line in content:

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -144,24 +144,6 @@ def resolve_path(path):
     if os.path.exists(real_path):
         return real_path
 
-
-def read(filepath):
-    with open(filepath, "r") as fd:
-        content = fd.read()
-    return content
-
-
-def write(filepath, content):
-
-    # check if parent directory where file is being written is a valid directory.
-    print(filepath)
-    if not is_dir(os.path.dirname(filepath)):
-        return None
-
-    with open(filepath, "w") as fd:
-        fd.write(content)
-
-
 def read_file(filepath):
     """ This method provides capability to read a file.
 
@@ -185,7 +167,9 @@ def read_file(filepath):
     if not filepath:
         return None
 
-    content = read(filepath)
+    with open(filepath, "r") as fd:
+        content = fd.read()
+
     return content
 
 
@@ -215,4 +199,10 @@ def write_file(filepath, content):
     if is_file(filepath) or is_dir(filepath):
         return None
 
-    write(filepath, content)
+    # check if parent directory is
+    if not is_dir(os.path.dirname(filepath)):
+        return None
+
+    with open(filepath, "w") as fd:
+        fd.write(content)
+

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -151,7 +151,7 @@ def read_file(filepath):
         :rtype: str
     """
 
-    # type check filepath to ensure its a string, if not return None
+    # ensure filepath is a string, if not, we raise an error.
     if not isinstance(filepath, str):
         sys.exit(f"Invalid type for file: {filepath} must be of type 'str' ")
 
@@ -183,7 +183,7 @@ def write_file(filepath, content):
         :type content: str, required
     """
 
-    # type check filepath to ensure its a string, if not return None
+    # ensure filepath is a string, if not we raise an error
     if not isinstance(filepath, str):
         sys.exit(f"Invalid type for file: {filepath} must be of type 'str' ")
 

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -117,11 +117,17 @@ def test_write_file_exceptions(tmp_path):
 
     # testing invalid type for file stream
     with pytest.raises(SystemExit) as e_info:
+        print("Passing 'None' as input filestream to write_file")
         write_file(None, input)
 
     # testing if directory is passed as filepath, this is also not allowed and expected to raise error
     with pytest.raises(SystemExit) as e_info:
+        print(f"Passing directory: {tmp_path} as input filestream to write_file")
         write_file(tmp_path, input)
+
+    # input content must be a string, will return None upon
+    assert not write_file(os.path.join(tmp_path, "null.txt"), ["hi"])
+
 
 def test_read_file(tmp_path):
     # testing invalid type for read_file, expects of type string. Expected return is 'None'

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -114,26 +114,27 @@ def test_write_file_exceptions(tmp_path):
     file = os.path.join(tmp_path, "name.txt")
     print(f"Writing content: {input} to file {file}")
     write_file(file, input)
-    print("Writing to same file again, is not allowed!!!")
-    # rewriting to same file is not allowed, expected return is 'None'
-    assert not write_file(file, input)
 
-    # testing invalid type for file stream, expected to return None
-    assert not write_file(None, input)
+    # testing invalid type for file stream
+    with pytest.raises(SystemExit) as e_info:
+        write_file(None, input)
 
-    # testing if directory is passed as filepath, this is also not allowed, expected to return None
-    assert not write_file(tmp_path, input)
-
+    # testing if directory is passed as filepath, this is also not allowed and expected to raise error
+    with pytest.raises(SystemExit) as e_info:
+        write_file(tmp_path, input)
 
 def test_read_file(tmp_path):
     # testing invalid type for read_file, expects of type string. Expected return is 'None'
     print("Reading file with invalid type, passing 'None'")
-    assert not read_file(None)
+    with pytest.raises(SystemExit) as e_info:
+        read_file(None)
+
     file = os.path.join(tmp_path, "hello.txt")
     print(f"Checking {file} is not a file.")
     # ensure file is not valid
     assert not is_file(file)
 
     print(f"Now reading an invalid file: {file}, expecting read_file to return 'None'")
-    # checking invalid file returns None
-    assert not read_file(file)
+    # checking invalid file should report an error
+    with pytest.raises(SystemExit) as e_info:
+        read_file(file)

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -2,7 +2,15 @@ import pytest
 import os
 import shutil
 import uuid
-from buildtest.utils.file import is_dir, is_file, create_dir, walk_tree, resolve_path, read_file, write_file
+from buildtest.utils.file import (
+    is_dir,
+    is_file,
+    create_dir,
+    walk_tree,
+    resolve_path,
+    read_file,
+    write_file,
+)
 from buildtest.exceptions import BuildTestError
 
 here = os.path.dirname(os.path.abspath(__file__))
@@ -79,50 +87,53 @@ def test_walk_tree_invalid_dir(tmp_path):
     )
     assert not list_of_files
 
+
 def test_write_file(tmp_path):
     input = """This is a 
     multi-line
     string"""
 
-    file = os.path.join(tmp_path,"test.txt")
+    file = os.path.join(tmp_path, "test.txt")
 
-    print (f"Writing content to file: {file}")
+    print(f"Writing content to file: {file}")
     write_file(file, input)
 
     print(f"Reading content from file: {file}")
     content = read_file(file)
 
     # ensure return type of read_file is a list
-    assert isinstance(content,list)
+    assert isinstance(content, str)
     # split origin input by newline to create a list
-    input = input.splitlines(True)
-    # perform a list equality between input content and result of read_file
+
+    # perform a string equality between input content and result of read_file
     assert input == content
 
+
 def test_write_file_exceptions(tmp_path):
-    input = ["hi", "my", "name", "is", "Bob"]
-    file = os.path.join(tmp_path,"name.txt")
+    input = "hi my name is Bob"
+    file = os.path.join(tmp_path, "name.txt")
     print(f"Writing content: {input} to file {file}")
-    write_file(file,input)
+    write_file(file, input)
     print("Writing to same file again, is not allowed!!!")
     # rewriting to same file is not allowed, expected return is 'None'
-    assert not write_file(file,input)
+    assert not write_file(file, input)
 
     # testing invalid type for file stream, expected to return None
-    assert not write_file(None,input)
+    assert not write_file(None, input)
 
     # testing if directory is passed as filepath, this is also not allowed, expected to return None
-    assert not write_file(tmp_path,input)
+    assert not write_file(tmp_path, input)
+
 
 def test_read_file(tmp_path):
     # testing invalid type for read_file, expects of type string. Expected return is 'None'
-    print ("Reading file with invalid type, passing 'None'")
+    print("Reading file with invalid type, passing 'None'")
     assert not read_file(None)
-    file = os.path.join(tmp_path,"hello.txt")
-    print (f"Checking {file} is not a file." )
+    file = os.path.join(tmp_path, "hello.txt")
+    print(f"Checking {file} is not a file.")
     # ensure file is not valid
     assert not is_file(file)
 
-    print (f"Now reading an invalid file: {file}, expecting read_file to return 'None'")
+    print(f"Now reading an invalid file: {file}, expecting read_file to return 'None'")
     # checking invalid file returns None
     assert not read_file(file)

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -2,7 +2,7 @@ import pytest
 import os
 import shutil
 import uuid
-from buildtest.utils.file import is_dir, is_file, create_dir, walk_tree, resolve_path
+from buildtest.utils.file import is_dir, is_file, create_dir, walk_tree, resolve_path, read_file, write_file
 from buildtest.exceptions import BuildTestError
 
 here = os.path.dirname(os.path.abspath(__file__))
@@ -78,3 +78,51 @@ def test_walk_tree_invalid_dir(tmp_path):
         f"Returned following files: {list_of_files} with .py extension for path: {tmp_path}"
     )
     assert not list_of_files
+
+def test_write_file(tmp_path):
+    input = """This is a 
+    multi-line
+    string"""
+
+    file = os.path.join(tmp_path,"test.txt")
+
+    print (f"Writing content to file: {file}")
+    write_file(file, input)
+
+    print(f"Reading content from file: {file}")
+    content = read_file(file)
+
+    # ensure return type of read_file is a list
+    assert isinstance(content,list)
+    # split origin input by newline to create a list
+    input = input.splitlines(True)
+    # perform a list equality between input content and result of read_file
+    assert input == content
+
+def test_write_file_exceptions(tmp_path):
+    input = ["hi", "my", "name", "is", "Bob"]
+    file = os.path.join(tmp_path,"name.txt")
+    print(f"Writing content: {input} to file {file}")
+    write_file(file,input)
+    print("Writing to same file again, is not allowed!!!")
+    # rewriting to same file is not allowed, expected return is 'None'
+    assert not write_file(file,input)
+
+    # testing invalid type for file stream, expected to return None
+    assert not write_file(None,input)
+
+    # testing if directory is passed as filepath, this is also not allowed, expected to return None
+    assert not write_file(tmp_path,input)
+
+def test_read_file(tmp_path):
+    # testing invalid type for read_file, expects of type string. Expected return is 'None'
+    print ("Reading file with invalid type, passing 'None'")
+    assert not read_file(None)
+    file = os.path.join(tmp_path,"hello.txt")
+    print (f"Checking {file} is not a file." )
+    # ensure file is not valid
+    assert not is_file(file)
+
+    print (f"Now reading an invalid file: {file}, expecting read_file to return 'None'")
+    # checking invalid file returns None
+    assert not read_file(file)


### PR DESCRIPTION
This PR successfully implements the status key implementation in the framework related to schema change addressed in https://github.com/buildtesters/schemas/pull/24 

The commit message along with comments should explain the logic on how i implemented the test_state (PASS/FAIL) which is used to count the number of pass and failed test.

I have ran three test, one with status check using returncode, one with regex and one using both. 

The three tests were committed to tutorials repo see commit https://github.com/buildtesters/tutorials/commit/5406b84e048557fb2d81b4de0febe847ca862164 

```
(buildtest-framework) ssi29@ag-mxg-hulk090> buildtest build -b system/systemd.yml -b system/selinux.yml  -b apps/openacc/vecadd.yml

            Discovered Buildspecs

/mxg-hpc/users/ssi29/tutorials/apps/openacc/vecadd.yml
/mxg-hpc/users/ssi29/tutorials/system/systemd.yml
/mxg-hpc/users/ssi29/tutorials/system/selinux.yml



Buildspec Name                 SubTest                        Status                         Buildspec Path   
________________________________________________________________________________________________________________________
vecadd                         vecadd_gnu                     PASS                           /mxg-hpc/users/ssi29/tutorials/apps/openacc/vecadd.yml
systemd                        systemd_default_target         PASS                           /mxg-hpc/users/ssi29/tutorials/system/systemd.yml
selinux                        selinux_disable                PASS                           /mxg-hpc/users/ssi29/tutorials/system/selinux.yml


============================================================
                        Test summary
============================================================
Executed 3 tests
Passed Tests: 3/3 Percentage: 100.000%
Failed Tests: 0/3 Percentage: 0.000%
```

Here is a snippet from the logs to give idea whats going on

**selinux.yml** - This one performs both regex and return code check

```
2020-04-22 11:44:32,122 [base.py:535 - run_tests() ] - [DEBUG] Return code: 0 for test: /mxg-hpc/users/ssi29/tutorials/.buildtest/selinux/selinux_disable.sh
2020-04-22 11:44:32,122 [base.py:555 - run_tests() ] - [DEBUG] Conducting Return Code check
2020-04-22 11:44:32,122 [base.py:558 - run_tests() ] - [DEBUG] Status Return Code: 0   Result Return Code: 0
2020-04-22 11:44:32,122 [base.py:567 - run_tests() ] - [DEBUG] Conducting Regular Expression check
2020-04-22 11:44:32,122 [base.py:471 - check_regex() ] - [DEBUG] Detected regex stream 'stdout' so reading output file: /mxg-hpc/users/ssi29/tutorials/.buildtest/selinux/run/selinux_disable_04-22-2020-11-44.out
2020-04-22 11:44:32,123 [base.py:482 - check_regex() ] - [DEBUG] Applying re.search with exp: ^SELINUX=disabled$
2020-04-22 11:44:32,123 [base.py:572 - run_tests() ] - [INFO] ReturnCode Match: True Regex Match: True

```

**systemd.yml** - this performs return code check only

```
2020-04-22 11:44:32,077 [base.py:513 - run_tests() ] - [DEBUG] Running Test via command: /bin/bash /mxg-hpc/users/ssi29/tutorials/.buildtest/systemd/systemd_default_target.sh
2020-04-22 11:44:32,094 [base.py:530 - run_tests() ] - [DEBUG] Writing run output to file: /mxg-hpc/users/ssi29/tutorials/.buildtest/systemd/run/systemd_default_target_04-22-2020-11-44.out
2020-04-22 11:44:32,095 [base.py:534 - run_tests() ] - [DEBUG] Writing run error to file: /mxg-hpc/users/ssi29/tutorials/.buildtest/systemd/run/systemd_default_target_04-22-2020-11-44.err
2020-04-22 11:44:32,095 [base.py:535 - run_tests() ] - [DEBUG] Return code: 0 for test: /mxg-hpc/users/ssi29/tutorials/.buildtest/systemd/systemd_default_target.sh
2020-04-22 11:44:32,095 [base.py:555 - run_tests() ] - [DEBUG] Conducting Return Code check
2020-04-22 11:44:32,095 [base.py:558 - run_tests() ] - [DEBUG] Status Return Code: 0   Result Return Code: 0
2020-04-22 11:44:32,095 [base.py:572 - run_tests() ] - [INFO] ReturnCode Match: True Regex Match: True
2020-04-22 11:44:32,095 [base.py:70 - __init__() ] - [DEBUG] buildtest found the available schema: 
```

**vecadd.yml** - this performs regex check only

```
2020-04-22 11:44:31,692 [base.py:513 - run_tests() ] - [DEBUG] Running Test via command: /bin/bash /mxg-hpc/users/ssi29/tutorials/.buildtest/vecadd/vecadd_gnu.sh
2020-04-22 11:44:32,068 [base.py:530 - run_tests() ] - [DEBUG] Writing run output to file: /mxg-hpc/users/ssi29/tutorials/.buildtest/vecadd/run/vecadd_gnu_04-22-2020-11-44.out
2020-04-22 11:44:32,069 [base.py:534 - run_tests() ] - [DEBUG] Writing run error to file: /mxg-hpc/users/ssi29/tutorials/.buildtest/vecadd/run/vecadd_gnu_04-22-2020-11-44.err
2020-04-22 11:44:32,069 [base.py:535 - run_tests() ] - [DEBUG] Return code: 0 for test: /mxg-hpc/users/ssi29/tutorials/.buildtest/vecadd/vecadd_gnu.sh
2020-04-22 11:44:32,069 [base.py:567 - run_tests() ] - [DEBUG] Conducting Regular Expression check
2020-04-22 11:44:32,069 [base.py:471 - check_regex() ] - [DEBUG] Detected regex stream 'stdout' so reading output file: /mxg-hpc/users/ssi29/tutorials/.buildtest/vecadd/run/vecadd_gnu_04-22-2020-11-44.out
2020-04-22 11:44:32,069 [base.py:482 - check_regex() ] - [DEBUG] Applying re.search with exp: ^final result: 1.000000$
2020-04-22 11:44:32,069 [base.py:572 - run_tests() ] - [INFO] ReturnCode Match: True Regex Match: True

```

Finally, if status is not defined buildtest works as normal, here is an example run without any status check. We are running the test https://github.com/buildtesters/tutorials/blob/master/apps/serial/hello.yml

```
(buildtest-framework) ssi29@ag-mxg-hulk090> buildtest build -b apps/serial/hello.yml

            Discovered Buildspecs

/mxg-hpc/users/ssi29/tutorials/apps/serial/hello.yml



Buildspec Name                 SubTest                        Status                         Buildspec Path   
________________________________________________________________________________________________________________________
hello                          fortan_hello                   PASS                           /mxg-hpc/users/ssi29/tutorials/apps/serial/hello.yml
hello                          c_hello                        PASS                           /mxg-hpc/users/ssi29/tutorials/apps/serial/hello.yml
hello                          cplusplus_hello                PASS                           /mxg-hpc/users/ssi29/tutorials/apps/serial/hello.yml


============================================================
                        Test summary
============================================================
Executed 3 tests
Passed Tests: 3/3 Percentage: 100.000%
Failed Tests: 0/3 Percentage: 0.000%

```

I have tested locally by tweaking returncode and regex to see if PASS/FAIL is working and it was successful. Feel free to test this by cloning the ``tutorials`` repo and set ``WORK`` environment to parent directory where you cloned tutorials and it should work.