### PR TITLE
Refactor BuilderBase to account for changes to shell, shebang key in script schema

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -500,10 +500,8 @@ class BuilderBase:
         os.chdir(self._get_testdir())
         self.logger.debug(f"Changing to directory {self._get_testdir()}")
 
-        # command to run the test
-        cmd = []
         # build the run command that includes the shell path, shell options and path to test file
-        cmd += [self.shell.path, self.shell.opts, testfile]
+        cmd = [self.shell.path, self.shell.opts, testfile]
         self.metadata["command"] = " ".join(cmd)
         self.logger.debug(f"Running Test via command: {self.metadata['command']}")
 

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -281,7 +281,9 @@ class BuilderBase:
 
         # if shell program (bash, sh, python) is not present in system raise an error
         if not shutil.which(self.shell_name):
-            raise BuildTestError(f"Can't find executable {self.shell_name}, please check your $PATH or install the appropriate package")
+            raise BuildTestError(
+                f"Can't find executable {self.shell_name}, please check your $PATH or install the appropriate package"
+            )
 
         self.shebang = self.recipe.get("shebang")
 

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -339,16 +339,16 @@ class BuilderBase:
         shell = self.shell.name
 
         # Parse environment depending on expected shell
-        # if pairs:
+        if pairs:
 
-        # Handles bash and sh
-        if re.search("(bash|sh)$", shell):
-            [env.append("%s=%s" % (k, v)) for k, v in pairs.items()]
+            # Handles bash and sh
+            if re.search("(bash|sh)$", shell):
+                [env.append("%s=%s" % (k, v)) for k, v in pairs.items()]
 
-        else:
-            self.logger.warning(
-                f"{shell} is not supported, skipping environment variables."
-            )
+            else:
+                self.logger.warning(
+                    f"{shell} is not supported, skipping environment variables."
+                )
 
         return env
 
@@ -396,6 +396,7 @@ class BuilderBase:
             if known_section in self.recipe:
                 self.metadata[known_section] = self.recipe.get(known_section)
 
+        self.metadata["shell"] = self.shell.name
         # Derive the path to the test script
         self.metadata["testpath"] = "%s.%s" % (
             os.path.join(self.testdir, self.name),

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -25,6 +25,7 @@ from buildtest.defaults import (
     build_sections,
     variable_sections,
 )
+from buildtest.exceptions import BuildTestError
 from buildtest.utils.command import BuildTestCommand
 from buildtest.utils.file import create_dir, is_dir, resolve_path, read_file, write_file
 
@@ -278,7 +279,12 @@ class BuilderBase:
         self.shell_name = self.shell.split()[0]
         self.shell_opts = self.shell.split()[1:]
 
+        # if shell program (bash, sh, python) is not present in system raise an error
+        if not shutil.which(self.shell_name):
+            raise BuildTestError(f"Can't find executable {self.shell_name}, please check your $PATH or install the appropriate package")
+
         self.shebang = self.recipe.get("shebang")
+
         # if shebang is not found in recipe let's set it to #!/bin/bash
         if not self.shebang:
             # when shell: python we set shebang to location of 'python' wrapper

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -508,7 +508,7 @@ class BuilderBase:
         cmd += [self.shell["path"], self.shell["opts"], testfile]
         self.metadata["command"] = " ".join(cmd)
         self.logger.debug(f"Running Test via command: {self.metadata['command']}")
-        
+
         command = BuildTestCommand(self.metadata["command"])
         out, err = command.execute()
 

--- a/buildtest/buildsystem/schemas/script/script-v0.0.1.schema.json
+++ b/buildtest/buildsystem/schemas/script/script-v0.0.1.schema.json
@@ -41,9 +41,9 @@
     },
     "shell": {
       "type": "string",
-      "default": "bash",
-      "description": "The shell interpreter to use."
+      "pattern": "^(/bin/bash|/bin/sh|sh|bash|python).*"
     },
+    "shebang": { "type": "string" },
     "pre_run": {
       "type": "string",
       "description": "A script run before the default run using the default shell."

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -189,12 +189,13 @@ def func_build_subcmd(args):
 
     # Load BuildExecutors
     executor = BuildExecutor(config_opts, default=args.executor)
-    print(
-        "{:<30} {:<30} {:<30} {:<30}".format(
-            "Buildspec Name", "SubTest", "Status", "Buildspec Path"
+    if not args.dry:
+        print(
+            "{:<30} {:<30} {:<30} {:<30}".format(
+                "Buildspec Name", "SubTest", "Status", "Buildspec Path"
+            )
         )
-    )
-    print("{:_<120}".format(""))
+        print("{:_<120}".format(""))
     # Process each Buildspec iteratively by parsing using BuildspecParser followed by
     # getting the appropriate builder and invoking the executor instance of type BuildExecutor
     # to run the test
@@ -208,6 +209,7 @@ def func_build_subcmd(args):
 
             # Keep track of total number of tests run
             total_tests += 1
+
             if not args.dry:
                 result = executor.run(builder)
 

--- a/buildtest/utils/command.py
+++ b/buildtest/utils/command.py
@@ -16,7 +16,7 @@ class Capturing:
 
        with Capturing() as capture:
            process = subprocess.Popen(...)
-           
+
 
        And then the output and error are retrieved from reading the files:
        and exposed as properties to the client:

--- a/buildtest/utils/shell.py
+++ b/buildtest/utils/shell.py
@@ -3,7 +3,7 @@ from buildtest.exceptions import BuildTestError
 
 
 class Shell:
-    def __init__(self, shell):
+    def __init__(self, shell="bash"):
         """ The Shell initializer takes an input shell and shell options and split
             string by shell name and options.
 
@@ -22,11 +22,18 @@ class Shell:
         self.name = shell.split()[0]
         self.opts = " ".join(shell.split()[1:])
 
+        path = shutil.which(self.name)
+
+        # raise an exception if shell program is not found
+        if not path:
+            raise BuildTestError(f"Can't find program: {self.name}")
+
     def opts(self, shell_opts):
         """Override the shell options in class attribute, this would be useful
            when shell options need to change due to change in shell program."""
 
         self.opts = shell_opts
+        return self.opts
 
     @property
     def path(self):

--- a/buildtest/utils/shell.py
+++ b/buildtest/utils/shell.py
@@ -20,20 +20,22 @@ class Shell:
             )
 
         self.name = shell.split()[0]
-        self.opts = " ".join(shell.split()[1:])
+        self._opts = " ".join(shell.split()[1:])
+        self.path = self.name
 
-        path = shutil.which(self.name)
+    @property
+    def opts(self):
+        """retrieve the shell opts that are set on init, and updated with setter
+        """
+        return self._opts
 
-        # raise an exception if shell program is not found
-        if not path:
-            raise BuildTestError(f"Can't find program: {self.name}")
-
+    @opts.setter
     def opts(self, shell_opts):
         """Override the shell options in class attribute, this would be useful
-           when shell options need to change due to change in shell program."""
-
-        self.opts = shell_opts
-        return self.opts
+           when shell options need to change due to change in shell program.
+        """
+        self._opts = shell_opts
+        return self._opts
 
     @property
     def path(self):
@@ -52,23 +54,38 @@ class Shell:
            '/usr/bin/sh'
 
         """
+        return self._path
 
-        path = shutil.which(self.name)
+    # Identity functions
+    def __str__(self):
+        return "[buildtest.shell][%s]" % self.name
+
+    def __repr__(self):
+        return self.__str__()
+
+    @path.setter
+    def path(self, name):
+        """If the user provides a new path with a name, do same checks to 
+           ensure that it's found.
+        """
+        path = shutil.which(name)
 
         # raise an exception if shell program is not found
         if not path:
-            raise BuildTestError(f"Can't find program: {self.name}")
+            raise BuildTestError(f"Can't find program: {name}")
+
+        # Update the name not that we are sure path is found
+        self.name = name
+        self._path = path
 
         # shebang is formed by adding the char '#!' with path to program
         self.shebang = f"#!{path}"
-        return path
 
     def get(self):
         """Return shell attributes as a dictionary"""
-
-        self.shell = {}
-        self.shell["name"] = self.name
-        self.shell["opts"] = self.opts
-        self.shell["path"] = self.path
-        self.shell["shebang"] = self.shebang
-        return self.shell
+        return {
+            "name": self.name,
+            "opts": self._opts,
+            "path": self._path,
+            "shebang": self.shebang,
+        }

--- a/buildtest/utils/shell.py
+++ b/buildtest/utils/shell.py
@@ -1,0 +1,67 @@
+import shutil
+from buildtest.exceptions import BuildTestError
+
+
+class Shell:
+    def __init__(self, shell):
+        """ The Shell initializer takes an input shell and shell options and split
+            string by shell name and options.
+
+            Parameters:
+
+            :param shell: specify shell program and any options passed to shell
+            :type shell: str
+        """
+
+        # enforce input argument 'shell' to be a string
+        if not isinstance(shell, str):
+            raise BuildTestError(
+                f"Invalid type for input: {shell} must be of type 'str'"
+            )
+
+        self.name = shell.split()[0]
+        self.opts = " ".join(shell.split()[1:])
+
+    def opts(self, shell_opts):
+        """Override the shell options in class attribute, this would be useful
+           when shell options need to change due to change in shell program."""
+
+        self.opts = shell_opts
+
+    @property
+    def path(self):
+        """This method returns the full path to shell program using ``shutil.which()``
+           If shell program is not found we raise an exception. The shebang is
+           is updated assuming path is valid which is just adding character '#!'
+           in front of path. The return is full path to shell program. This method
+           automatically updates the shell path when there is a change in attribute
+           self.name
+
+           >>> shell = Shell("bash")
+           >>> shell.path
+           '/usr/bin/bash'
+           >>> shell.name="sh"
+           >>> shell.path
+           '/usr/bin/sh'
+
+        """
+
+        path = shutil.which(self.name)
+
+        # raise an exception if shell program is not found
+        if not path:
+            raise BuildTestError(f"Can't find program: {self.name}")
+
+        # shebang is formed by adding the char '#!' with path to program
+        self.shebang = f"#!{path}"
+        return path
+
+    def get(self):
+        """Return shell attributes as a dictionary"""
+
+        self.shell = {}
+        self.shell["name"] = self.name
+        self.shell["opts"] = self.opts
+        self.shell["path"] = self.path
+        self.shell["shebang"] = self.shebang
+        return self.shell

--- a/examples/script/python-circle.yml
+++ b/examples/script/python-circle.yml
@@ -2,13 +2,13 @@ version: 0.0.1
 
 circle_area:
   type: script
-  shell: python
+  shell: python -v
   description: "Calculate circle of area given a radius"
+  env:
+    foo: bar
   run: | 
     import math
     radius = 2
     area = math.pi * radius * radius
     print("Circle Radius ", radius)
     print("Area of circle ", area)
-    if True:
-        print("Block")

--- a/examples/script/python-circle.yml
+++ b/examples/script/python-circle.yml
@@ -2,10 +2,8 @@ version: 0.0.1
 
 circle_area:
   type: script
-  shell: python -v
+  shell: python 
   description: "Calculate circle of area given a radius"
-  env:
-    foo: bar
   run: | 
     import math
     radius = 2

--- a/tests/utils/test_shell.py
+++ b/tests/utils/test_shell.py
@@ -1,0 +1,64 @@
+import pytest
+import shutil
+from buildtest.exceptions import BuildTestError
+from buildtest.utils.shell import Shell
+
+
+def test_default_shell():
+    # creating a Shell object with no argument will result in bash shell
+
+    shell = Shell()
+    # checking if shell.name is bash
+    assert shell.name == "bash"
+    # check shell.path and shebang is full path to bash reported by shutil.which
+    assert shell.path == shutil.which("bash")
+    assert shell.shebang == f"#!{shutil.which('bash')}"
+
+
+def test_sh_shell():
+    # create a sh shell
+    shell = Shell("sh")
+    assert shell.name == "sh"
+
+    # pass shell options to shell
+    shell = Shell("sh -x")
+    assert shell.name == "sh"
+    assert shell.opts == "-x"
+
+
+def test_update_instance():
+
+    # create a sh shell
+    shell = Shell("sh")
+    assert shell.name == "sh"
+    # check shell.path and shebang is full path to bash reported by shutil.which
+    assert shell.path == shutil.which("sh")
+    assert shell.shebang == f"#!{shutil.which('sh')}"
+
+    # update attributes 'name' and 'path' in instance object
+    shell.name = "python"
+    shell.path = shutil.which("python")
+
+    # check instance attribute match from ones reported from get method
+    assert shell.get()["name"] == shell.name
+    assert shell.get()["path"] == shell.path
+
+    # update shell opts and check value reported by get method
+    shell.opts = ["-v"]
+    assert shell.get()["opts"] == shell.opts
+
+
+def test_shell_exceptions(tmp_path):
+    # Shell will raise an error if program is not found
+    with pytest.raises(BuildTestError) as einfo:
+        Shell("xyz")
+
+    # input argument to Shell must be a string, any other value will raise an exception
+    with pytest.raises(BuildTestError) as einfo:
+        Shell(["sh"])
+
+    shell = Shell()
+    # update shell.path to invalid program will raise an error. In this case we use tmp_path to set a random filepath
+    # to shell.path and we expect Shell to raise an exception of type BuildTestError
+    with pytest.raises(BuildTestError) as einfo:
+        shell.path = tmp_path


### PR DESCRIPTION
sync script schema from https://github.com/buildtesters/schemas/blob/master/script/script-v0.0.1.schema.json
modify implementation on shell detection, environment variable, and the
command to execute the test. We can now support passing shell options on
the command line. The shebang can be customized via 'shebang' key if
it's not found it will use the default shebang based on shell type. If
it's python it will resort to path of 'python' wrapper.
When running in dry mode we were getting output header of table of
results that were not suppose to show up.
Add more log details for BuilderBase