### PR TITLE
catch exception when failed to read or write fail due to IOError.

### DIFF
--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -176,7 +176,7 @@ def read_file(filepath):
         with open(filepath, "r") as fd:
             content = fd.read()
     except IOError as err:
-        raise BuildTestError("Failed to read: %s: %s", filepath, err)
+        raise BuildTestError("Failed to read: %s: %s" % (filepath, err))
 
     return content
 
@@ -214,7 +214,7 @@ def write_file(filepath, content):
         return None
 
     try:
-        with open(filepath, "r") as fd:
-            content = fd.write()
+        with open(filepath, "w") as fd:
+            fd.write(content)
     except IOError as err:
-        raise BuildTestError("Failed to write: %s: %s", filepath, err)
+        raise BuildTestError(f"Failed to write: {filepath}: {err}")

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -11,6 +11,7 @@ include the following:
 import os
 import logging
 import sys
+from buildtest.exceptions import BuildTestError
 
 logger = logging.getLogger(__name__)
 
@@ -171,9 +172,11 @@ def read_file(filepath):
         sys.exit(
             f"Unable to find input file: {input_file}. Please specify a valid file"
         )
-
-    with open(filepath, "r") as fd:
-        content = fd.read()
+    try:
+        with open(filepath, "r") as fd:
+            content = fd.read()
+    except IOError as err:
+        raise BuildTestError("Failed to read: %s: %s", filepath, err)
 
     return content
 
@@ -210,5 +213,8 @@ def write_file(filepath, content):
     if not isinstance(content, str):
         return None
 
-    with open(filepath, "w") as fd:
-        fd.write(content)
+    try:
+        with open(filepath, "r") as fd:
+            content = fd.write()
+    except IOError as err:
+        raise BuildTestError("Failed to write: %s: %s", filepath, err)

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -93,7 +93,7 @@ def test_write_file(tmp_path):
     multi-line
     string"""
 
-    file = os.path.join(tmp_path, "test.txt")
+    file = os.path.join(tmp_path, "test_write.txt")
 
     print(f"Writing content to file: {file}")
     write_file(file, input)
@@ -125,6 +125,11 @@ def test_write_file_exceptions(tmp_path):
         print(f"Passing directory: {tmp_path} as input filestream to write_file")
         write_file(tmp_path, input)
 
+    print("Writing to '/etc/shadow' will raise an exception BuildTestError")
+    # writing to /etc/shadow will raise an error during write since /etc/shadow will result in Permission Error
+    with pytest.raises(BuildTestError) as e_info:
+        write_file("/etc/shadow", input)
+
     # input content must be a string, will return None upon
     assert not write_file(os.path.join(tmp_path, "null.txt"), ["hi"])
 
@@ -144,3 +149,8 @@ def test_read_file(tmp_path):
     # checking invalid file should report an error
     with pytest.raises(SystemExit) as e_info:
         read_file(file)
+
+    print("Reading '/etc/shadow' will raise an exception BuildTestError")
+    # reading /etc/shadow will raise a Permission error so we catch this exception BuildTestError
+    with pytest.raises(BuildTestError) as e_info:
+        read_file("/etc/shadow")


### PR DESCRIPTION
This can be catched if you read or write to /etc/shadow which is not
allowed by any users

This address #291 

Read Exception
-------------------

```
>>> read_file("/etc/shadow")
Traceback (most recent call last):
  File "/mxg-hpc/users/ssi29/buildtest/buildtest/utils/file.py", line 176, in read_file
    with open(filepath, "r") as fd:
PermissionError: [Errno 13] Permission denied: '/etc/shadow'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mxg-hpc/users/ssi29/buildtest/buildtest/utils/file.py", line 179, in read_file
    raise BuildTestError("Failed to read: %s: %s", filepath, err)
buildtest.exceptions.BuildTestError: "Failed to read: /etc/shadow: [Errno 13] Permission denied: '/etc/shadow'"
```

Write Exception
--------------------

```
>>> write_file("/etc/shadow","hi")
Traceback (most recent call last):
  File "/mxg-hpc/users/ssi29/buildtest/buildtest/utils/file.py", line 217, in write_file
    with open(filepath, "r") as fd:
PermissionError: [Errno 13] Permission denied: '/etc/shadow'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mxg-hpc/users/ssi29/buildtest/buildtest/utils/file.py", line 220, in write_file
    raise BuildTestError("Failed to write: %s: %s", filepath, err)
buildtest.exceptions.BuildTestError: "Failed to write: /etc/shadow: [Errno 13] Permission denied: '/etc/shadow'"

```