### PR TITLE
Sync schemas and add support for viewing global schema

### DIFF
--- a/buildtest/buildsystem/schemas/global.schema.json
+++ b/buildtest/buildsystem/schemas/global.schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://buildtesters.github.io/schemas/global/global.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "BuildTest Wrapper for Test Configurations",
+  "title": "buildtest Global Schema",
   "type": "object",
   "required": ["version"],
   "propertyNames": {
@@ -11,11 +11,19 @@
     "version": {
       "type": "string",
       "description": "The semver version of the schema to use (x.x.x)."
+      },
+    "maintainers": {
+      "type": "array",
+      "description": "One or more maintainers or aliases",
+      "minItems": 1,
+      "items": {
+        "type": "string"
       }
-    },
-    "patternProperties": {
-      "^[A-Za-z_.][A-Za-z0-9_]*$": {
-         "type": ["object", "string"]
-       }
     }
+  },
+  "patternProperties": {
+    "^[A-Za-z_.][A-Za-z0-9_]*$": {
+       "type": ["object", "string"]
+     }
+  }
 }

--- a/buildtest/buildsystem/schemas/script/script-v0.0.1.schema.json
+++ b/buildtest/buildsystem/schemas/script/script-v0.0.1.schema.json
@@ -16,14 +16,6 @@
       "type": "string",
       "description": "A description for the build recipe."
     },
-    "maintainers": {
-      "type": "array",
-      "description": "One or more maintainers or aliases",
-      "minItems": 1,
-      "items": {
-        "type": "string"
-      }
-    },
     "env": {
       "type": "object",
       "description": "One or more key value pairs for an environment (key=value)",
@@ -44,17 +36,9 @@
       "pattern": "^(/bin/bash|/bin/sh|sh|bash|python).*"
     },
     "shebang": { "type": "string" },
-    "pre_run": {
-      "type": "string",
-      "description": "A script run before the default run using the default shell."
-    },
     "run": {
       "type": "string",
       "description": "A script to run using the default shell."
-    },
-    "post_run": {
-      "type": "string",
-      "description": "A script run after the default run using the default shell."
     },
     "status": {
       "type": "object",

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -189,11 +189,10 @@ class BuildTestParser:
             help="show schema by name (e.g., script)",
             choices=supported_schemas,
         )
-        # can't use attribute args.global so setting dest=main for argparse
         parser_schema.add_argument(
             "-g",
             "--global",
-            dest="main",
+            dest="_global",
             help="show global schema",
             action="store_true",
         )

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -6,6 +6,7 @@ interact with a global configuration for buildtest.
 import argparse
 
 from buildtest import BUILDTEST_VERSION
+from buildtest.defaults import supported_schemas
 from buildtest.menu.build import func_build_subcmd
 from buildtest.menu.get import func_get_subcmd
 from buildtest.menu.config import (
@@ -183,6 +184,17 @@ class BuildTestParser:
             "-v", "--version", help="choose a specific version of schema to show.",
         )
         parser_schema.add_argument(
-            "-n", "--name", help="show schema by name (e.g., script)",
+            "-n",
+            "--name",
+            help="show schema by name (e.g., script)",
+            choices=supported_schemas,
+        )
+        # can't use attribute args.global so setting dest=main for argparse
+        parser_schema.add_argument(
+            "-g",
+            "--global",
+            dest="main",
+            help="show global schema",
+            action="store_true",
         )
         parser_schema.set_defaults(func=show_schema_layout)

--- a/buildtest/menu/show.py
+++ b/buildtest/menu/show.py
@@ -1,28 +1,38 @@
 import json
-import sys
+import os
 
-from buildtest.defaults import supported_schemas
 from buildtest.buildsystem.schemas.utils import (
     load_schema,
     get_schemas_available,
     get_schema_fullpath,
+    here,
 )
 
 
 def show_schema_layout(args):
-    """Implements method ``buildtest show schema``"""
+    """This method implements command ``buildtest show schema`` which displays json schemas
+       supported by buildtest. The input ``args`` is an instance of argparse class that contains
+       user selection via command line. The method can display the global schema when
+       ``buildtest show schema --global`` is specified or any name schema via
+       ``buildtest show schema --name <NAME>``. The result is an output of the json schema on the console.
 
-    # buildtest show schema --name script
-    if args.name is None:
-        sys.exit("Please provide the name of a schema (e.g., script) to show.")
+       Parameters:
 
-    # Must be supported
-    if args.name not in supported_schemas:
-        sys.exit(
-            "%s is not a supported schema. Options include %s"
-            % (args.name, "\n".join(supported_schemas))
-        )
+       :param args: instance of argparse class
+       :type args: <class 'argparse.Namespace'>
+       :result: output of json schema on console
+    """
 
+    # implements ``buildtest show schema --global``. Since we can't use args.global we set this to main
+    if args.main:
+        global_schema = os.path.join(here, "global.schema.json")
+        # check if file exists
+        assert global_schema
+        recipe = load_schema(global_schema)
+        print(json.dumps(recipe, indent=2))
+        return
+
+    # section below implements ``buildtest show schema --name``
     schema = get_schemas_available()[args.name]
     version = args.version or "latest"
 
@@ -31,4 +41,4 @@ def show_schema_layout(args):
 
     schema = get_schema_fullpath(schema.get(version, schema.get("latest")))
     schema = load_schema(schema)
-    print(json.dumps(schema, indent=4))
+    print(json.dumps(schema, indent=2))

--- a/buildtest/menu/show.py
+++ b/buildtest/menu/show.py
@@ -23,22 +23,18 @@ def show_schema_layout(args):
        :result: output of json schema on console
     """
 
-    # implements ``buildtest show schema --global``. Since we can't use args.global we set this to main
-    if args.main:
-        global_schema = os.path.join(here, "global.schema.json")
-        # check if file exists
-        assert global_schema
-        recipe = load_schema(global_schema)
-        print(json.dumps(recipe, indent=2))
-        return
+    # implements buildtest show schema --global
+    if args._global:
+        schema = os.path.join(here, "global.schema.json")
+    # implements buildtest show schema --name
+    elif args.name:
+        schema = get_schemas_available()[args.name]
+        version = args.version or "latest"
 
-    # section below implements ``buildtest show schema --name``
-    schema = get_schemas_available()[args.name]
-    version = args.version or "latest"
+        if version not in schema:
+            print("Warning, %s is not a known version, showing latest." % version)
 
-    if version not in schema:
-        print("Warning, %s is not a known version, showing latest." % version)
+        schema = get_schema_fullpath(schema.get(version, schema.get("latest")))
 
-    schema = get_schema_fullpath(schema.get(version, schema.get("latest")))
-    schema = load_schema(schema)
-    print(json.dumps(schema, indent=2))
+    recipe = load_schema(schema)
+    print(json.dumps(recipe, indent=2))

--- a/tests/menu/test_show.py
+++ b/tests/menu/test_show.py
@@ -2,20 +2,20 @@ from buildtest.menu.show import show_schema_layout
 
 
 class script_schema:
-    main = False
+    _global = False
     name = "script"
     version = "latest"
 
 
 class script_mismatch_version_schema:
-    main = False
+    _global = False
     name = "script"
     # invalid version for script schema this should resort to latest schema
     version = "99.99"
 
 
 class global_schema:
-    main = True
+    _global = True
     name = None
     version = None
 

--- a/tests/menu/test_show.py
+++ b/tests/menu/test_show.py
@@ -1,9 +1,27 @@
 from buildtest.menu.show import show_schema_layout
 
 
-def test_show_schema():
-    class args:
-        name = "script"
-        version = "latest"
+class script_schema:
+    main = False
+    name = "script"
+    version = "latest"
 
-    show_schema_layout(args)
+
+class script_mismatch_version_schema:
+    main = False
+    name = "script"
+    # invalid version for script schema this should resort to latest schema
+    version = "99.99"
+
+
+class global_schema:
+    main = True
+    name = None
+    version = None
+
+
+def test_show_schema():
+
+    show_schema_layout(script_schema)
+    show_schema_layout(global_schema)
+    show_schema_layout(script_mismatch_version_schema)


### PR DESCRIPTION
This PR is adding the following support
- Sync global and script schema 
- Option ``buildtest show schema --global`` to view the global schema. I figure this would be special schema since it doesn't have version and up a directory as pose to script schema
- Set --name to use choices field that allows argparse to handle to input choice which makes sense to me.
- Lastly we increase coverage to 100% for buildtest/menu/show.py
 