### PR TITLE
first attempt at implementing compiler schema in Buildtest

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -787,7 +787,7 @@ class CompilerBuilder(BuilderBase):
         """
 
         if workdir:
-            return [os.path.join(workdir / self.executable)]
+            return [os.path.join(workdir, self.executable)]
 
         return [f"./{self.executable}"]
 
@@ -799,7 +799,7 @@ class CompilerBuilder(BuilderBase):
         return run
 
     def build_run_cmd(self, args):
-
+        """This method builds the run command which refers to how to run the generated binary after compilation."""
         if args:
             return self.run_with_args(args)
 
@@ -845,7 +845,6 @@ class CompilerBuilder(BuilderBase):
            a list that contains content of the test.
         """
 
-        self.compiler_setup()
         self.setup()
 
         # every test starts with shebang line

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -194,7 +194,7 @@ class BuildspecParser:
                         )
                     elif recipe["compiler"].get("name") == "cray":
                         builders.append(
-                            GNUCompiler(name, recipe, self.buildspec, testdir=testdir)
+                            CrayCompiler(name, recipe, self.buildspec, testdir=testdir)
                         )
                     else:
                         continue

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -787,7 +787,7 @@ class CompilerBuilder(BuilderBase):
         """
 
         if workdir:
-            return [f"{workdir}/{self.executable}"]
+            return [os.path.join(workdir / self.executable)]
 
         return [f"./{self.executable}"]
 

--- a/buildtest/buildsystem/schemas/compiler/compiler-v0.0.1.schema.json
+++ b/buildtest/buildsystem/schemas/compiler/compiler-v0.0.1.schema.json
@@ -25,11 +25,15 @@
       "properties": {
         "source": { "type": "string" },
         "gnu": { "$ref": "#/definitions/compiler" },
-        "intel": { "$ref": "#/definitions/compiler" }
+        "intel": { "$ref": "#/definitions/compiler" },
+        "pgi": { "$ref": "#/definitions/compiler" },
+        "cray": { "$ref": "#/definitions/compiler" }
       },
       "oneOf": [
         { "required": ["source","gnu"] },
-        { "required": ["source","intel"] }
+        { "required": ["source","intel"] },
+        { "required": ["source","pgi"] },
+        { "required": ["source","cray"] }
       ],
       "additionalProperties": false
     }

--- a/buildtest/buildsystem/schemas/compiler/compiler-v0.0.1.schema.json
+++ b/buildtest/buildsystem/schemas/compiler/compiler-v0.0.1.schema.json
@@ -1,0 +1,50 @@
+{
+  "$id": "https://buildtesters.github.io/schemas/compiler/compiler-v0.0.1.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BuildTest Schema for compiler",
+  "type": "object",
+  "required": ["type", "compiler"],
+  "propertyNames": {
+    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+  },
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "pattern": "^compiler$"
+    },
+    "description": {
+      "type": "string"
+    },
+    "module": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "compiler": {
+      "type": "object",
+      "properties": {
+        "source": { "type": "string" },
+        "gnu": { "$ref": "#/definitions/compiler" },
+        "intel": { "$ref": "#/definitions/compiler" }
+      },
+      "oneOf": [
+        { "required": ["source","gnu"] },
+        { "required": ["source","intel"] }
+      ],
+      "additionalProperties": false
+    }
+  },
+  "definitions": {
+    "compiler": {
+      "type": "object",
+      "properties": {
+        "cflags": {"type":  "string"},
+        "cxxflags": {"type":  "string"},
+        "fflags": {"type":  "string"},
+        "cppflags": {"type":  "string"},
+        "ldflags": {"type": "string"},
+        "exec_args": {"type": "string"}
+      }
+    }
+  }
+}

--- a/buildtest/buildsystem/schemas/compiler/compiler-v0.0.1.schema.json
+++ b/buildtest/buildsystem/schemas/compiler/compiler-v0.0.1.schema.json
@@ -23,19 +23,19 @@
     "compiler": {
       "type": "object",
       "properties": {
+        "name": {
+          "type": "string",
+          "enum": ["gnu", "intel", "pgi", "cray"]
+        },
         "source": { "type": "string" },
         "exec_args": {"type": "string"},
-        "gnu": { "$ref": "#/definitions/compiler" },
-        "intel": { "$ref": "#/definitions/compiler" },
-        "pgi": { "$ref": "#/definitions/compiler" },
-        "cray": { "$ref": "#/definitions/compiler" }
+        "cflags": {"type":  "string"},
+        "cxxflags": {"type":  "string"},
+        "fflags": {"type":  "string"},
+        "cppflags": {"type":  "string"},
+        "ldflags": {"type": "string"}
       },
-      "oneOf": [
-        { "required": ["source","gnu"] },
-        { "required": ["source","intel"] },
-        { "required": ["source","pgi"] },
-        { "required": ["source","cray"] }
-      ],
+      "required": ["source", "name"],
       "additionalProperties": false
     }
   },

--- a/buildtest/buildsystem/schemas/compiler/compiler-v0.0.1.schema.json
+++ b/buildtest/buildsystem/schemas/compiler/compiler-v0.0.1.schema.json
@@ -38,17 +38,5 @@
       "required": ["source", "name"],
       "additionalProperties": false
     }
-  },
-  "definitions": {
-    "compiler": {
-      "type": "object",
-      "properties": {
-        "cflags": {"type":  "string"},
-        "cxxflags": {"type":  "string"},
-        "fflags": {"type":  "string"},
-        "cppflags": {"type":  "string"},
-        "ldflags": {"type": "string"}
-      }
-    }
   }
 }

--- a/buildtest/buildsystem/schemas/compiler/compiler-v0.0.1.schema.json
+++ b/buildtest/buildsystem/schemas/compiler/compiler-v0.0.1.schema.json
@@ -24,6 +24,7 @@
       "type": "object",
       "properties": {
         "source": { "type": "string" },
+        "exec_args": {"type": "string"},
         "gnu": { "$ref": "#/definitions/compiler" },
         "intel": { "$ref": "#/definitions/compiler" },
         "pgi": { "$ref": "#/definitions/compiler" },
@@ -46,8 +47,7 @@
         "cxxflags": {"type":  "string"},
         "fflags": {"type":  "string"},
         "cppflags": {"type":  "string"},
-        "ldflags": {"type": "string"},
-        "exec_args": {"type": "string"}
+        "ldflags": {"type": "string"}
       }
     }
   }

--- a/buildtest/buildsystem/schemas/global.schema.json
+++ b/buildtest/buildsystem/schemas/global.schema.json
@@ -23,7 +23,7 @@
   },
   "patternProperties": {
     "^[A-Za-z_.][A-Za-z0-9_]*$": {
-       "type": ["object", "string"]
+       "type": ["object", "string", "array"]
      }
   }
 }

--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -9,7 +9,7 @@ import os
 logID = "buildtest"
 
 # each has a subfolder in buildtest/buildsystem/schemas/ with *.schema.json
-supported_schemas = ["script"]
+supported_schemas = ["script", "compiler"]
 
 # Get user home based on effective uid, root of install to copy files
 userhome = pwd.getpwuid(os.getuid())[5]

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -31,7 +31,7 @@ class BuildTestSystem:
         self.scheduler = self.check_scheduler()
         self.check_lmod()
 
-        if self.system["platform"] != "Linux":
+        if self.system["platform"] not in ["Linux", "Darwin"]:
             print("System must be Linux")
             sys.exit(1)
 


### PR DESCRIPTION
This PR does the following
- Added class CompilerBuilder which is a subclass of BuilderBase that implements the compiler schema.
 - Add support for viewing compiler schema via 'buildtest show schema'
 - Modify global schema since we ran into validation error when specifying maintainer key. This was due to expected type.
 - Add compiler schema to buildtest with some additional key's including ``cxxflags``, ``fflags``, ``cppflags`` ``exec_args``