### PR TITLE
fix path to git clone when using ssh

### DIFF
--- a/buildtest/menu/get.py
+++ b/buildtest/menu/get.py
@@ -33,9 +33,14 @@ def func_get_subcmd(args):
     root = os.path.join(BUILDSPEC_DEFAULT_PATH, "github.com")
     create_dir(root)
 
-    # Parse the repository name
+    # Parse the repository name assumes it is using HTTPS in format https://github.com/<username>/<repo>.git
     username = args.repo.split("/")[-2]
-    repo = args.repo.split("/")[-1]
+
+    # resolve url when its using SSH in format git@github.com:<username>/<repo>
+    if re.search("^(git@github.com)", args.repo):
+        url = args.repo.split(":")[1]
+        username = url.split("/")[0]
+
     clone_path = os.path.join(root, username)
     create_dir(clone_path)
 

--- a/tests/menu/test_get.py
+++ b/tests/menu/test_get.py
@@ -1,11 +1,28 @@
 import pytest
+import os
 import shutil
-from buildtest.menu.get import clone
+
+from buildtest.defaults import BUILDSPEC_DEFAULT_PATH
+from buildtest.menu.get import clone, func_get_subcmd
 from buildtest.utils.file import is_dir, create_dir
+
+
+class none_repo:
+    repo = None
+
+
+class only_github_repo:
+    repo = "https://gitlab.com/gitlab-org/gitlab.git"
+
+
+class ssh_repo:
+    repo = "git@github.com:buildtesters/buildtest-stampede2.git"
+    branch = "master"
 
 
 def test_clone(tmp_path):
     repo = "https://github.com/buildtesters/tutorials.git"
+    http_link = "http://github.com/buildtesters/buildtest-cori"
 
     assert is_dir(clone(repo, tmp_path))
 
@@ -17,3 +34,24 @@ def test_clone(tmp_path):
     # will fail to clone if invalid branch is specified
     with pytest.raises(SystemExit) as e_info:
         clone(repo, tmp_path, "develop")
+
+    # check if repo is None, this raises error
+    with pytest.raises(SystemExit) as e_info:
+        func_get_subcmd(none_repo)
+
+    # currently we support fetching github repos, so testing a gitlab repo
+    with pytest.raises(SystemExit) as e_info:
+        func_get_subcmd(only_github_repo)
+
+    # test http link
+    clone(http_link, tmp_path, "master")
+
+    # test ssh repo
+    func_get_subcmd(ssh_repo)
+    url = ssh_repo.repo.split(":")[1]
+    username = url.split("/")[0]
+    repo = ssh_repo.repo.split("/")[-1]
+    repo_path = os.path.join(BUILDSPEC_DEFAULT_PATH, "github.com", username, repo)
+    repo_path = os.path.basename(repo_path).replace(".git", "")
+    print(f"Checking repo destination path {repo_path}")
+    assert repo_path

--- a/tests/menu/test_get.py
+++ b/tests/menu/test_get.py
@@ -4,7 +4,7 @@ import shutil
 
 from buildtest.defaults import BUILDSPEC_DEFAULT_PATH
 from buildtest.menu.get import clone, func_get_subcmd
-from buildtest.utils.file import is_dir, create_dir
+from buildtest.utils.file import is_dir
 
 
 class none_repo:
@@ -46,6 +46,12 @@ def test_clone(tmp_path):
     # test http link
     clone(http_link, tmp_path, "master")
 
+
+@pytest.mark.skipif(
+    "TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
+    reason="Skipping Travis Test",
+)
+def test_ssh_clone():
     # test ssh repo
     func_get_subcmd(ssh_repo)
     url = ssh_repo.repo.split(":")[1]


### PR DESCRIPTION
Address bug #293 

```
(buildtest) siddiq90@DOE-7086392 buildtest % buildtest get git@github.com:buildtesters/tutorials.git
Cloning into '/Users/siddiq90/.buildtest/site/github.com/buildtesters/tutorials'...
remote: Enumerating objects: 106, done.
remote: Counting objects: 100% (106/106), done.
remote: Compressing objects: 100% (73/73), done.
remote: Total 106 (delta 32), reused 97 (delta 25), pack-reused 0
Receiving objects: 100% (106/106), 20.97 KiB | 3.00 MiB/s, done.
Resolving deltas: 100% (32/32), done.
```