### PR TITLE
move run implementation from BuilderBase to LocalExecutor

### DIFF
--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -1,9 +1,15 @@
 """
 BuildExecutor: manager for test executors
 """
-
+import datetime
 import logging
+import os
+import re
 import sys
+
+from buildtest.defaults import BUILDTEST_SETTINGS_FILE
+from buildtest.utils.file import write_file, read_file
+from buildtest.utils.command import BuildTestCommand
 
 
 class BuildExecutor:
@@ -16,7 +22,7 @@ class BuildExecutor:
        provided, we use reasonable defaults.
     """
 
-    def __init__(self, config_opts, default=None):
+    def __init__(self, config_opts):
         """initiate executors, meaning that we provide the config_opts
            that are validated, and can instantiate each executor to be available
 
@@ -24,9 +30,6 @@ class BuildExecutor:
 
            :param config_opts: the validated config opts provided by buildtest.
            :type config_opts: dictionary, required
-           :param default: the name of the default executor. If not set (or undefined)
-           we fall back to buildtest defaults (see set_default).
-           :type default: str, optional
         """
 
         self.executors = {}
@@ -48,8 +51,6 @@ class BuildExecutor:
                 name, config_opts["executors"]["slurm"][name]
             )
 
-        # self.set_default(default)
-
     def __str__(self):
         return "[buildtest-executor]"
 
@@ -60,7 +61,7 @@ class BuildExecutor:
         """Given the name of an executor return the executor for running 
            a buildtest build, or get the default.
         """
-        return self.executors.get(name) or self.executors.get("default")
+        return self.executors.get(name)
 
     def _choose_executor(self, builder):
         """Choose executor is called at the onset of a run or dryrun. We
@@ -74,11 +75,20 @@ class BuildExecutor:
         """
 
         executor = builder.metadata.get("recipe").get("executor")
+        # if executor not defined in buildspec we raise an error
+        if not executor:
+            builder.logger.error(
+                "'executor' key not defined in buildspec: %s in section: %s",
+                builder.metadata["buildspec"],
+                builder.metadata["name"],
+            )
+            builder.logger.debug("test: %s", builder.metadata["recipe"])
+            sys.exit(1)
 
         # The executor (or a default) must be define
         if executor not in self.executors:
             builder.logger.warning(
-                "executor %s is not defined in settings.yml" % executor
+                "executor %s is not defined in %s" % (executor, BUILDTEST_SETTINGS_FILE)
             )
             sys.exit(1)
 
@@ -123,29 +133,6 @@ class BuildExecutor:
                 getattr(executor, step)()
         return executor.result
 
-    def set_default(self, name=None):
-        """Set a particular name as the default executor (defaults to default).
-           In the case that no executors are defined, we return a base (local)
-           executor. If executors are defined, we return the first in the list.
-
-           :param name: the name for the key to set as default, if it exists.
-           :type name: string
-        """
-
-        # If a default is not defined
-        if "default" not in self.executors:
-
-            # If no executors are defined, return a base (local)
-            if not self.executors:
-                self.executors["default"] = BaseExecutor("default", {})
-
-            # Otherwise return the first in the list
-            else:
-                if name in self.executors:
-                    self.executors["default"] = self.executors[name]
-                else:
-                    self.executors["default"] = list(self.executors.values())[0]
-
 
 class BaseExecutor:
     """The BaseExecutor is an abstract base class for all executors. All
@@ -170,7 +157,7 @@ class BaseExecutor:
            :param builder: the builder object for the executor to control.
            :type builder: buildtest.buildsystem.base.BuilderBase (or subclass).
         """
-
+        self.logger = logging.getLogger(__name__)
         self.name = name
         self._settings = settings
         self.load(name)
@@ -197,11 +184,14 @@ class BaseExecutor:
            so we are sure that the builder is defined. This is also where
            we set the result to return.
         """
-        self.result = self.builder.run()
+        pass
 
     def dryrun(self):
         """The dry run step defines the result based on a dry run."""
         self.result = self.builder.dry_run()
+
+    def setup(self):
+        pass
 
     def __str__(self):
         return "[executor-%s-%s]" % (self.type, self.name)
@@ -209,9 +199,169 @@ class BaseExecutor:
     def __repr__(self):
         return self.__str__()
 
+    def get_formatted_time(self, key, fmt="%m/%d/%Y %X"):
+        """Given some timestamp key in self.metadata, return a pretty printed
+           version of it. This is intended to log in the console for the user.
+
+           Parameters:
+
+           key: The key to look up in the metadata
+           fmt: the format string to use
+        """
+        timestamp = self.builder.metadata.get(key, "")
+        if timestamp:
+            timestamp = timestamp.strftime(fmt)
+        return timestamp
+
+    def check_regex(self, regex):
+        """ This method conducts a regular expression check using 're.search' with regular
+            expression defined in Buildspec. User must specify an output stream (stdout, stderr)
+            to select when performing regex. In buildtest, this would read the .out or .err file
+            based on stream and run the regular expression to see if there is a match.
+
+            Parameters:
+
+            :param regex: Regular expression object defined in Buildspec file
+            :type regex: str, required
+            :return:  A boolean return True/False based on if re.search is successful or not
+            :rtype: bool
+        """
+
+        if regex["stream"] == "stdout":
+            self.logger.debug(
+                f"Detected regex stream 'stdout' so reading output file: {self.builder.metadata['outfile']}"
+            )
+            content = read_file(self.builder.metadata["outfile"])
+
+        elif regex["stream"] == "stderr":
+            self.logger.debug(
+                f"Detected regex stream 'stderr' so reading error file: {self.builder.metadata['errfile']}"
+            )
+            content = read_file(self.builder.metadata["errfile"])
+
+        self.logger.debug(f"Applying re.search with exp: {regex['exp']}")
+
+        # perform a regex search based on value of 'exp' key defined in Buildspec with content file (output or error)
+        return re.search(regex["exp"], content) != None
+
 
 class LocalExecutor(BaseExecutor):
     type = "local"
+
+    def run(self):
+
+        # Keep a result object
+        self.result = {}
+        self.result["START_TIME"] = self.get_formatted_time("start_time")
+
+        self.result["LOGFILE"] = self.builder.metadata.get("logfile", "")
+        self.result["BUILD_ID"] = self.builder.metadata.get("build_id")
+
+        # Change to the test directory
+        os.chdir(self.builder.metadata["testdir"])
+        self.logger.debug(f"Changing to directory {self.builder.metadata['testdir']}")
+
+        # build the run command that includes the shell path, shell options and path to test file
+        cmd = [
+            self.builder.shell.path,
+            self.builder.shell.opts,
+            self.builder.metadata["testpath"],
+        ]
+        self.builder.metadata["command"] = " ".join(cmd)
+        self.logger.debug(
+            f"Running Test via command: {self.builder.metadata['command']}"
+        )
+
+        command = BuildTestCommand(self.builder.metadata["command"])
+        out, err = command.execute()
+
+        # Record the ending time
+        self.builder.metadata["end_time"] = datetime.datetime.now()
+
+        # Keep an output file
+        run_output_file = os.path.join(
+            self.builder.metadata.get("rundir"), self.builder.metadata.get("build_id")
+        )
+        outfile = run_output_file + ".out"
+        errfile = run_output_file + ".err"
+
+        # write output of test to .out file
+
+        out = "\n".join(out)
+        err = "\n".join(err)
+
+        self.logger.debug(f"Writing run output to file: {outfile}")
+        write_file(outfile, out)
+
+        # write error from test to .err file
+        self.logger.debug(f"Writing run error to file: {errfile}")
+        write_file(errfile, err)
+
+        self.builder.metadata["outfile"] = outfile
+        self.builder.metadata["errfile"] = errfile
+
+        self.logger.debug(
+            f"Return code: {command.returncode} for test: {self.builder.metadata['testpath']}"
+        )
+        self.result["RETURN_CODE"] = command.returncode
+        self.result["END_TIME"] = self.get_formatted_time("end_time")
+
+        status = self.builder.recipe.get("status")
+
+        test_state = "FAIL"
+
+        # if status is defined in Buildspec, then check for returncode and regex
+        if status:
+
+            # returncode_match is boolean to check if reference returncode matches return code from test
+            returncode_match = True
+
+            # regex_match is boolean to check if output/error stream matches regex defined in Buildspec,
+            # if no regex is defined we set this to True since we do a logical AND
+            regex_match = True
+
+            if "returncode" in status:
+                self.logger.debug("Conducting Return Code check")
+                self.logger.debug(
+                    "Status Return Code: %s   Result Return Code: %s"
+                    % (status["returncode"], self.result["RETURN_CODE"])
+                )
+                # checks if test returncode matches returncode specified in Buildspec and assign boolean to returncode_match
+                returncode_match = status["returncode"] == self.result["RETURN_CODE"]
+
+            if "regex" in status:
+                self.logger.debug("Conducting Regular Expression check")
+                # self.check_regex  applies regular expression check specified in Buildspec with output or error
+                # stream. self.check_regex returns a boolean (True/False) by using re.search
+                regex_match = self.check_regex(status["regex"])
+
+            self.logger.info(
+                "ReturnCode Match: %s Regex Match: %s "
+                % (returncode_match, regex_match)
+            )
+
+            if returncode_match and regex_match:
+                test_state = "PASS"
+
+        # if status is not defined we check test returncode, by default 0 is PASS and any other return code is a FAIL
+        else:
+            if command.returncode == 0:
+                test_state = "PASS"
+
+        # this variable is used later when counting all the pass/fail test in buildtest/menu/build.py
+        self.result["TEST_STATE"] = test_state
+
+        print(
+            "{:<30} {:<30} {:<30} {:<30}".format(
+                self.builder.config_name,
+                self.builder.name,
+                self.result["TEST_STATE"],
+                self.builder.buildspec,
+            )
+        )
+
+        # Return to starting directory for next test
+        os.chdir(self.builder.pwd)
 
 
 class SSHExecutor(BaseExecutor):

--- a/tests/buildsystem/test_base.py
+++ b/tests/buildsystem/test_base.py
@@ -55,18 +55,3 @@ def test_BuildspecParser():
 
             for k in ["testpath", "testdir", "rundir", "build_id"]:
                 assert k in builder.metadata
-
-            # If recipe had sections for pre_run, post_run, shell, they would be added here as well
-
-            result = builder.run()
-            for value in [
-                "BUILD_ID",
-                "START_TIME",
-                "END_TIME",
-                "RETURN_CODE",
-                "LOGFILE",
-            ]:
-                assert value in result
-
-            # Dry run should just print to screen
-            result = builder.dry_run()

--- a/tests/executors/test_base.py
+++ b/tests/executors/test_base.py
@@ -8,6 +8,7 @@ from jsonschema import validate
 from buildtest.executors.base import BuildExecutor
 from buildtest.buildsystem.schemas.utils import load_schema
 from buildtest.defaults import DEFAULT_SETTINGS_SCHEMA
+from buildtest.buildsystem.base import BuildspecParser
 
 pytest_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -35,3 +36,15 @@ def test_build_executor():
     # Each should have
     for name, executor in be.executors.items():
         assert hasattr(executor, "_settings")
+
+    examples_dir = os.path.join(pytest_root, "examples", "buildspecs")
+    for buildspec in os.listdir(examples_dir):
+        buildspec = os.path.join(examples_dir, buildspec)
+        bp = BuildspecParser(buildspec)
+
+        builders = bp.get_builders()
+        # build each test and then run it
+        for builder in builders:
+            builder.build()
+            result = be.run(builder)
+            assert result


### PR DESCRIPTION
is implementation specific to local test execution.
Add test for BuildExecutor in regression test.
Remove all run methods from BuilderBase now that it is implemented
in the executor class.