### PR TITLE
removing --dry option from buildtest build and clean up output of buildtest build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - 3.9
 git:
   quiet: true
 branches:

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -77,20 +77,23 @@ class BuildExecutor:
         executor = builder.metadata.get("recipe").get("executor")
         # if executor not defined in buildspec we raise an error
         if not executor:
-            builder.logger.error(
-                "'executor' key not defined in buildspec: %s in section: %s",
-                builder.metadata["buildspec"],
+            msg = "[%s]: 'executor' key not defined in buildspec: %s" % (
                 builder.metadata["name"],
+                builder.metadata["buildspec"],
             )
+            builder.logger.error(msg)
             builder.logger.debug("test: %s", builder.metadata["recipe"])
-            sys.exit(1)
+            sys.exit(msg)
 
         # The executor (or a default) must be define
         if executor not in self.executors:
-            builder.logger.warning(
-                "executor %s is not defined in %s" % (executor, BUILDTEST_SETTINGS_FILE)
+            msg = "[%s]: executor %s is not defined in %s" % (
+                builder.metadata["name"],
+                executor,
+                BUILDTEST_SETTINGS_FILE,
             )
-            sys.exit(1)
+            builder.logger.error(msg)
+            sys.exit(msg)
 
         # Get the executor by name, and add the builder to it
         executor = self.executors.get(executor)
@@ -271,6 +274,7 @@ class LocalExecutor(BaseExecutor):
 
         command = BuildTestCommand(self.builder.metadata["command"])
         out, err = command.execute()
+        # print (self.builder.metadata['command'])
 
         # Record the ending time
         self.builder.metadata["end_time"] = datetime.datetime.now()
@@ -347,15 +351,6 @@ class LocalExecutor(BaseExecutor):
 
         # this variable is used later when counting all the pass/fail test in buildtest/menu/build.py
         self.result["TEST_STATE"] = test_state
-
-        print(
-            "{:<30} {:<30} {:<30} {:<30}".format(
-                self.builder.config_name,
-                self.builder.name,
-                self.result["TEST_STATE"],
-                self.builder.buildspec,
-            )
-        )
 
         # Return to starting directory for next test
         os.chdir(self.builder.pwd)

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -274,7 +274,6 @@ class LocalExecutor(BaseExecutor):
 
         command = BuildTestCommand(self.builder.metadata["command"])
         out, err = command.execute()
-        # print (self.builder.metadata['command'])
 
         # Record the ending time
         self.builder.metadata["end_time"] = datetime.datetime.now()

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -105,14 +105,6 @@ class BuildTestParser:
         )
 
         parser_build.add_argument(
-            "-d",
-            "--dry",
-            help="dry-run mode, buildtest will not write the test scripts but print "
-            "content of test-script that would be written",
-            action="store_true",
-        )
-
-        parser_build.add_argument(
             "--settings", help="Specify an alternate buildtest settings file to use",
         )
 

--- a/tests/menu/test_buildspec.py
+++ b/tests/menu/test_buildspec.py
@@ -4,7 +4,7 @@ import pytest
 
 from buildtest.menu.buildspec import func_buildspec_find
 from buildtest.menu.repo import func_repo_add
-from buildtest.defaults import REPO_FILE
+from buildtest.defaults import REPO_FILE, BUILDSPEC_CACHE_FILE
 from buildtest.utils.file import is_file
 
 
@@ -13,8 +13,20 @@ def test_repofile_not_found():
         should raise SystemExit
     """
 
-    if is_file(REPO_FILE):
+    try:
+        print(f"Removing File: {REPO_FILE}")
         os.remove(REPO_FILE)
+    except OSError:
+        pass
+
+    try:
+        print(f"Removing File: {BUILDSPEC_CACHE_FILE}")
+        os.remove(BUILDSPEC_CACHE_FILE)
+    except OSError:
+        pass
+
+    assert not is_file(REPO_FILE)
+    assert not is_file(BUILDSPEC_CACHE_FILE)
 
     class args:
         find = True

--- a/tests/menu/test_repo.py
+++ b/tests/menu/test_repo.py
@@ -22,6 +22,14 @@ class ssh_repo:
     branch = "master"
 
 
+class repo_list_command:
+    show = None
+
+
+class repo_list_show_command:
+    show = True
+
+
 def test_clone(tmp_path):
     https_link = "https://github.com/buildtesters/tutorials.git"
 
@@ -37,12 +45,12 @@ def test_clone(tmp_path):
         clone(https_link, tmp_path, "develop")
 
     class args:
-        repo = " buildtesters/tutorials.git"
+        repo = "buildtesters/tutorials.git"
 
     func_repo_remove(args)
 
 
-def test_func_repo_add(tmp_path):
+def test_func_repo_add():
 
     # check if repo is None, this raises error
     with pytest.raises(SystemExit):
@@ -52,8 +60,18 @@ def test_func_repo_add(tmp_path):
     with pytest.raises(SystemExit):
         func_repo_add(only_github_repo)
 
+    avail_repos = func_repo_list(repo_list_command)
+    # remove buildtesters/buildtest-cori before adding to list to ensure
+    # directory does not exist and entry is removed from REPO_FILE
+    if "buildtesters/buildtest-cori" in avail_repos:
+
+        class args:
+            repo = "buildtesters/buildtest-cori"
+
+        func_repo_remove(args)
+
     class args:
-        http_link = "http://github.com/buildtesters/buildtest-cori"
+        repo = "http://github.com/buildtesters/buildtest-cori"
         branch = "master"
 
     # test http link
@@ -77,11 +95,6 @@ def test_ssh_clone():
 
 
 def test_func_repo_list():
-    class repo_list_command:
-        show = None
-
-    class repo_list_show_command:
-        show = True
 
     func_repo_list(repo_list_command)
     func_repo_list(repo_list_show_command)
@@ -130,7 +143,7 @@ def test_repofile_not_found():
     os.remove(REPO_FILE)
 
     class args:
-        repo = "http://github.com/buildtesters/buildtest-cori"
+        repo = "buildtesters/buildtest-cori"
 
     # since REPO_FILE does not exist this will raise an error
     with pytest.raises(SystemExit):


### PR DESCRIPTION
Clean up output of buildtest build
Run each executor.run method in try/except block and catch all error
message since executor can skip tests if they don't confirm to executor.
Error messages are printed after successful tests.