### PR TITLE
add getter methods for extracting repo entry and repo destination path

### DIFF
--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -185,7 +185,6 @@ def func_build_subcmd(args, config_opts):
     print(f"Buildspec Search Path: {buildspec_searchpath}")
     print(f"Test Directory: {test_directory}")
 
-
     # list to store all Buildspecs that are found using discover_buildspecs
     # followed by exclusion check
     buildspecs = []

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -39,7 +39,7 @@ def discover_buildspecs(buildspec):
     """
 
     buildspecs = []
-    search_path = get_repo_paths()
+    search_path = get_repo_paths() or []
     # add default path to search path
     search_path.append(BUILDSPEC_DEFAULT_PATH)
 

--- a/buildtest/menu/repo.py
+++ b/buildtest/menu/repo.py
@@ -79,7 +79,6 @@ def clone(url, dest, branch="master"):
     """
 
     name = os.path.basename(url).replace(".git", "")
-    print("name:", name)
     dest = os.path.join(dest, name)
 
     # If http prefix is provided, change this to https
@@ -163,7 +162,17 @@ def active_repos():
 
 
 def get_repo_paths():
+    """ Return list of destination path where repositories are cloned. This
+        is used to build the buildspec search path.
+
+        :return: A list of directory path where repos are cloned
+        :rtype: list
+    """
     dest_paths = []
+
+    if not is_file(REPO_FILE):
+        return
+
     with open(REPO_FILE, "r") as fd:
         repo_dict = yaml.load(fd.read(), Loader=yaml.SafeLoader)
     for repo in repo_dict.keys():

--- a/buildtest/menu/repo.py
+++ b/buildtest/menu/repo.py
@@ -36,7 +36,9 @@ def func_repo_add(args):
     config_opts = get_default_settings()
     repo_path = None
 
-    clone_prefix = config_opts.get("config", {}).get("paths", {}).get("clonepath") or config_opts.get("config", {}).get("paths", {}).get("prefix")
+    clone_prefix = config_opts.get("config", {}).get("paths", {}).get(
+        "clonepath"
+    ) or config_opts.get("config", {}).get("paths", {}).get("prefix")
 
     # if clonepath key is defined than override value generated from 'prefix'
     if clone_prefix:
@@ -77,7 +79,7 @@ def clone(url, dest, branch="master"):
     """
 
     name = os.path.basename(url).replace(".git", "")
-    print ("name:", name)
+    print("name:", name)
     dest = os.path.join(dest, name)
 
     # If http prefix is provided, change this to https
@@ -95,7 +97,7 @@ def clone(url, dest, branch="master"):
         username = url.split(":")[1].split("/")[0]
         reponame = url.split(":")[1].split("/")[1]
 
-    reponame = reponame.replace(".git","")
+    reponame = reponame.replace(".git", "")
 
     # Fail early if path exists
     if os.path.exists(dest):
@@ -142,6 +144,7 @@ def func_repo_list(args):
 
     return repo_dict.keys()
 
+
 def active_repos():
     """ Return list of active repository names from REPO_FILE
 
@@ -158,6 +161,7 @@ def active_repos():
 
     return list(repo_dict.keys())
 
+
 def get_repo_paths():
     dest_paths = []
     with open(REPO_FILE, "r") as fd:
@@ -166,6 +170,8 @@ def get_repo_paths():
         dest_paths.append(repo_dict[repo]["dest"])
 
     return dest_paths
+
+
 def func_repo_remove(args):
 
     if not is_file(REPO_FILE):

--- a/buildtest/settings/settings.schema.json
+++ b/buildtest/settings/settings.schema.json
@@ -38,7 +38,6 @@
               "prefix": { "type":  "string" },
               "clonepath": { "type": "string" },
               "logdir": {"type":  "string" },
-              "searchpath": { "type": "string" },
               "testdir": { "type": "string" }
             }
           }

--- a/buildtest/settings/settings.yml
+++ b/buildtest/settings/settings.yml
@@ -16,15 +16,7 @@ executors:
       host: localhost
       user: siddiq90
       identity_file: ~/.ssh/id_rsa
-  slurm:
-    haswell:
-      options: ["-C haswell"]
-      launcher: sbatch
 config:
   editor: vi
   paths:
     prefix: /tmp
-    clonepath: /tmp
-    searchpath: /tmp
-    logdir: /tmp
-    testdir: /tmp

--- a/buildtest/settings/slurm-example.yml
+++ b/buildtest/settings/slurm-example.yml
@@ -1,11 +1,12 @@
-editor: vi
 executors:
-  normal:
-    type: slurm
-    description: submit jobs with slurm using srun instead of sbatch
-    launcher: sbatch
-    options:
-      - "-p normal"
-      - "-t 00:10"
-      - "-N 1"
-      - "-n 1"
+  slurm:
+    haswell:
+      options: ["-C haswell"]
+      launcher: sbatch
+      modules:
+        purge: True
+        load: [PrgEnv-intel]
+config:
+  editor: vi
+  paths:
+    prefix: /tmp

--- a/buildtest/settings/ssh-executor-example.yml
+++ b/buildtest/settings/ssh-executor-example.yml
@@ -1,0 +1,10 @@
+executors:
+  ssh:
+    localhost:
+      host: localhost
+      user: siddiq90
+      identity_file: ~/.ssh/id_rsa
+config:
+  editor: vi
+  paths:
+    prefix: /tmp

--- a/tests/menu/test_repo.py
+++ b/tests/menu/test_repo.py
@@ -45,7 +45,7 @@ def test_clone(tmp_path):
         clone(https_link, tmp_path, "develop")
 
     class args:
-        repo = "buildtesters/tutorials.git"
+        repo = "buildtesters/tutorials"
 
     func_repo_remove(args)
 


### PR DESCRIPTION
via get_repo_paths and active_repos.
Fix bug when adding repo where .git extension was added to entry, this
needed to be removed.
Remove searchpath key from settings.schema.json
Create slurm and ssh executor examples in separate .yml files and remove
these from settings.yml which is the default settings file for buildtest.
This was done because we expect buildtest to provide local executor as
default while other executors would require further customization by site.