### PR TITLE
add Timer class to time execution of test, log test result in json file and modify output of buildtest build

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -308,8 +308,10 @@ class BuilderBase:
         self.schema_table = get_schemas_available()
         type = self.recipe["type"]
         self.schemafile = self.schema_table[type][version]
+        self.metadata["schemafile"] = self.schemafile
 
         self.executor = self.recipe.get("executor")
+        self.metadata["executor"] = self.executor
         # The default shell will be bash
         self.shell = Shell(self.recipe.get("shell", "bash"))
 

--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -25,6 +25,8 @@ REPO_FILE = os.path.join(BUILDTEST_ROOT, "repo.yaml")
 
 BUILDSPEC_CACHE_FILE = os.path.join(BUILDTEST_ROOT, "buildspec.cache")
 
+BUILD_REPORT = os.path.join(os.path.dirname(root), "var", "report.json")
+
 # BUILDSPEC_DEFAULT_PATH is the root directory where Buildspec are found
 # when using buildtest get to clone a buildtest test repo
 BUILDSPEC_DEFAULT_PATH = os.path.join(BUILDTEST_ROOT, "site")

--- a/buildtest/utils/timer.py
+++ b/buildtest/utils/timer.py
@@ -1,0 +1,26 @@
+import time
+
+
+class TimerError(Exception):
+    """A custom exception used to report errors in use of Timer class"""
+
+
+class Timer:
+    def __init__(self):
+        self._start_time = None
+
+    def start(self):
+        """Start a new timer"""
+        if self._start_time is not None:
+            raise TimerError(f"Timer is running. Use .stop() to stop it")
+
+        self._start_time = time.perf_counter()
+
+    def stop(self):
+        """Stop the timer, and report the elapsed time"""
+        if self._start_time is None:
+            raise TimerError(f"Timer is not running. Use .start() to start it")
+
+        elapsed_time = time.perf_counter() - self._start_time
+        self._start_time = None
+        return elapsed_time

--- a/buildtest/utils/timer.py
+++ b/buildtest/utils/timer.py
@@ -12,14 +12,14 @@ class Timer:
     def start(self):
         """Start a new timer"""
         if self._start_time is not None:
-            raise TimerError(f"Timer is running. Use .stop() to stop it")
+            raise TimerError("Timer is running. Use .stop() to stop it")
 
         self._start_time = time.perf_counter()
 
     def stop(self):
         """Stop the timer, and report the elapsed time"""
         if self._start_time is None:
-            raise TimerError(f"Timer is not running. Use .start() to start it")
+            raise TimerError("Timer is not running. Use .start() to start it")
 
         elapsed_time = time.perf_counter() - self._start_time
         self._start_time = None

--- a/tests/buildsystem/test_base.py
+++ b/tests/buildsystem/test_base.py
@@ -11,7 +11,7 @@ from buildtest.defaults import supported_schemas
 testroot = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-def test_BuildspecParser():
+def test_BuildspecParser(tmp_path):
 
     # Examples folder
     examples_dir = os.path.join(testroot, "examples", "buildspecs")
@@ -38,7 +38,7 @@ def test_BuildspecParser():
         for supported_schema in supported_schemas:
             assert supported_schema in bp.schema_table
 
-        builders = bp.get_builders()
+        builders = bp.get_builders(tmp_path)
 
         for builder in builders:
 
@@ -53,5 +53,5 @@ def test_BuildspecParser():
             # and write test
             builder.build()
 
-            for k in ["testpath", "testdir", "rundir", "build_id"]:
+            for k in ["testpath", "testroot", "rundir", "build_id"]:
                 assert k in builder.metadata

--- a/tests/executors/test_base.py
+++ b/tests/executors/test_base.py
@@ -5,6 +5,7 @@ BuildExecutor: testing functions
 import os
 
 from jsonschema import validate
+from jsonschema.exceptions import ValidationError
 from buildtest.executors.base import BuildExecutor
 from buildtest.buildsystem.schemas.utils import load_schema
 from buildtest.defaults import DEFAULT_SETTINGS_SCHEMA
@@ -13,7 +14,7 @@ from buildtest.buildsystem.base import BuildspecParser
 pytest_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-def test_build_executor():
+def test_build_executor(tmp_path):
     example_schema = os.path.join(
         pytest_root, "examples", "config_schemas", "valid", "combined-example.yml"
     )
@@ -40,9 +41,13 @@ def test_build_executor():
     examples_dir = os.path.join(pytest_root, "examples", "buildspecs")
     for buildspec in os.listdir(examples_dir):
         buildspec = os.path.join(examples_dir, buildspec)
-        bp = BuildspecParser(buildspec)
+        try:
+            bp = BuildspecParser(buildspec)
+        except (SystemExit, ValidationError):
+            continue
 
-        builders = bp.get_builders()
+        builders = bp.get_builders(tmp_path)
+        print(builders)
         # build each test and then run it
         for builder in builders:
             builder.build()

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-
-# This run_tests.sh file is intended to invoke python testing of buildtest.
-# It is required that buildtest is installed, or interacted with 
-# from the root of the development directory.
-
-
-# Run tests just for everything else
-pytest -vra tests/


### PR DESCRIPTION
- We changed few keys in builder.metadata and added few keys as well including `executors`, `schemafile`. We add `result` key in builder.metadata that is captured from executor class.
- Add test result in var/report.json
- Changed regtest since test failed because we now require testdir as argument to get_builders method
- Furthermore, we now force BuilderBase to create testdir based onconfiguration option, no more directory path based on current directory
- Change output columns in build and running section. We remove executor column from build and put this in running section. We add column returncode in running table.