### PR TITLE
Add option --clear in buildtest buildspec find which clears buildspec…

### DIFF
--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -298,6 +298,12 @@ class BuildTestParser:
         buildspec_find = subparsers_buildspec.add_parser(
             "find", help="find all buildspecs"
         )
+        buildspec_find.add_argument(
+            "-c",
+            "--clear",
+            help="Clear buildspec cache and find all buildspecs again",
+            action="store_true",
+        )
         buildspec_view = subparsers_buildspec.add_parser(
             "view", help="view a buildspec"
         )

--- a/buildtest/menu/buildspec.py
+++ b/buildtest/menu/buildspec.py
@@ -27,6 +27,13 @@ def func_buildspec_find(args):
     """
 
     cache = {}
+    # implements buildtest buildspec find --clear which removes cache file before finding all buildspecs
+    if args.clear:
+        try:
+            os.remove(BUILDSPEC_CACHE_FILE)
+            print(f"Clearing cache file: {BUILDSPEC_CACHE_FILE}")
+        except OSError:
+            pass
 
     if is_file(BUILDSPEC_CACHE_FILE):
         with open(BUILDSPEC_CACHE_FILE, "r") as fd:

--- a/buildtest/menu/repo.py
+++ b/buildtest/menu/repo.py
@@ -12,7 +12,7 @@ import yaml
 
 from buildtest.config import get_default_settings
 from buildtest.defaults import BUILDSPEC_DEFAULT_PATH, REPO_FILE
-from buildtest.utils.file import create_dir, is_file
+from buildtest.utils.file import create_dir, is_file, resolve_path
 
 logger = logging.getLogger(__name__)
 
@@ -36,13 +36,16 @@ def func_repo_add(args):
     config_opts = get_default_settings()
     repo_path = None
 
-    clone_prefix = config_opts.get("config", {}).get("paths", {}).get(
-        "clonepath"
-    ) or config_opts.get("config", {}).get("paths", {}).get("prefix")
-
     # if clonepath key is defined than override value generated from 'prefix'
+
+    clonepath = config_opts.get("config", {}).get("paths", {}).get("clonepath")
+    prefix = config_opts.get("config", {}).get("paths", {}).get("prefix")
+
+    clone_prefix = clonepath or prefix
+
     if clone_prefix:
-        repo_path = os.path.realpath(clone_prefix)
+        # resolve clone prefix, this accounts for shell expansion, directory expansion and gets realpath. We don't care if path exists to ensure we don't return None
+        repo_path = resolve_path(clone_prefix, exist=False)
 
     # it is possible prefix and clonepath are not defined, in that case we used default value
     repo_search_path = repo_path or BUILDSPEC_DEFAULT_PATH

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -118,7 +118,7 @@ def create_dir(dirname):
             raise
 
 
-def resolve_path(path):
+def resolve_path(path, exist=True):
     """This method will resolve a file path to account for shell expansion and resolve paths in
        when a symlink is provided in the file. This method assumes file already exists.
 
@@ -138,6 +138,9 @@ def resolve_path(path):
     real_path = os.path.realpath(path)
 
     if os.path.exists(real_path):
+        return real_path
+
+    if not exist:
         return real_path
 
 

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -214,7 +214,7 @@ def write_file(filepath, content):
 
     # ensure content is of type string
     if not isinstance(content, str):
-        return None
+        return
 
     try:
         with open(filepath, "w") as fd:

--- a/tests/menu/test_buildspec.py
+++ b/tests/menu/test_buildspec.py
@@ -30,6 +30,7 @@ def test_repofile_not_found():
 
     class args:
         find = True
+        clear = False
 
     with pytest.raises(SystemExit):
         func_buildspec_find(args)
@@ -42,7 +43,9 @@ def test_func_buildspec_find():
 
     func_repo_add(args)
 
+    # testing buildtest buildspec find --clear
     class args:
         find = True
+        clear = True
 
     func_buildspec_find(args)

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -122,15 +122,19 @@ def test_write_file_exceptions(tmp_path):
         print("Passing 'None' as input filestream to write_file")
         write_file(None, input)
 
+    assert is_dir(tmp_path)
     # testing if directory is passed as filepath, this is also not allowed and expected to raise error
     with pytest.raises(SystemExit):
-        print(f"Passing directory: {tmp_path} as input filestream to write_file")
+        print(f"Passing directory: {tmp_path} as input filestream to method write_file")
         write_file(tmp_path, input)
 
-    print("Writing to '/etc/shadow' will raise an exception BuildTestError")
-    # writing to /etc/shadow will raise an error during write since /etc/shadow will result in Permission Error
+    filename = "".join(random.choice(string.ascii_letters) for i in range(10))
+    path = os.path.join("/",filename)
+    print(f"Can't write to path: {path} due to permissions")
+
+
     with pytest.raises(BuildTestError):
-        write_file("/etc/shadow", input)
+        write_file(path, input)
 
     # input content must be a string, will return None upon
     assert not write_file(os.path.join(tmp_path, "null.txt"), ["hi"])

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -1,6 +1,8 @@
 import pytest
 import os
+import random
 import shutil
+import string
 import uuid
 from buildtest.utils.file import (
     is_dir,
@@ -9,6 +11,7 @@ from buildtest.utils.file import (
     walk_tree,
     read_file,
     write_file,
+    resolve_path,
 )
 from buildtest.exceptions import BuildTestError
 
@@ -153,3 +156,18 @@ def test_read_file(tmp_path):
     # reading /etc/shadow will raise a Permission error so we catch this exception BuildTestError
     with pytest.raises(BuildTestError):
         read_file("/etc/shadow")
+
+
+def test_resolve_path():
+    assert resolve_path("$HOME")
+    assert resolve_path("~")
+
+    random_name = "".join(random.choice(string.ascii_letters) for i in range(10))
+    # test a directory path that doesn't exist in $HOME with random key, but setting exist=False will return
+    # path but doesn't mean file exists
+    path = resolve_path(os.path.join("$HOME", random_name), exist=False)
+
+    # checking if path is not file, or directory and not None. This is only valid when exist=False is set
+    assert not is_file(path)
+    assert not is_dir(path)
+    assert path is not None


### PR DESCRIPTION
… cache

before finding them. This is useful when adding multiple repos at a time and then
finding way to update buildspec cache without removing file manually. This option
will remove file and then search again.
add argument 'exist' in resolve_path to allow path retrieval even if
path doesn't exist instead of None. This is optional argument.
Update regtest for buildspec find and add test for resolve_path