### PR TITLE
change behavior of slurm polling and validate slurm executors in check_settings

### DIFF
--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -115,7 +115,7 @@ def validate_slurm_executors(slurm_executor):
 
     slurm_partitions = get_slurm_partitions()
     slurm_qos = get_slurm_qos()
-    slurm_cluster = get_slurm_qos()
+    slurm_cluster = get_slurm_clusters()
 
     for executor in slurm_executor:
 

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -10,7 +10,7 @@ from buildtest.defaults import (
     DEFAULT_SETTINGS_FILE,
     DEFAULT_SETTINGS_SCHEMA,
 )
-from buildtest.system import get_slurm_partitions,get_slurm_qos, get_slurm_clusters
+from buildtest.system import get_slurm_partitions, get_slurm_qos, get_slurm_clusters
 from buildtest.utils.command import BuildTestCommand
 from buildtest.utils.file import create_dir, is_dir, is_file
 
@@ -74,7 +74,6 @@ def check_settings(settings_path=None, run_init=True):
     validate(instance=user_schema, schema=config_schema)
     logger.debug("Validation was successful")
 
-
     slurm_executors = user_schema.get("executors", {}).get("slurm")
 
     if slurm_executors:
@@ -103,6 +102,7 @@ def get_default_settings():
     """Load and return the default buildtest settings file. """
 
     return load_settings()
+
 
 def validate_slurm_executors(slurm_executor):
     """This method will validate slurm executors, we check if partition, qos,
@@ -138,18 +138,16 @@ def validate_slurm_executors(slurm_executor):
                     f"{slurm_executor[executor]['partition']} is in state: {part_state}. It must be in 'up' state in order to accept jobs"
                 )
         # check if 'qos' key is valid qos
-        if slurm_executor[executor].get('qos'):
+        if slurm_executor[executor].get("qos"):
 
-            if slurm_executor[executor]['qos'] not in slurm_qos:
+            if slurm_executor[executor]["qos"] not in slurm_qos:
                 sys.exit(
                     f"{slurm_executor[executor]['qos']} not a valid qos! Please select one of the following qos: {slurm_qos}"
                 )
         # check if 'cluster' key is valid slurm cluster
-        if slurm_executor[executor].get('cluster'):
+        if slurm_executor[executor].get("cluster"):
 
-            if slurm_executor[executor]['cluster'] not in slurm_cluster:
+            if slurm_executor[executor]["cluster"] not in slurm_cluster:
                 sys.exit(
                     f"{slurm_executor[executor]['cluster']} not a valid slurm cluster! Please select one of the following slurm clusters: {slurm_cluster}"
                 )
-
-

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -141,8 +141,9 @@ class BuildExecutor:
         if executor.type != "slurm":
             return True
 
-        job_state = executor.poll()
-        if job_state not in ["PENDING", "RUNNING"]:
+        if executor.job_state in ["PENDING", "RUNNING"]:
+            executor.poll()
+        else:
             executor.gather()
             return True
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -135,42 +135,8 @@ class BuildExecutor:
         """
         return executor.result
 
-    def poll(self):
+    def poll(self, builder):
 
-        print("Executor List: ", self.executors)
-
-        interval = 10
-        while True:
-            statelist = []
-            print("\n")
-            print(f"Polling Jobs in {interval} seconds")
-            print("{:_<40}".format(""))
-
-            time.sleep(interval)
-
-            slurm_executors = [
-                self.executors[executor]
-                for executor in self.executors.keys()
-                if executor.startswith("slurm")
-            ]
-            print("slurm_executors:", slurm_executors)
-            for executor in slurm_executors:
-                if (
-                    executor.job_state in ["PENDING", "RUNNING"]
-                    or not executor.job_state
-                ):
-                    state = False
-                    executor.poll(executor.builder)
-                else:
-                    state = True
-                    executor.gather()
-
-                statelist.append(state)
-                print("State List:", statelist)
-                # break when all poll states are True
-                if all(statelist):
-                    break
-        """        
         executor = self._choose_executor(builder)
         if executor.type != "slurm":
             return True
@@ -183,7 +149,6 @@ class BuildExecutor:
             return True
 
         return False
-        """
 
 
 class BaseExecutor:

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -559,6 +559,9 @@ class SlurmExecutor(BaseExecutor):
             err += f"[{self.builder.metadata['name']}] running command: {sbatch_cmd}"
             sys.exit(err)
 
+        # wait 5 seconds before querying slurm for jobID. It can take some time for output
+        # of job to show up from time of submission and running squeue.
+        time.sleep(5)
         # get last job ID
         output = subprocess.check_output(
             "squeue -u $USER -h -O JobID | tail -n 1",
@@ -566,7 +569,7 @@ class SlurmExecutor(BaseExecutor):
             universal_newlines=True,
         )
         self.job_id = int(output.strip())
-
+        self.logger.debug(f"[{self.builder.metadata['name']}] JobID: {self.job_id} dispatched to scheduler")
         self.result["state"] = "N/A"
         self.result["runtime"] = "0"
         self.result["returncode"] = "0"

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -424,7 +424,6 @@ class SlurmExecutor(BaseExecutor):
         "Account",
         "AllocNodes",
         "AllocTRES",
-        "Constraints",
         "ConsumedEnergyRaw",
         "CPUTimeRaw",
         "End",
@@ -434,7 +433,6 @@ class SlurmExecutor(BaseExecutor):
         "NCPUS",
         "NNodes",
         "QOS",
-        "Reason",
         "ReqGRES",
         "ReqMem",
         "ReqNodes",
@@ -569,7 +567,9 @@ class SlurmExecutor(BaseExecutor):
             universal_newlines=True,
         )
         self.job_id = int(output.strip())
-        self.logger.debug(f"[{self.builder.metadata['name']}] JobID: {self.job_id} dispatched to scheduler")
+        self.logger.debug(
+            f"[{self.builder.metadata['name']}] JobID: {self.job_id} dispatched to scheduler"
+        )
         self.result["state"] = "N/A"
         self.result["runtime"] = "0"
         self.result["returncode"] = "0"

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -141,6 +141,7 @@ class BuildExecutor:
         if executor.type != "slurm":
             return True
 
+        # only poll job if its in PENDING or RUNNING state
         if executor.job_state in ["PENDING", "RUNNING"]:
             executor.poll()
         else:
@@ -420,6 +421,7 @@ class SlurmExecutor(BaseExecutor):
     type = "slurm"
     DEFAULT_POLL_INTERVAL = 30
     steps = ["dispatch", "poll", "gather", "close"]
+    job_state = None
     poll_cmd = "sacct"
     sacct_fields = [
         "Account",
@@ -585,9 +587,6 @@ class SlurmExecutor(BaseExecutor):
 
         # while True:
 
-        print(
-            f"[{self.builder.metadata['name']}]: Polling Job {self.job_id} in  {self.poll_interval} seconds"
-        )
         # time.sleep(self.poll_interval)
         self.logger.debug(f"Query Job: {self.job_id}")
 
@@ -602,7 +601,7 @@ class SlurmExecutor(BaseExecutor):
         cmd.execute()
         self.job_state = cmd.get_output()
         self.job_state = "".join(self.job_state).rstrip()
-        msg = f"Job {self.job_id} in {self.job_state} state for test: {self.builder.metadata['name']}"
+        msg = f"[{self.builder.metadata['name']}]: JobID {self.job_id} in {self.job_state} state: "
         print(msg)
         self.logger.debug(msg)
         return self.job_state

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import sys
 import time
 
@@ -546,10 +547,9 @@ class SlurmExecutor(BaseExecutor):
             sys.exit(err)
 
         # get last job ID
-        cmd = BuildTestCommand("squeue -u $USER -h -O JobID | tail -n 1")
-        cmd.execute()
-        out = "".join(cmd.get_output()).strip()
-        self.job_id = int(out)
+        output = subprocess.check_output("squeue -u $USER -h -O JobID | tail -n 1", shell=True,universal_newlines=True)
+        self.job_id = int(output.strip())
+
 
         self.result["runtime"] = "0"
         self.write_testresults(out, err)

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -16,6 +16,7 @@ from buildtest.utils.file import write_file, read_file
 from buildtest.utils.command import BuildTestCommand
 from buildtest.utils.timer import Timer
 
+
 class BuildExecutor:
     """A BuildExecutor is a base class some type of executor, defined under
        the buildtest/settings/default-config.json schema. For example,
@@ -546,7 +547,6 @@ class SlurmExecutor(BaseExecutor):
             ``sacct -j <jobid> -o State -n -X -P``
         """
 
-
         self.logger.debug(f"Query Job: {self.job_id}")
 
         slurm_query = f"{self.poll_cmd} -j {self.job_id} -o State -n -X -P"
@@ -564,7 +564,6 @@ class SlurmExecutor(BaseExecutor):
         print(msg)
         self.logger.debug(msg)
         return self.job_state
-
 
     def gather(self):
         """Gather Slurm detail after job completion"""

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -148,6 +148,7 @@ class BuildExecutor:
 
         return False
 
+
 class BaseExecutor:
     """The BaseExecutor is an abstract base class for all executors. All
        executors must have a listing of steps and dryrun_steps
@@ -568,6 +569,7 @@ class SlurmExecutor(BaseExecutor):
 
         self.result["state"] = "N/A"
         self.result["runtime"] = "0"
+        self.result["returncode"] = "0"
         self.write_testresults(out, err)
 
     def poll(self):
@@ -577,7 +579,7 @@ class SlurmExecutor(BaseExecutor):
             ``sacct -j <jobid> -o State -n -X -P``
         """
 
-        #while True:
+        # while True:
 
         print(
             f"[{self.builder.metadata['name']}]: Polling Job {self.job_id} in  {self.poll_interval} seconds"
@@ -600,8 +602,8 @@ class SlurmExecutor(BaseExecutor):
         print(msg)
         self.logger.debug(msg)
         return self.job_state
-            #if self.job_state not in ["PENDING", "RUNNING"]:
-            #    break
+        # if self.job_state not in ["PENDING", "RUNNING"]:
+        #    break
 
     def gather(self):
         """Gather Slurm detail after job completion"""

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -464,7 +464,8 @@ class SlurmExecutor(BaseExecutor):
             query = "sinfo -p {self.partition} -h -O available"
             cmd = BuildTestCommand(query)
             cmd.execute()
-            part_state = "".cmd.get_output().rstrip()
+            part_state = "".cmd.get_output()
+            part_state = part_state.rstrip()
             # check if partition is in 'up' state. If not we raise an error.
             if part_state != "up":
                 sys.exit(

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -545,7 +545,11 @@ class SlurmExecutor(BaseExecutor):
             err += f"[{self.builder.metadata['name']}] running command: {sbatch_cmd}"
             sys.exit(err)
 
-        self.job_id = int(re.search(r"\d+", "".join(out)).group())
+        # get last job ID
+        cmd = BuildTestCommand("squeue -u $USER -h -O JobID | tail -n 1")
+        cmd.execute()
+        out = "".join(cmd.get_output()).strip()
+        self.job_id = int(out)
 
         self.result["runtime"] = "0"
         self.write_testresults(out, err)

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -135,20 +135,55 @@ class BuildExecutor:
         """
         return executor.result
 
-    def poll(self, builder):
+    def poll(self):
 
+        print("Executor List: ", self.executors)
+
+        interval = 10
+        while True:
+            statelist = []
+            print("\n")
+            print(f"Polling Jobs in {interval} seconds")
+            print("{:_<40}".format(""))
+
+            time.sleep(interval)
+
+            slurm_executors = [
+                self.executors[executor]
+                for executor in self.executors.keys()
+                if executor.startswith("slurm")
+            ]
+            print("slurm_executors:", slurm_executors)
+            for executor in slurm_executors:
+                if (
+                    executor.job_state in ["PENDING", "RUNNING"]
+                    or not executor.job_state
+                ):
+                    state = False
+                    executor.poll(executor.builder)
+                else:
+                    state = True
+                    executor.gather()
+
+                statelist.append(state)
+                print("State List:", statelist)
+                # break when all poll states are True
+                if all(statelist):
+                    break
+        """        
         executor = self._choose_executor(builder)
         if executor.type != "slurm":
             return True
-
+        
         # only poll job if its in PENDING or RUNNING state
-        if executor.job_state in ["PENDING", "RUNNING"]:
+        if executor.job_state in ["PENDING", "RUNNING"] or not executor.job_state:
             executor.poll()
         else:
             executor.gather()
             return True
 
         return False
+        """
 
 
 class BaseExecutor:

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -461,7 +461,7 @@ class SlurmExecutor(BaseExecutor):
                     f"{self.partition} not a valid partition!. Please select one of the following partitions: {slurm_partitions}"
                 )
 
-            query = "sinfo -p {self.partition} -h -O available"
+            query = f"sinfo -p {self.partition} -h -O available"
             cmd = BuildTestCommand(query)
             cmd.execute()
             part_state = "".join(cmd.get_output())

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -464,7 +464,7 @@ class SlurmExecutor(BaseExecutor):
             query = "sinfo -p {self.partition} -h -O available"
             cmd = BuildTestCommand(query)
             cmd.execute()
-            part_state = "".cmd.get_output()
+            part_state = "".join(cmd.get_output())
             part_state = part_state.rstrip()
             # check if partition is in 'up' state. If not we raise an error.
             if part_state != "up":

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import sys
+import time
 from jsonschema.exceptions import ValidationError
 from buildtest.defaults import BUILDSPEC_DEFAULT_PATH
 
@@ -341,6 +342,18 @@ def func_build_subcmd(args, config_opts):
         for error in errmsg:
             print(error)
         print("\n")
+
+    while True:
+        statelist = []
+        time.sleep(20)
+
+        for builder in builders:
+            state = executor.poll(builder)
+            statelist.append(state)
+
+        # break when all poll states are True
+        if all(statelist):
+            break
 
     if total_tests == 0:
         print("No tests were executed")

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -343,9 +343,15 @@ def func_build_subcmd(args, config_opts):
             print(error)
         print("\n")
 
+
+    interval = 20
     while True:
         statelist = []
-        time.sleep(20)
+        print ("\n")
+        print (f"Polling Jobs in {interval} seconds")
+        print ("{:_<80}".format(""))
+
+        time.sleep(interval)
 
         for builder in builders:
             state = executor.poll(builder)

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -347,15 +347,19 @@ def func_build_subcmd(args, config_opts):
             print(error)
         print("\n")
 
-    # poll will be True if one of the result State is N/A which is buildtest way
-    # to inform job is dispatched to scheduler which requires polling
+    # poll will be True if one of the result State is N/A which is buildtest way to inform job is dispatched to scheduler which requires polling
+
+    if poll:
+        executor.poll()
+
+    """
     if poll:
         interval = 10
         while True:
             statelist = []
             print("\n")
             print(f"Polling Jobs in {interval} seconds")
-            print("{:_<80}".format(""))
+            print("{:_<40}".format(""))
 
             time.sleep(interval)
 
@@ -366,10 +370,12 @@ def func_build_subcmd(args, config_opts):
             # break when all poll states are True
             if all(statelist):
                 break
+    """
 
     if total_tests == 0:
         print("No tests were executed")
         return
+
     print(
         """
 +----------------------+

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -349,7 +349,6 @@ def func_build_subcmd(args, config_opts):
 
     # poll will be True if one of the result State is N/A which is buildtest way to inform job is dispatched to scheduler which requires polling
 
-
     if poll:
         interval = 10
         while True:

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -294,6 +294,7 @@ def func_build_subcmd(args, config_opts):
     total_tests = 0
     errmsg = []
     results = []
+    poll = False
     print(
         """
 +----------------------+
@@ -323,6 +324,9 @@ def func_build_subcmd(args, config_opts):
         else:
             failed_tests += 1
 
+        if result["state"] == "N/A":
+            poll = True
+
         print(
             "{:<20} {:<20} {:<20} {:<20} {:<20}".format(
                 builder.name,
@@ -343,23 +347,25 @@ def func_build_subcmd(args, config_opts):
             print(error)
         print("\n")
 
+    # poll will be True if one of the result State is N/A which is buildtest way
+    # to inform job is dispatched to scheduler which requires polling
+    if poll:
+        interval = 10
+        while True:
+            statelist = []
+            print("\n")
+            print(f"Polling Jobs in {interval} seconds")
+            print("{:_<80}".format(""))
 
-    interval = 20
-    while True:
-        statelist = []
-        print ("\n")
-        print (f"Polling Jobs in {interval} seconds")
-        print ("{:_<80}".format(""))
+            time.sleep(interval)
 
-        time.sleep(interval)
+            for builder in builders:
+                state = executor.poll(builder)
+                statelist.append(state)
 
-        for builder in builders:
-            state = executor.poll(builder)
-            statelist.append(state)
-
-        # break when all poll states are True
-        if all(statelist):
-            break
+            # break when all poll states are True
+            if all(statelist):
+                break
 
     if total_tests == 0:
         print("No tests were executed")

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -349,10 +349,7 @@ def func_build_subcmd(args, config_opts):
 
     # poll will be True if one of the result State is N/A which is buildtest way to inform job is dispatched to scheduler which requires polling
 
-    if poll:
-        executor.poll()
 
-    """
     if poll:
         interval = 10
         while True:
@@ -370,7 +367,6 @@ def func_build_subcmd(args, config_opts):
             # break when all poll states are True
             if all(statelist):
                 break
-    """
 
     if total_tests == 0:
         print("No tests were executed")

--- a/buildtest/menu/config.py
+++ b/buildtest/menu/config.py
@@ -28,7 +28,7 @@ def func_config_validate(args=None):
     """
     try:
         check_settings()
-    except ValidationError as err:
+    except (ValidationError,SystemExit) as err:
         print(err)
         raise sys.exit(f"{BUILDTEST_SETTINGS_FILE} is not valid")
 

--- a/buildtest/menu/config.py
+++ b/buildtest/menu/config.py
@@ -28,7 +28,7 @@ def func_config_validate(args=None):
     """
     try:
         check_settings()
-    except (ValidationError,SystemExit) as err:
+    except (ValidationError, SystemExit) as err:
         print(err)
         raise sys.exit(f"{BUILDTEST_SETTINGS_FILE} is not valid")
 

--- a/buildtest/menu/repo.py
+++ b/buildtest/menu/repo.py
@@ -160,8 +160,6 @@ def func_repo_list(args):
         for repo in repo_dict.keys():
             print(repo)
 
-    # return repo_dict.keys()
-
 
 def active_repos():
     """ Return list of active repository names from REPO_FILE


### PR DESCRIPTION
Previously, we were polling slurm jobs serially, before we can proceed to next job this was inefficient. Now we dispatch all jobs
first and poll later. We poll in while loop until all jobs have finished. The slurm executors were checked in `dispatch` method which caused slurm query per SlurmExecutor instance and this led to many redundant checks. Instead we move slurm executor checks in `check_settings` which is performed once. 