### PR TITLE
add --tags option in buildtest build. Build tests using tags

### DIFF
--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -29,7 +29,7 @@ BUILDTEST_SETTINGS_FILE = os.path.join(BUILDTEST_USER_HOME, "config.yml")
 
 var_root = os.path.join(BUILDTEST_ROOT, "var")
 
-BUILDSPEC_CACHE_FILE = os.path.join(var_root, "buildspec.cache")
+BUILDSPEC_CACHE_FILE = os.path.join(var_root, "buildspec-cache.json")
 
 BUILD_REPORT = os.path.join(var_root, "report.json")
 

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -142,6 +142,12 @@ class BuildTestParser:
             help="Exclude one or more configs from processing. Configs can be files or directories.",
         )
 
+        parser_build.add_argument(
+            "--tags",
+            help="Specify buildspecs by tags",
+            # action="append",
+        )
+
     def buildspec_menu(self):
         """This method implements ``buildtest buildspec`` command
 

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -27,17 +27,33 @@ logger = logging.getLogger(__name__)
 
 
 def discover_buildspecs_by_tags(input_tag):
+    """This method discovers buildspecs by tags, using ``--tags`` option
+       from ``buildtest build`` command. This method will read BUILDSPEC_CACHE_FILE
+       and search for ``tags`` key in buildspec recipe and match with input
+       tag. Since ``tags`` field is a list, we check if input tag is in ``list``
+       and if so we add the entire buildspec into a list. The return is a list
+       of buildspec files to process.
+
+       :param input_tag: Input tags from command line argument ``buildtest build --tags <tags>``
+       :type input_tag: string
+       :return: a list of buildspec files that match tag name
+       :rtype: list
+    """
 
     with open(BUILDSPEC_CACHE_FILE, "r") as fd:
         cache = json.loads(fd.read())
 
     buildspecs = []
+    # query all buildspecs from BUILDSPEC_CACHE_FILE for tags keyword and
+    # if it matches input_tag we add buildspec to list
     for path in cache.keys():
         for buildspecfile in cache[path].keys():
             for test in cache[path][buildspecfile].keys():
+
+                # if tags is not declared we set to empty list
                 tag = cache[path][buildspecfile][test].get("tags") or []
 
-                if tag and input_tag in tag:
+                if input_tag in tag:
                     buildspecs.append(buildspecfile)
 
     return buildspecs

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -4,13 +4,18 @@ for building test scripts from a Buildspec
 """
 
 import logging
+import json
 import os
 import re
 import sys
 import time
 from tabulate import tabulate
 from jsonschema.exceptions import ValidationError
-from buildtest.defaults import BUILDSPEC_DEFAULT_PATH, BUILDTEST_ROOT
+from buildtest.defaults import (
+    BUILDSPEC_DEFAULT_PATH,
+    BUILDTEST_ROOT,
+    BUILDSPEC_CACHE_FILE,
+)
 
 from buildtest.buildsystem.parser import BuildspecParser
 from buildtest.config import load_settings, check_settings
@@ -19,6 +24,23 @@ from buildtest.menu.report import update_report
 from buildtest.utils.file import walk_tree, resolve_path
 
 logger = logging.getLogger(__name__)
+
+
+def discover_buildspecs_by_tags(input_tag):
+
+    with open(BUILDSPEC_CACHE_FILE, "r") as fd:
+        cache = json.loads(fd.read())
+
+    buildspecs = []
+    for path in cache.keys():
+        for buildspecfile in cache[path].keys():
+            for test in cache[path][buildspecfile].keys():
+                tag = cache[path][buildspecfile][test].get("tags") or []
+
+                if tag and input_tag in tag:
+                    buildspecs.append(buildspecfile)
+
+    return buildspecs
 
 
 def discover_buildspecs(buildspec):
@@ -140,7 +162,7 @@ def func_build_subcmd(args, config_opts):
     # 1. Command line option --testdir
     # 2. Configuration option specified by 'testdir'
     # 3. Configuration option specified by 'prefix'
-    # 4. Defaults to current working directory in .buildtest subdirectory
+    # 4. Defaults to $BUILDTEST_ROOT/var/tests
     test_directory = (
         args.testdir
         or config_paths_testdir
@@ -163,10 +185,14 @@ def func_build_subcmd(args, config_opts):
     # followed by exclusion check
     buildspecs = []
 
-    # Discover list of one or more Buildspec files based on path provided. Since --buildspec can be provided multiple
-    # times we need to invoke discover_buildspecs once per argument.
-    for option in args.buildspec:
-        buildspecs += discover_buildspecs(option)
+    if args.tags:
+        buildspecs += discover_buildspecs_by_tags(args.tags)
+
+    if args.buildspec:
+        # Discover list of one or more Buildspec files based on path provided. Since --buildspec can be provided multiple
+        # times we need to invoke discover_buildspecs once per argument.
+        for option in args.buildspec:
+            buildspecs += discover_buildspecs(option)
 
     # remove any duplicate Buildspec from list by converting list to set and then back to list
     buildspecs = list(set(buildspecs))

--- a/buildtest/menu/buildspec.py
+++ b/buildtest/menu/buildspec.py
@@ -31,7 +31,7 @@ def func_buildspec_find(args):
     config_opts = load_settings()
 
     buildspec_paths = (
-        config_opts.get("config", {}).get("paths", {}).get("buildspec_root")
+        config_opts.get("config", {}).get("paths", {}).get("buildspec_roots")
     )
     paths = [BUILDSPEC_DEFAULT_PATH]
 
@@ -127,6 +127,7 @@ def func_buildspec_find(args):
                 for file, msg in invalid_buildspecs.items():
                     fd.write(f"buildspec:{file} \n\n")
                     fd.write(f"{msg} \n")
+
             print(f"Writing invalid buildspecs to file: {buildspec_error_file} ")
             print("\n\n")
 
@@ -136,8 +137,7 @@ def func_buildspec_find(args):
     paths = cache.keys()
 
     table = {"Name": [], "Type": [], "Executor": [], "Description": []}
-    # print("{:<25} {:<25} {:<25}".format("Name", "Schema Type", "Executor"))
-    # print("{:_<80}".format(""))
+
     for path in paths:
         for buildspecfile in cache[path].keys():
             for test in cache[path][buildspecfile].keys():
@@ -145,7 +145,7 @@ def func_buildspec_find(args):
                 type = cache[path][buildspecfile][test]["type"]
                 executor = cache[path][buildspecfile][test]["executor"]
                 description = cache[path][buildspecfile][test].get("description")
-                # print("{:<25} {:<25} {:<25}".format(test, type, executor))
+
                 table["Name"].append(test)
                 table["Type"].append(type)
                 table["Executor"].append(executor)

--- a/tests/menu/test_build.py
+++ b/tests/menu/test_build.py
@@ -54,6 +54,7 @@ def test_func_build_subcmd():
         settings = None
         testdir = None
         exclude = None
+        tags = None
 
     buildtest_configuration = load_settings()
 
@@ -65,6 +66,7 @@ def test_func_build_subcmd():
         settings = BUILDTEST_SETTINGS_FILE
         testdir = "/tmp"
         exclude = [buildspec_paths]
+        tags = None
 
     # this results in no buildspecs built
     with pytest.raises(SystemExit):

--- a/tutorials/compilers/passing_args.yml
+++ b/tutorials/compilers/passing_args.yml
@@ -4,6 +4,7 @@ buildspecs:
     type: compiler
     description: Passing arguments example
     executor: local.bash
+    tags: [tutorials]
     build:
       source: "src/argc.c"
       name: gnu

--- a/tutorials/environment.yml
+++ b/tutorials/environment.yml
@@ -6,6 +6,7 @@ buildspecs:
     env:
       FIRST_NAME: avocado
       LAST_NAME: dinosaur
+    tags: [tutorials]
     run: |
       hostname
       whoami

--- a/tutorials/invalid_buildspec_section.yml
+++ b/tutorials/invalid_buildspec_section.yml
@@ -4,6 +4,7 @@ buildspecs:
     executor: local.bash
     type: badscript
     description: invalid type
+    tags: [tutorials]
     env:
       Address: 65 Whale Drive
       City: Manchester

--- a/tutorials/invalid_executor.yml
+++ b/tutorials/invalid_executor.yml
@@ -4,4 +4,5 @@ buildspecs:
     executor: badexecutor
     type: script
     description: valid test but invalid executor name so test won't run
+    tags: [tutorials]
     run: hostname

--- a/tutorials/pass_returncode.yml
+++ b/tutorials/pass_returncode.yml
@@ -5,6 +5,7 @@ buildspecs:
     executor: local.sh
     type: script
     description: exit 1 by default is FAIL
+    tags: [tutorials]
     run: exit 1
 
   exit1_pass:
@@ -12,6 +13,7 @@ buildspecs:
     type: script
     description: report exit 1 as PASS
     run: exit 1
+    tags: [tutorials]
     status:
       returncode: 1
 
@@ -20,6 +22,7 @@ buildspecs:
     type: script
     description: exit 2 failed since it failed to match returncode 1
     run: exit 2
+    tags: [tutorials]
     status:
       returncode: 1
 

--- a/tutorials/python-shell.yml
+++ b/tutorials/python-shell.yml
@@ -5,7 +5,7 @@ buildspecs:
     type: script
     shell: python
     description: "Calculate circle of area given a radius"
-    tags: ["python"]
+    tags: [tutorials]
     run: |
       import math
       radius = 2

--- a/tutorials/selinux.yml
+++ b/tutorials/selinux.yml
@@ -5,6 +5,7 @@ buildspecs:
     type: script
     description: Check if SELinux is Disabled
     run: cat /etc/selinux/config  | egrep -e "^SELINUX=disabled$"
+    tags: [tutorials]
     status:
       regex:
         stream: stdout

--- a/tutorials/shell_examples.yml
+++ b/tutorials/shell_examples.yml
@@ -5,6 +5,7 @@ buildspecs:
     type: script
     description: "/bin/sh shell example"
     shell: /bin/sh
+    tags: [tutorials]
     run: "bzip2 --help"
 
   _bin_bash_shell:
@@ -12,6 +13,7 @@ buildspecs:
     type: script
     description: "/bin/bash shell example"
     shell: /bin/bash
+    tags: [tutorials]
     run: "bzip2 -h"
 
   bash_shell:
@@ -19,6 +21,7 @@ buildspecs:
     type: script
     description: "bash shell example"
     shell: bash
+    tags: [tutorials]
     run: "echo $SHELL"
 
   sh_shell:
@@ -26,6 +29,7 @@ buildspecs:
     type: script
     description: "sh shell example"
     shell: sh
+    tags: [tutorials]
     run: "echo $SHELL"
 
   shell_options:
@@ -33,6 +37,7 @@ buildspecs:
     type: script
     description: "shell options"
     shell: "sh -x"
+    tags: [tutorials]
     run: |
       echo $SHELL
       hostname

--- a/tutorials/skip_tests.yml
+++ b/tutorials/skip_tests.yml
@@ -4,11 +4,13 @@ buildspecs:
     type: script
     executor: local.bash
     skip: Yes
+    tags: [tutorials]
     run: hostname
 
   unskipped:
     type: script
     executor: local.bash
     skip: No
+    tags: [tutorials]
     run: hostname
 

--- a/tutorials/vars.yml
+++ b/tutorials/vars.yml
@@ -3,6 +3,7 @@ buildspecs:
   variables:
     type: script
     executor: local.bash
+    tags: [tutorials]
     vars:
       X: 1
       Y: 2


### PR DESCRIPTION
searches the buildspec cache file for keyword 'tags' and see if
input tag matches one in buildspec.
Add tutorials tag name to tutorials examples