### PR TITLE
add LSF JobName, output, error into jobscript. Fix lsf executor validate bug

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -200,6 +200,11 @@ class BuilderBase:
             for bsub_cmd in bsub:
                 lines.append(f"#BSUB {bsub_cmd}")
 
+            if self.executor.startswith("bsub"):
+                lines.append(f"#BSUB -J {self.name}")
+                lines.append(f"#BSUB -o {self.name}-%J.out")
+                lines.append(f"#BSUB -e {self.name}-%J.err")
+
         return lines
 
     def build(self):

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -200,7 +200,7 @@ class BuilderBase:
             for bsub_cmd in bsub:
                 lines.append(f"#BSUB {bsub_cmd}")
 
-            if self.executor.startswith("bsub"):
+            if self.executor.startswith("lsf"):
                 lines.append(f"#BSUB -J {self.name}")
                 lines.append(f"#BSUB -o {self.name}-%J.out")
                 lines.append(f"#BSUB -e {self.name}-%J.err")

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -100,13 +100,13 @@ def validate_lsf_executors(lsf_executors):
                 )
 
             # check queue record for Status
-            for name in record.keys():
+            for name in record:
 
                 # skip record until we find matching queue
-                if record[name]["QUEUE_NAME"] != queue:
+                if name["QUEUE_NAME"] != queue:
                     continue
 
-                queue_state = record[name]["STATUS"]
+                queue_state = name["STATUS"]
                 # if state not Open:Active we raise error
                 if not queue_state == valid_queue_state:
                     sys.exit(

--- a/buildtest/executors/lsf.py
+++ b/buildtest/executors/lsf.py
@@ -192,8 +192,12 @@ class LSFExecutor(BaseExecutor):
 
         self.result["starttime"] = job_data["START_TIME"]
         self.result["endtime"] = job_data["FINISH_TIME"]
-        self.builder.metadata["outfile"] = job_data["OUTPUT_FILE"]
-        self.builder.metadata["errfile"] = job_data["ERROR_FILE"]
+        self.builder.metadata["outfile"] = os.path.join(
+            self.builder.testdir, job_data["OUTPUT_FILE"]
+        )
+        self.builder.metadata["errfile"] = os.path.join(
+            self.builder.testdir, job_data["ERROR_FILE"]
+        )
 
         self.logger.debug(f"[{self.builder.name}] result: {self.result}")
         self.logger.debug(


### PR DESCRIPTION
There was a bug in lsf executor validate
Added Jobname, output and errorfile into testscript. There was a bug in `buildtest report` when showing output and errorfile for LSF jobs. It was showing the name of file and not full path.