### PR TITLE
fix bug in self.result in LocalExecutor class 

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -61,6 +61,7 @@ class BuilderBase:
         self.metadata["name"] = self.name
         self.metadata["buildspec"] = buildspec
         self.metadata["recipe"] = recipe
+        self.metadata["tags"] = recipe.get("tags")
 
         # A builder is required to define the type attribute
         if not hasattr(self, "type"):
@@ -214,7 +215,7 @@ class BuilderBase:
         """
 
         # Generate a unique id for the build based on key and unique string
-        self.metadata["build_id"] = self._generate_build_id()
+        self.metadata["id"] = self._generate_build_id()
 
         # Derive the path to the test script
         self.metadata["testpath"] = "%s.%s" % (

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -116,7 +116,7 @@ class BaseExecutor:
 
         # Keep an output file
         run_output_file = os.path.join(
-            self.builder.metadata.get("testroot"), self.builder.metadata.get("build_id")
+            self.builder.metadata.get("testroot"), self.builder.metadata.get("id")
         )
         outfile = run_output_file + ".out"
         errfile = run_output_file + ".err"
@@ -192,7 +192,7 @@ class BaseExecutor:
         # Return to starting directory for next test
         os.chdir(self.builder.pwd)
 
-        self.builder.metadata["result"] = self.result
+        # self.builder.metadata["result"] = self.result
 
 
 class SSHExecutor(BaseExecutor):

--- a/buildtest/executors/local.py
+++ b/buildtest/executors/local.py
@@ -33,8 +33,10 @@ class LocalExecutor(BaseExecutor):
            and self.result keeps track of run result. The output and error file
            is written to filesystem. After test
         """
-        # Keep a result object
-        # self.result = {}
+
+        # self.result must be initialized to empty dict since this is shared by
+        # builders that use the Local Executor.
+        self.result = {}
 
         # check shell type mismatch between buildspec shell and executor shell. We can't support python with sh/bash.
         if (
@@ -48,8 +50,7 @@ class LocalExecutor(BaseExecutor):
                 f"[{self.name}]: shell mismatch, expecting {self.shell} while buildspec shell is {self.builder.shell.name}"
             )
 
-        self.result["LOGFILE"] = self.builder.metadata.get("logfile", "")
-        self.result["BUILD_ID"] = self.builder.metadata.get("build_id")
+        self.result["id"] = self.builder.metadata.get("id")
 
         # Change to the test directory
         os.chdir(self.builder.metadata["testroot"])
@@ -74,8 +75,6 @@ class LocalExecutor(BaseExecutor):
         self.builder.metadata["endtime"] = datetime.datetime.now()
         self.result["endtime"] = self.get_formatted_time("endtime")
 
-        self.write_testresults(out, err)
-
         self.logger.debug(
             f"Return code: {command.returncode} for test: {self.builder.metadata['testpath']}"
         )
@@ -83,3 +82,5 @@ class LocalExecutor(BaseExecutor):
 
         self.write_testresults(out, err)
         self.check_test_state()
+
+        self.builder.metadata["result"] = self.result

--- a/buildtest/executors/lsf.py
+++ b/buildtest/executors/lsf.py
@@ -78,7 +78,7 @@ class LSFExecutor(BaseExecutor):
 
         self.check()
 
-        self.result["BUILD_ID"] = self.builder.metadata.get("build_id")
+        self.result["id"] = self.builder.metadata.get("id")
 
         os.chdir(self.builder.metadata["testroot"])
         self.logger.debug(f"Changing to directory {self.builder.metadata['testroot']}")

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -89,7 +89,7 @@ class SlurmExecutor(BaseExecutor):
 
         self.check()
 
-        self.result["BUILD_ID"] = self.builder.metadata.get("build_id")
+        self.result["id"] = self.builder.metadata.get("id")
 
         os.chdir(self.builder.metadata["testroot"])
         self.logger.debug(f"Changing to directory {self.builder.metadata['testroot']}")

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -88,7 +88,9 @@ class SlurmExecutor(BaseExecutor):
         """This method is responsible for dispatching job to slurm scheduler."""
 
         self.check()
-
+        self.result = {}
+        # The job_id variable is used to store the JobID retrieved by sacct
+        self.job_id = 0
         self.result["id"] = self.builder.metadata.get("id")
 
         os.chdir(self.builder.metadata["testroot"])
@@ -128,7 +130,7 @@ class SlurmExecutor(BaseExecutor):
 
         print(f"[{self.builder.metadata['name']}] job dispatched to scheduler")
         print(
-            f"[{self.builder.metadata['name']}] acquiring job id in {interval} seconds"
+            f"[{self.builder.metadata['name']}] acquiring JobID in {interval} seconds"
         )
 
         # wait 5 seconds before querying slurm for jobID. It can take few seconds
@@ -145,9 +147,10 @@ class SlurmExecutor(BaseExecutor):
         self.logger.debug(f"[Acquire Job ID]: {cmd}")
         output = subprocess.check_output(cmd, shell=True, universal_newlines=True)
         self.job_id = int(output.strip())
-        self.logger.debug(
-            f"[{self.builder.metadata['name']}] JobID: {self.job_id} dispatched to scheduler"
-        )
+        msg = f"[{self.builder.metadata['name']}] JobID: {self.job_id} dispatched to scheduler"
+        print(msg)
+        self.logger.debug(msg)
+
         self.result["state"] = "N/A"
         self.result["runtime"] = "0"
         self.result["returncode"] = "0"
@@ -221,3 +224,4 @@ class SlurmExecutor(BaseExecutor):
             f"[{self.builder.name}] returncode: {self.result['returncode']}"
         )
         self.check_test_state()
+        self.builder.metadata["result"] = self.result

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -382,7 +382,6 @@ def func_build_subcmd(args, config_opts):
         print("\n")
 
     ########## END RUN STAGE ####################
-
     # poll will be True if one of the result State is N/A which is buildtest way to inform job is dispatched to scheduler which requires polling
     if poll:
         ########## BEGIN POLL STAGE ####################

--- a/buildtest/menu/report.py
+++ b/buildtest/menu/report.py
@@ -162,8 +162,10 @@ def update_report(valid_builders):
         ]:
             entry[item] = builder.metadata[item]
 
-        # convert tags to string.
-        entry["tags"] = " ".join(builder.metadata["tags"])
+        entry["tags"] = ""
+        # convert tags to string if defined in buildspec
+        if builder.metadata["tags"]:
+            entry["tags"] = " ".join(builder.metadata["tags"])
 
         # query over result attributes, we only assign some keys of interest
         for item in ["starttime", "endtime", "runtime", "state", "returncode"]:

--- a/buildtest/menu/report.py
+++ b/buildtest/menu/report.py
@@ -28,7 +28,7 @@ def func_report(args=None):
     format_fields = [
         "buildspec",
         "name",
-        "build_id",
+        "id",
         "testroot",
         "testpath",
         "command",
@@ -36,6 +36,7 @@ def func_report(args=None):
         "errfile",
         "schemafile",
         "executor",
+        "tags",
         "starttime",
         "endtime",
         "runtime",
@@ -46,7 +47,7 @@ def func_report(args=None):
     format_table = [
         ["buildspec", "Buildspec file"],
         ["name", "Name of test defined in buildspec"],
-        ["build_id", "Unique Build Identifier"],
+        ["id", "Unique Build Identifier"],
         ["testroot", "Root of test directory"],
         ["testpath", "Path to test"],
         ["command", "Command executed"],
@@ -54,6 +55,7 @@ def func_report(args=None):
         ["errfile", "Error File"],
         ["schemafile", "Schema file used for validation"],
         ["executor", "Executor name"],
+        ["tags", "Tag name"],
         ["starttime", "Start Time of test in date format"],
         ["endtime", "End Time for Test in date format"],
         ["runtime", "Total runtime in seconds"],
@@ -70,13 +72,13 @@ def func_report(args=None):
 
     # default table format fields
     display_table = {
-        "name": [],
+        "id": [],
         "state": [],
         "returncode": [],
         "starttime": [],
         "endtime": [],
         "runtime": [],
-        "build_id": [],
+        "tags": [],
         "buildspec": [],
     }
 
@@ -149,7 +151,7 @@ def update_report(valid_builders):
         # query over attributes found in builder.metadata, we only assign
         # keys that we care obout for reporting
         for item in [
-            "build_id",
+            "id",
             "testroot",
             "testpath",
             "command",
@@ -159,6 +161,9 @@ def update_report(valid_builders):
             "executor",
         ]:
             entry[item] = builder.metadata[item]
+
+        # convert tags to string.
+        entry["tags"] = " ".join(builder.metadata["tags"])
 
         # query over result attributes, we only assign some keys of interest
         for item in ["starttime", "endtime", "runtime", "state", "returncode"]:


### PR DESCRIPTION
This PR is fixing a bug where base class (BaseExecutor) was initializing self.result and it was not reset in child class LocalExecutor.run().

Each builder that used same executor were sharing variables this caused issue with returncode that was incorrectly reported in var/report.json