### PR TITLE
add buildtest build --executor option to filter test by executor name

### DIFF
--- a/buildtest/buildsystem/parser.py
+++ b/buildtest/buildsystem/parser.py
@@ -172,7 +172,7 @@ class BuildspecParser:
 
     # Builders
 
-    def get_builders(self, testdir):
+    def get_builders(self, testdir, tag_filter=None, executor_filter=None):
         """Based on a loaded Buildspec file, return the correct builder
            for each based on the type. Each type is associated with a known
            Builder class.
@@ -191,6 +191,26 @@ class BuildspecParser:
                 if recipe.get("skip"):
                     print(f"[{name}] test is skipped.")
                     continue
+
+                # if input 'buildtest build --executor' is set we filter test by
+                # executor name. For now we skip all test that don't belong in executor list.
+                if executor_filter and recipe.get("executor") not in executor_filter:
+                    print(
+                        f"[{name}] test is skipped because it is not in executor filter list: {executor_filter}"
+                    )
+                    continue
+
+                if tag_filter:
+                    found = False
+                    for tagname in tag_filter:
+                        if tagname in recipe.get("tags"):
+                            found = True
+
+                    if not found:
+                        print(
+                            f"[{name}] test is skipped because it is not in tag filter list: {tag_filter}"
+                        )
+                        continue
 
                 # Add the builder based on the type
                 if recipe["type"] == "script":

--- a/buildtest/docgen/main.py
+++ b/buildtest/docgen/main.py
@@ -63,6 +63,8 @@ def tutorial():
         f"{os.path.join(prefix, 'tags.txt')}": "buildtest build --tags tutorials",
         f"{os.path.join(prefix, 'multi-tags.txt')}": "buildtest build --tags compile --tags python",
         f"{os.path.join(prefix, 'combine-tags-buildspec-exclude.txt')}": "buildtest build --tags python -b tutorials/compilers -x tutorials/compilers/vecadd.yml",
+        f"{os.path.join(prefix, 'single-executor.txt')}": "buildtest build --executor local.sh",
+        f"{os.path.join(prefix, 'multi-executor.txt')}": "buildtest build --executor local.sh --executor local.bash",
         f"{os.path.join(prefix, 'stage_parse.txt')}": "buildtest build -b tutorials/systemd.yml --stage=parse",
         f"{os.path.join(prefix, 'stage_build.txt')}": "buildtest build -b tutorials/systemd.yml --stage=build",
     }

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -169,16 +169,6 @@ class BuildTestParser:
         )
 
         parser_build.add_argument(
-            "-t",
-            "--testdir",
-            help="specify a custom test directory. By default, use .buildtest in $PWD.",
-        )
-
-        parser_build.add_argument(
-            "--settings", help="Specify an alternate buildtest settings file to use",
-        )
-
-        parser_build.add_argument(
             "-x",
             "--exclude",
             action="append",
@@ -186,13 +176,34 @@ class BuildTestParser:
         )
 
         parser_build.add_argument(
-            "--tags", action="append", type=str, help="Specify buildspecs by tags",
+            "--tags",
+            action="append",
+            type=str,
+            help="Specify buildspecs by tags found in buildspec cache",
+        )
+
+        parser_build.add_argument(
+            "-e",
+            "--executor",
+            action="append",
+            type=str,
+            help="Specify buildspecs by executor name found in buildspec cache",
         )
         parser_build.add_argument(
             "-s",
             "--stage",
             help="control behavior of buildtest build",
             choices=["parse", "build"],
+        )
+
+        parser_build.add_argument(
+            "-t",
+            "--testdir",
+            help="specify a custom test directory. By default, use .buildtest in $PWD.",
+        )
+
+        parser_build.add_argument(
+            "--settings", help="Specify an alternate buildtest settings file to use",
         )
 
     def buildspec_menu(self):

--- a/buildtest/menu/buildspec.py
+++ b/buildtest/menu/buildspec.py
@@ -307,7 +307,9 @@ def get_executors(cache):
     print(tabulate(table, headers=table.keys(), tablefmt="grid"))
 
 
-def parse_buildspecs(buildspecs, test_directory, printTable=False):
+def parse_buildspecs(
+    buildspecs, test_directory, tags=None, executors=None, printTable=False
+):
     """ Parse all buildspecs by invoking class ``BuildspecParser``. If buildspec
         fails validation we add it to ``skipped_tests`` list and print all skipped
         tests at end. If buildspec passes validation we get all builders by invoking
@@ -339,7 +341,9 @@ def parse_buildspecs(buildspecs, test_directory, printTable=False):
         table["validstate"].append(valid_state)
         table["buildspec"].append(buildspec)
 
-        builders += bp.get_builders(testdir=test_directory)
+        builders += bp.get_builders(
+            testdir=test_directory, tag_filter=tags, executor_filter=executors
+        )
 
     # print any skipped buildspecs if they failed to validate during build stage
     if len(skipped_tests) > 0:

--- a/docs/docgen/buildtest_build_--help.txt
+++ b/docs/docgen/buildtest_build_--help.txt
@@ -1,16 +1,18 @@
 $ buildtest build --help
-usage: buildtest [options] [COMMANDS] build [-h] [-b BUILDSPEC] [-t TESTDIR] [--settings SETTINGS] [-x EXCLUDE]
-                                            [--tags TAGS] [-s {parse,build}]
+usage: buildtest [options] [COMMANDS] build [-h] [-b BUILDSPEC] [-x EXCLUDE] [--tags TAGS] [-e EXECUTOR]
+                                            [-s {parse,build}] [-t TESTDIR] [--settings SETTINGS]
 
 optional arguments:
   -h, --help            show this help message and exit
   -b BUILDSPEC, --buildspec BUILDSPEC
                         Specify a Buildspec (YAML) file to build and run the test.
+  -x EXCLUDE, --exclude EXCLUDE
+                        Exclude one or more configs from processing. Configs can be files or directories.
+  --tags TAGS           Specify buildspecs by tags found in buildspec cache
+  -e EXECUTOR, --executor EXECUTOR
+                        Specify buildspecs by executor name found in buildspec cache
+  -s {parse,build}, --stage {parse,build}
+                        control behavior of buildtest build
   -t TESTDIR, --testdir TESTDIR
                         specify a custom test directory. By default, use .buildtest in $PWD.
   --settings SETTINGS   Specify an alternate buildtest settings file to use
-  -x EXCLUDE, --exclude EXCLUDE
-                        Exclude one or more configs from processing. Configs can be files or directories.
-  --tags TAGS           Specify buildspecs by tags
-  -s {parse,build}, --stage {parse,build}
-                        control behavior of buildtest build

--- a/docs/docgen/buildtest_buildspec_find_tags.txt
+++ b/docs/docgen/buildtest_buildspec_find_tags.txt
@@ -5,7 +5,11 @@ Searching buildspec in following directories:  /Users/siddiq90/Documents/buildte
 +===========+
 | tutorials |
 +-----------+
+| fail      |
++-----------+
 | compile   |
 +-----------+
 | python    |
++-----------+
+| pass      |
 +-----------+

--- a/docs/docgen/getting_started/multi-executor.txt
+++ b/docs/docgen/getting_started/multi-executor.txt
@@ -1,0 +1,108 @@
+$ buildtest build --executor local.sh --executor local.bash 
+
++-------------------------------+
+| Stage: Discovering Buildspecs |
++-------------------------------+ 
+    
+
+Discovered Buildspecs:
+ 
+/Users/siddiq90/Documents/buildtest/tutorials/compilers/gnu_hello.yml
+/Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+/Users/siddiq90/Documents/buildtest/tutorials/compilers/pre_post_build_run.yml
+/Users/siddiq90/Documents/buildtest/tutorials/environment.yml
+/Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
+/Users/siddiq90/Documents/buildtest/tutorials/compilers/passing_args.yml
+/Users/siddiq90/Documents/buildtest/tutorials/systemd.yml
+/Users/siddiq90/Documents/buildtest/tutorials/compilers/vecadd.yml
+/Users/siddiq90/Documents/buildtest/tutorials/selinux.yml
+/Users/siddiq90/Documents/buildtest/tutorials/skip_tests.yml
+/Users/siddiq90/Documents/buildtest/tutorials/vars.yml
+[skip] test is skipped.
+
++---------------------------+
+| Stage: Parsing Buildspecs |
++---------------------------+ 
+    
+ schemafile                | validstate   | buildspec
+---------------------------+--------------+--------------------------------------------------------------------------------
+ compiler-v1.0.schema.json | True         | /Users/siddiq90/Documents/buildtest/tutorials/compilers/gnu_hello.yml
+ script-v1.0.schema.json   | True         | /Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+ compiler-v1.0.schema.json | True         | /Users/siddiq90/Documents/buildtest/tutorials/compilers/pre_post_build_run.yml
+ script-v1.0.schema.json   | True         | /Users/siddiq90/Documents/buildtest/tutorials/environment.yml
+ script-v1.0.schema.json   | True         | /Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
+ compiler-v1.0.schema.json | True         | /Users/siddiq90/Documents/buildtest/tutorials/compilers/passing_args.yml
+ script-v1.0.schema.json   | True         | /Users/siddiq90/Documents/buildtest/tutorials/systemd.yml
+ compiler-v1.0.schema.json | True         | /Users/siddiq90/Documents/buildtest/tutorials/compilers/vecadd.yml
+ script-v1.0.schema.json   | True         | /Users/siddiq90/Documents/buildtest/tutorials/selinux.yml
+ script-v1.0.schema.json   | True         | /Users/siddiq90/Documents/buildtest/tutorials/skip_tests.yml
+ script-v1.0.schema.json   | True         | /Users/siddiq90/Documents/buildtest/tutorials/vars.yml
+
++----------------------+
+| Stage: Building Test |
++----------------------+ 
+
+ Name                   | Schema File               | Test Path                                                                                                  | Buildspec
+------------------------+---------------------------+------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------
+ hello_f                | compiler-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/hello_f/generate.sh                     | /Users/siddiq90/Documents/buildtest/tutorials/compilers/gnu_hello.yml
+ hello_c                | compiler-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/hello_c/generate.sh                     | /Users/siddiq90/Documents/buildtest/tutorials/compilers/gnu_hello.yml
+ hello_cplusplus        | compiler-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/hello_cplusplus/generate.sh             | /Users/siddiq90/Documents/buildtest/tutorials/compilers/gnu_hello.yml
+ cc_example             | compiler-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/cc_example/generate.sh                  | /Users/siddiq90/Documents/buildtest/tutorials/compilers/gnu_hello.yml
+ fc_example             | compiler-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/fc_example/generate.sh                  | /Users/siddiq90/Documents/buildtest/tutorials/compilers/gnu_hello.yml
+ cxx_example            | compiler-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/cxx_example/generate.sh                 | /Users/siddiq90/Documents/buildtest/tutorials/compilers/gnu_hello.yml
+ _bin_sh_shell          | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/_bin_sh_shell/generate.sh            | /Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+ _bin_bash_shell        | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/shell_examples/_bin_bash_shell/generate.sh        | /Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+ bash_shell             | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/shell_examples/bash_shell/generate.sh             | /Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+ sh_shell               | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/sh_shell/generate.sh                 | /Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+ shell_options          | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/shell_options/generate.sh            | /Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+ pre_post_build_run     | compiler-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/pre_post_build_run/pre_post_build_run/generate.sh | /Users/siddiq90/Documents/buildtest/tutorials/compilers/pre_post_build_run.yml
+ environment_variables  | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/environment/environment_variables/generate.sh     | /Users/siddiq90/Documents/buildtest/tutorials/environment.yml
+ exit1_fail             | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_fail/generate.sh              | /Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
+ exit1_pass             | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_pass/generate.sh              | /Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
+ returncode_mismatch    | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/returncode_mismatch/generate.sh     | /Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
+ executable_arguments   | compiler-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/passing_args/executable_arguments/generate.sh     | /Users/siddiq90/Documents/buildtest/tutorials/compilers/passing_args.yml
+ systemd_default_target | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/systemd/systemd_default_target/generate.sh        | /Users/siddiq90/Documents/buildtest/tutorials/systemd.yml
+ vecadd_gnu             | compiler-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/vecadd/vecadd_gnu/generate.sh                     | /Users/siddiq90/Documents/buildtest/tutorials/compilers/vecadd.yml
+ selinux_disable        | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/selinux/selinux_disable/generate.sh               | /Users/siddiq90/Documents/buildtest/tutorials/selinux.yml
+ unskipped              | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/skip_tests/unskipped/generate.sh                  | /Users/siddiq90/Documents/buildtest/tutorials/skip_tests.yml
+ variables              | script-v1.0.schema.json   | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/vars/variables/generate.sh                        | /Users/siddiq90/Documents/buildtest/tutorials/vars.yml
+
++----------------------+
+| Stage: Running Test  |
++----------------------+ 
+    
+ name                   | executor   | status   |   returncode | testpath
+------------------------+------------+----------+--------------+------------------------------------------------------------------------------------------------------------
+ hello_f                | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/hello_f/generate.sh
+ hello_c                | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/hello_c/generate.sh
+ hello_cplusplus        | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/hello_cplusplus/generate.sh
+ cc_example             | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/cc_example/generate.sh
+ fc_example             | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/fc_example/generate.sh
+ cxx_example            | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/gnu_hello/cxx_example/generate.sh
+ _bin_sh_shell          | local.sh   | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/_bin_sh_shell/generate.sh
+ _bin_bash_shell        | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/shell_examples/_bin_bash_shell/generate.sh
+ bash_shell             | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/shell_examples/bash_shell/generate.sh
+ sh_shell               | local.sh   | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/sh_shell/generate.sh
+ shell_options          | local.sh   | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/shell_options/generate.sh
+ pre_post_build_run     | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/pre_post_build_run/pre_post_build_run/generate.sh
+ environment_variables  | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/environment/environment_variables/generate.sh
+ exit1_fail             | local.sh   | FAIL     |            1 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_fail/generate.sh
+ exit1_pass             | local.sh   | PASS     |            1 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_pass/generate.sh
+ returncode_mismatch    | local.sh   | FAIL     |            2 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/returncode_mismatch/generate.sh
+ executable_arguments   | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/passing_args/executable_arguments/generate.sh
+ systemd_default_target | local.bash | FAIL     |            1 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/systemd/systemd_default_target/generate.sh
+ vecadd_gnu             | local.bash | FAIL     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/vecadd/vecadd_gnu/generate.sh
+ selinux_disable        | local.bash | FAIL     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/selinux/selinux_disable/generate.sh
+ unskipped              | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/skip_tests/unskipped/generate.sh
+ variables              | local.bash | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.bash/vars/variables/generate.sh
+
++----------------------+
+| Stage: Test Summary  |
++----------------------+ 
+    
+Executed 22 tests
+Passed Tests: 17/22 Percentage: 77.273%
+Failed Tests: 5/22 Percentage: 22.727%
+
+
+

--- a/docs/docgen/getting_started/single-executor.txt
+++ b/docs/docgen/getting_started/single-executor.txt
@@ -1,0 +1,59 @@
+$ buildtest build --executor local.sh 
+
++-------------------------------+
+| Stage: Discovering Buildspecs |
++-------------------------------+ 
+    
+
+Discovered Buildspecs:
+ 
+/Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
+/Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+[_bin_bash_shell] test is skipped because it is not in executor filter list: ['local.sh']
+[bash_shell] test is skipped because it is not in executor filter list: ['local.sh']
+
++---------------------------+
+| Stage: Parsing Buildspecs |
++---------------------------+ 
+    
+ schemafile              | validstate   | buildspec
+-------------------------+--------------+-------------------------------------------------------------------
+ script-v1.0.schema.json | True         | /Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
+ script-v1.0.schema.json | True         | /Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+
++----------------------+
+| Stage: Building Test |
++----------------------+ 
+
+ Name                | Schema File             | Test Path                                                                                              | Buildspec
+---------------------+-------------------------+--------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------
+ exit1_fail          | script-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_fail/generate.sh          | /Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
+ exit1_pass          | script-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_pass/generate.sh          | /Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
+ returncode_mismatch | script-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/returncode_mismatch/generate.sh | /Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
+ _bin_sh_shell       | script-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/_bin_sh_shell/generate.sh        | /Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+ sh_shell            | script-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/sh_shell/generate.sh             | /Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+ shell_options       | script-v1.0.schema.json | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/shell_options/generate.sh        | /Users/siddiq90/Documents/buildtest/tutorials/shell_examples.yml
+
++----------------------+
+| Stage: Running Test  |
++----------------------+ 
+    
+ name                | executor   | status   |   returncode | testpath
+---------------------+------------+----------+--------------+--------------------------------------------------------------------------------------------------------
+ exit1_fail          | local.sh   | FAIL     |            1 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_fail/generate.sh
+ exit1_pass          | local.sh   | PASS     |            1 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_pass/generate.sh
+ returncode_mismatch | local.sh   | FAIL     |            2 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/returncode_mismatch/generate.sh
+ _bin_sh_shell       | local.sh   | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/_bin_sh_shell/generate.sh
+ sh_shell            | local.sh   | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/sh_shell/generate.sh
+ shell_options       | local.sh   | PASS     |            0 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/shell_examples/shell_options/generate.sh
+
++----------------------+
+| Stage: Test Summary  |
++----------------------+ 
+    
+Executed 6 tests
+Passed Tests: 4/6 Percentage: 66.667%
+Failed Tests: 2/6 Percentage: 33.333%
+
+
+

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -135,7 +135,7 @@ example we build all tests with tag name `compiler` and `python`.
 
 When multiple tags are specified, we search each tag independently and if it
 is found in the buildspec cache we retrieve the test. To see a list of available
-tags in your buildspec cache see :ref:`find_buildspecs`.
+tags in your buildspec cache see :ref:`buildspec_tags`.
 
 You can combine ``--tags`` with ``--buildspec`` and ``--exclude`` in a single command.
 buildtest will query tags and buildspecs independently and combine all discovered
@@ -148,6 +148,32 @@ but we exclude **tutorials/compilers/vecadd.yml**.
 
 .. program-output:: cat docgen/getting_started/combine-tags-buildspec-exclude.txt
 
+Building by Executors
+-----------------------
+
+buildtest can build tests by executor name using the ``--executor`` option. If you
+to build all test associated to an executor such as ``local.sh`` you can run::
+
+  $ buildtest build --executor local.sh
+
+buildtest will query buildspec cache for the executor name and retrieve a list of
+buildspecs with matching executor name. Later we process every buildspec and filter
+tests with executor name. In the first stage we retrieve the buildspec file which may
+contain one or more test and in second stage we process each test.
+
+To see a list of available executors in buildspec cache see :ref:`buildspec_executor`.
+
+.. Note:: By default all tests are run in buildspec file, the --executor is filtering by tests
+
+In this example we run all tests that are associated to `local.sh` executor
+
+.. program-output:: cat docgen/getting_started/single-executor.txt
+
+We can append arguments to ``--executor`` to search for multiple executors by
+specifying ``--executor <name1> --executor <name2>``. In next example we search
+all tests associated with ``local.sh`` and ``local.bash`` executor.
+
+.. program-output:: cat docgen/getting_started/multi-executor.txt
 
 
 Control builds by Stages
@@ -225,14 +251,24 @@ Shown below is a list of options for ``buildtest buildspec find`` command.
 
 .. program-output:: cat docgen/buildtest_buildspec_find_--help.txt
 
+If you want to find all buildspec files in cache run ``buildtest buildspec find --buildspec-files``
+
+.. program-output:: cat docgen/buildtest_buildspec_find_buildspecfiles.txt
+
+.. _buildspec_tags:
+
+Querying buildspec tags
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 If you want to retrieve all unique tags from all buildspecs you can run
 ``buildtest buildspec find --tags``
 
 .. program-output:: cat docgen/buildtest_buildspec_find_tags.txt
 
-If you want to find all buildspec files in cache run ``buildtest buildspec find --buildspec-files``
+.. _buildspec_executor:
 
-.. program-output:: cat docgen/buildtest_buildspec_find_buildspecfiles.txt
+Querying buildspec executor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To find all executors from cache you can run ``buildtest buildspec find --list-executors``.
 This will retrieve the `'executor'` field from all buildspec and any duplicates will

--- a/tests/menu/test_build.py
+++ b/tests/menu/test_build.py
@@ -37,6 +37,7 @@ def test_build_by_tags():
         testdir = None
         exclude = None
         tags = ["tutorials"]
+        executor = None
 
     #  testing buildtest build --tags tutorials
     func_build_subcmd(args, buildtest_configuration)
@@ -49,6 +50,7 @@ def test_build_by_tags():
         testdir = None
         exclude = None
         tags = ["compile", "python"]
+        executor = None
 
     #  testing buildtest build --tags tutorials --tags python
     func_build_subcmd(args, buildtest_configuration)
@@ -133,9 +135,9 @@ def test_discover_buildspec():
     assert discovered_bp
     assert not exclude_bps
 
-    # the tags field expect a string when searching in cache, passing a list will raise AssertionError
-    # with pytest.raises(AssertionError):
-    #    discover_buildspecs(tags=["tutorials"])
+    # the tags field expect a list when searching in cache, passing a string will raise AssertionError
+    with pytest.raises(AssertionError):
+        discover_buildspecs(tags="tutorials")
 
 
 def test_build_buildspecs():
@@ -150,6 +152,7 @@ def test_build_buildspecs():
         testdir = None
         exclude = None
         tags = None
+        executor = None
 
     #  testing buildtest build --buildspec tests/examples/buildspecs
     func_build_subcmd(args, buildtest_configuration)
@@ -162,6 +165,7 @@ def test_build_buildspecs():
         testdir = "/tmp"
         exclude = [buildspec_paths]
         tags = None
+        executor = None
 
     #  testing buildtest build --buildspec tests/examples/buildspecs --exclude tests/examples/buildspecs
     # this results in no buildspecs built
@@ -181,6 +185,7 @@ def test_build_by_stages():
         testdir = None
         exclude = None
         tags = ["tutorials"]
+        executor = None
 
     # testing buildtest build --tags tutorials --stage=parse
     func_build_subcmd(args, buildtest_configuration)
@@ -193,6 +198,7 @@ def test_build_by_stages():
         testdir = None
         exclude = None
         tags = ["tutorials"]
+        executor = None
 
     # testing buildtest build --tags tutorials --stage=build
     func_build_subcmd(args, buildtest_configuration)

--- a/tutorials/invalid_buildspec_section.yml
+++ b/tutorials/invalid_buildspec_section.yml
@@ -4,7 +4,7 @@ buildspecs:
     executor: local.bash
     type: badscript
     description: invalid type
-    tags: [tutorials]
+    tags: [tutorials, fail]
     env:
       Address: 65 Whale Drive
       City: Manchester

--- a/tutorials/invalid_executor.yml
+++ b/tutorials/invalid_executor.yml
@@ -4,5 +4,5 @@ buildspecs:
     executor: badexecutor
     type: script
     description: valid test but invalid executor name so test won't run
-    tags: [tutorials]
+    tags: [tutorials, fail]
     run: hostname

--- a/tutorials/pass_returncode.yml
+++ b/tutorials/pass_returncode.yml
@@ -5,7 +5,7 @@ buildspecs:
     executor: local.sh
     type: script
     description: exit 1 by default is FAIL
-    tags: [tutorials]
+    tags: [tutorials, fail]
     run: exit 1
 
   exit1_pass:
@@ -13,7 +13,7 @@ buildspecs:
     type: script
     description: report exit 1 as PASS
     run: exit 1
-    tags: [tutorials]
+    tags: [tutorials, pass]
     status:
       returncode: 1
 
@@ -22,7 +22,7 @@ buildspecs:
     type: script
     description: exit 2 failed since it failed to match returncode 1
     run: exit 2
-    tags: [tutorials]
+    tags: [tutorials, fail]
     status:
       returncode: 1
 


### PR DESCRIPTION
This option can be appended multiple times.
Add documentation and example on this feature.
The tags and executors need to be filtered in BuildspecParser when getting
the builders. The tag query was testing querying the buildspecs but not filtering
by tests.
Add few extra tags in tutorials examples.