### PR TITLE
remove buildtest --docs and --schemadocs and replace with positional

### DIFF
--- a/buildtest/docs.py
+++ b/buildtest/docs.py
@@ -5,11 +5,11 @@ requested from command line.
 import webbrowser
 
 
-def buildtestdocs():
+def buildtestdocs(args):
     """Open buildtest docs in web browser. This implements ``buildtest --docs``"""
     webbrowser.open("https://buildtest.readthedocs.io/")
 
 
-def schemadocs():
+def schemadocs(args):
     """Open buildtest schema docs in web browser. This implements ``buildtest --schemadocs``"""
     webbrowser.open("https://buildtesters.github.io/schemas/")

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -1,6 +1,5 @@
 import os
 from buildtest.config import load_settings, check_settings
-from buildtest.docs import buildtestdocs, schemadocs
 from buildtest.defaults import var_root, BUILDTEST_USER_HOME
 from buildtest.menu import BuildTestParser
 from buildtest.menu.build import func_build_subcmd
@@ -33,12 +32,6 @@ def main():
 
     if args.debug:
         streamlog(args.debug)
-
-    if args.docs:
-        buildtestdocs()
-
-    if args.schemadocs:
-        schemadocs()
 
     # invoking load_settings will attempt to initialize buildtest settings and
     # load the schema

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -7,6 +7,7 @@ import argparse
 
 from buildtest import BUILDTEST_VERSION
 from buildtest.defaults import supported_schemas
+from buildtest.docs import buildtestdocs, schemadocs
 from buildtest.menu.buildspec import (
     func_buildspec_find,
     func_buildspec_edit,
@@ -77,6 +78,8 @@ class BuildTestParser:
             "report": "Show report for test results",
             "schema": "Commands for viewing buildtest schemas",
             "config": "Buildtest Configuration Menu",
+            "docs": "Open buildtest docs in browser",
+            "schemadocs": "Open buildtest schema docs in browser",
         }
 
         self.main_menu()
@@ -109,14 +112,11 @@ class BuildTestParser:
             choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
             help="Enable debugging messages.",
         )
-        self.parser.add_argument(
-            "--docs", action="store_true", help="Open buildtest docs in browser"
-        )
-        self.parser.add_argument(
-            "--schemadocs",
-            action="store_true",
-            help="Open buildtest  schema docs in browser",
-        )
+        parser_docs = self.subparsers.add_parser("docs")
+        parser_docs.set_defaults(func=buildtestdocs)
+
+        parser_schemadocs = self.subparsers.add_parser("schemadocs")
+        parser_schemadocs.set_defaults(func=schemadocs)
 
     def parse_options(self):
         """This method parses the argument from ArgumentParser class and returns

--- a/docs/configuring_buildtest.rst
+++ b/docs/configuring_buildtest.rst
@@ -244,6 +244,50 @@ buildspec_roots. buildtest will find all `.yml` extension. By default buildtest 
 add the ``$BUILDTEST_ROOT/tutorials`` to search path, where $BUILDTEST_ROOT is root
 of buildtest repo.
 
+Before & After scripts for executors
+-------------------------------------
+
+Often times, you may want to run a set of commands before or after tests for more than
+one test. For this reason, we support ``before_script`` and ``after_script`` section
+per executor which is of string type where you can specify arbitrary commands.
+
+This can be demonstrated with this executor name **local.e4s** responsible for
+building `E4S Testsuite <https://github.com/E4S-Project/testsuite>`_::
+
+    e4s:
+      description: "E4S testsuite locally"
+      shell: bash
+      before_script: |
+        cd $SCRATCH
+        git clone https://github.com/E4S-Project/testsuite.git
+        cd testsuite
+        source /global/common/software/spackecp/luke-wyatt-testing/spack/share/spack/setup-env.sh
+        source setup.sh
+
+buildtest will write a ``before_script.sh`` and ``after_script.sh`` for every executor.
+This can be found in ``var/executors`` directory as shown below::
+
+    $ tree var/executors/
+    var/executors/
+    |-- local.bash
+    |   |-- after_script.sh
+    |   `-- before_script.sh
+    |-- local.e4s
+    |   |-- after_script.sh
+    |   `-- before_script.sh
+    |-- local.python
+    |   |-- after_script.sh
+    |   `-- before_script.sh
+    |-- local.sh
+    |   |-- after_script.sh
+    |   `-- before_script.sh
+
+
+    4 directories, 8 files
+
+The ``before_script`` and ``after_script`` field is available for all executors and
+if its not specified the file will be empty. Every test will source the before
+and after script for the given executor.
 
 CLI to buildtest configuration
 -----------------------------------------------

--- a/docs/docgen/buildtest_--help.txt
+++ b/docs/docgen/buildtest_--help.txt
@@ -8,8 +8,6 @@ optional arguments:
   -V, --version         show program's version number and exit
   -d {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --debug {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                         Enable debugging messages.
-  --docs                Open buildtest docs in browser
-  --schemadocs          Open buildtest schema docs in browser
 
 COMMANDS:
 
@@ -18,7 +16,9 @@ COMMANDS:
    report                         Show report for test results
    schema                         Commands for viewing buildtest schemas
    config                         Buildtest Configuration Menu
+   docs                           Open buildtest docs in browser
+   schemadocs                     Open buildtest schema docs in browser
 
-  {build,buildspec,report,schema,config}
+  {docs,schemadocs,build,buildspec,report,schema,config}
 
 Documentation: https://buildtest.readthedocs.io/en/latest/index.html

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -432,16 +432,34 @@ Debug Mode
 ------------
 
 buildtest can stream logs to ``stdout`` stream for debugging. You can use ``buildtest -d <DEBUGLEVEL>``
-or long option ``--debug`` with any buildtest commands. The DEBUGLEVEL are:
-``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``,  ``CRITICAL`` which controls
-log level to be displayed in console. buildtest is using
-`logging.setLevel <https://docs.python.org/3/library/logging.html#logging.Logger.setLevel>`_
+or long option ``--debug`` with any buildtest commands. The DEBUGLEVEL are the following:
+
+- DEBUG
+- INFO
+- WARNING
+- ERROR
+- CRITICAL
+
+buildtest is using `logging.setLevel <https://docs.python.org/3/library/logging.html#logging.Logger.setLevel>`_
 to control log level.
 
-The same content is logged in **buildtest.log** with default log level of ``DEBUG``.
+The content is logged in **buildtest.log** with default log level of ``DEBUG``.
 If you want to get all logs use ``-d DEBUG`` with your buildtest command::
 
     buildtest -d DEBUG <command>
+
+Accessing buildtest documentation
+----------------------------------
+
+We provide two command line options to access buildtest and schema docs. To
+access buildtest docs you can run::
+
+  $ buildtest docs
+
+To access schema docs run::
+
+  $ buildtest schemadocs
+
 
 Logfile
 -------


### PR DESCRIPTION
arguments "docs" and "schemadocs"
Add documentation on before_script and after_script for executor