### PR TITLE
Fix python bug and add stage/run directory for staging builds

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -100,16 +100,11 @@ class BuilderBase:
         """Return the test extension, which depends on the shell used. Based
            on the value of ``shell`` key we return the shell extension.
 
-           shell: python --> py
            shell: bash --> sh (default)
 
            :return: returns test extension based on shell type
            :rtype: str
         """
-
-        if "python" in self.shell.name:
-            self.logger.debug("Setting test extension to 'py'")
-            return "py"
 
         self.logger.debug("Setting test extension to 'sh'")
         return "sh"
@@ -261,8 +256,15 @@ class BuilderBase:
         lines += [
             f"source {os.path.join(executor_root, self.executor, 'before_script.sh')}"
         ]
+        if self.shell.name == "python":
+            python_content = self.generate_script()
+            python_content = "\n".join(python_content)
+            script_path = "%s.py" % os.path.join(self.metadata["testroot"], self.name)
+            write_file(script_path, python_content)
+            lines += [f"python {script_path}"]
+        else:
+            lines += self.generate_script()
 
-        lines += self.generate_script()
         lines += [
             f"source {os.path.join(executor_root, self.executor, 'after_script.sh')}"
         ]

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -124,8 +124,11 @@ class BuilderBase:
         self.metadata["id"] = self._generate_build_id()
 
         create_dir(self.testdir)
-        id = len(os.listdir(self.testdir))
-        self.test_id = os.path.join(self.testdir, str(id))
+        num_content = len(os.listdir(self.testdir))
+        # the testid is incremented for every run, this can be done by getting
+        # length of all files in testdir and creating a directory. Subsequent
+        # runs will increment this counter
+        self.test_id = os.path.join(self.testdir, str(num_content))
         create_dir(self.test_id)
 
         self.stage_dir = os.path.join(self.test_id, "stage")

--- a/buildtest/docs.py
+++ b/buildtest/docs.py
@@ -5,11 +5,12 @@ requested from command line.
 import webbrowser
 
 
-def buildtestdocs(args):
-    """Open buildtest docs in web browser. This implements ``buildtest --docs``"""
+def buildtestdocs(args=None):
+    print(args)
+    """Open buildtest docs in web browser. This implements ``buildtest docs``"""
     webbrowser.open("https://buildtest.readthedocs.io/")
 
 
-def schemadocs(args):
-    """Open buildtest schema docs in web browser. This implements ``buildtest --schemadocs``"""
+def schemadocs(args=None):
+    """Open buildtest schema docs in web browser. This implements ``buildtest schemadocs``"""
     webbrowser.open("https://buildtesters.github.io/schemas/")

--- a/buildtest/docs.py
+++ b/buildtest/docs.py
@@ -6,7 +6,6 @@ import webbrowser
 
 
 def buildtestdocs(args=None):
-    print(args)
     """Open buildtest docs in web browser. This implements ``buildtest docs``"""
     webbrowser.open("https://buildtest.readthedocs.io/")
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -99,7 +99,9 @@ class BaseExecutor:
 
         # Keep an output file
         run_output_file = os.path.join(
-            self.builder.metadata.get("testroot"), self.builder.metadata.get("id")
+            self.builder.metadata.get("testroot"),
+            "run",
+            self.builder.metadata.get("id"),
         )
         outfile = run_output_file + ".out"
         errfile = run_output_file + ".err"

--- a/buildtest/executors/local.py
+++ b/buildtest/executors/local.py
@@ -59,8 +59,8 @@ class LocalExecutor(BaseExecutor):
         self.result["id"] = self.builder.metadata.get("id")
 
         # Change to the test directory
-        os.chdir(self.builder.metadata["testroot"])
-        self.logger.debug(f"Changing to directory {self.builder.metadata['testroot']}")
+        os.chdir(self.builder.stage_dir)
+        self.logger.debug(f"Changing to directory {self.builder.stage_dir}")
 
         cmd = ["bash", self.builder.metadata["testpath"]]
 

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -92,8 +92,8 @@ class SlurmExecutor(BaseExecutor):
         self.job_id = 0
         self.result["id"] = self.builder.metadata.get("id")
 
-        os.chdir(self.builder.metadata["testroot"])
-        self.logger.debug(f"Changing to directory {self.builder.metadata['testroot']}")
+        os.chdir(self.builder.stage_dir)
+        self.logger.debug(f"Changing to directory {self.builder.stage_dir}")
 
         sbatch_cmd = [self.launcher, "--parsable"]
 
@@ -210,6 +210,18 @@ class SlurmExecutor(BaseExecutor):
         self.builder.metadata["errfile"] = os.path.join(
             job_data["WorkDir"].rstrip(),
             f"{job_data['JobName']}-{job_data['JobID']}.err",
+        )
+        shutil.copy2(
+            self.builder.metadata["outfile"],
+            os.path.join(
+                self.builder.run_dir, os.path.basename(self.builder.metadata["outfile"])
+            ),
+        )
+        shutil.copy2(
+            self.builder.metadata["errfile"],
+            os.path.join(
+                self.builder.run_dir, os.path.basename(self.builder.metadata["errfile"])
+            ),
         )
         self.logger.debug(f"[{self.builder.name}] result: {self.result}")
         self.logger.debug(

--- a/buildtest/menu/buildspec.py
+++ b/buildtest/menu/buildspec.py
@@ -120,14 +120,19 @@ def func_buildspec_find(args):
 
                 schema_type = cache[path][buildspecfile][test].get("type")
                 executor = cache[path][buildspecfile][test].get("executor")
-                tags = cache[path][buildspecfile][test].get("tags")
+                # if tags not defined in cache we set to empty list for comparison with tag_filter
+                tags = cache[path][buildspecfile][test].get("tags") or []
                 description = cache[path][buildspecfile][test].get("description")
 
+                # skip all entries that dont match filtered executor
                 if executor_filter and executor_filter != executor:
                     continue
 
-                if tags_filter and tags_filter not in tags:
-                    continue
+                # if skip all entries that dont match filtered tag. We only search if --filter tag=value is set
+                if tags_filter:
+                    # if tags is not set in buildspec cache we default to empty list which and this condition should always be true
+                    if tags_filter not in tags:
+                        continue
 
                 if type_filter and type_filter != schema_type:
                     continue

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -60,7 +60,7 @@ def is_dir(dirname):
     return os.path.isdir(dirname)
 
 
-def walk_tree(root_dir, ext):
+def walk_tree(root_dir, ext=None):
     """This method will traverse a directory tree and return list of files
        based on extension type. This method invokes is_dir() to check if directory
        exists before traversal.
@@ -70,7 +70,7 @@ def walk_tree(root_dir, ext):
        :param root_dir: directory path to traverse
        :type root_dir: str, required
        :param ext: file extensions to search in traversal
-       :type ext: str, required
+       :type ext: str, optional
 
        :return: returns a list of file paths
        :rtype: list
@@ -83,7 +83,12 @@ def walk_tree(root_dir, ext):
 
     for root, subdir, files in os.walk(root_dir):
         for fname in files:
-            if fname.endswith(ext):
+            # if ext is provided check if file ends with extension and add to list, otherwise
+            # add all files to list and return
+            if ext:
+                if fname.endswith(ext):
+                    list_files.append(os.path.join(root, fname))
+            else:
                 list_files.append(os.path.join(root, fname))
 
     return list_files

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,9 @@
+from buildtest.docs import buildtestdocs, schemadocs
+
+
+def test_buildtestdocs():
+    buildtestdocs()
+
+
+def test_schemadocs():
+    schemadocs()


### PR DESCRIPTION
This PR address issues where we couldn't reference files relative to working directory. Now we create a stage directory which symlinks all files in working directory so we can access files as needed. The compiler schema logic for `source` field doesn't require full path to file since we symlink the files.
We copy the generate.sh and output/error file into `run` directory.

Each subsequent run for same test will have a test id (`0`,`1`, ...) which is part of the directory root. This allows clean builds for each test.