### PR TITLE
add regression test for schemas into buildtest. Migrate schema development into buildtest.

### DIFF
--- a/.github/workflows/jsonschemadocs.yml
+++ b/.github/workflows/jsonschemadocs.yml
@@ -1,0 +1,88 @@
+name: jsonschema2md
+
+on:
+  push:
+    branches:
+      - devel
+
+
+jobs:
+  jsonschemadocs:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+
+    - name: jsonschema2md install
+      run: |
+        npm install -g @adobe/jsonschema2md
+        jsonschema2md -d buildtest/schemas/ -o schema_docs/
+    - name: Upload jsonschema docs
+      uses: actions/upload-artifact@v2
+      with:
+        name: schemadocs
+        path: schema_docs/
+
+    - name: Upload schema files
+      uses: actions/upload-artifact@v2
+      with:
+        name: schemafiles
+        path: buildtest/schemas/*.schema.json
+
+  DeployPages:
+    needs: jsonschemadocs
+    runs-on: ubuntu-latest
+    steps:
+
+     - name: Checkout 🛎️
+       uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+       with:
+          persist-credentials: false
+
+
+     - name: Install SSH Client 🔑
+       uses: webfactory/ssh-agent@v0.2.0
+       with:
+         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+     - name: Download schemafiles
+       uses: actions/download-artifact@v2
+       with:
+         name: schemafiles
+         path: downloads/schemas
+
+     - name: Download jsonschema docs
+       uses: actions/download-artifact@v2
+       with:
+          name: schemadocs
+          path: downloads/schema_docs
+
+     - name: Display content of downloaded directory
+       run: |
+         ls -l downloads/schema_docs
+         ls -R downloads/schemas
+
+
+     - name: Deploy Schema Docs 🚀
+       uses: JamesIves/github-pages-deploy-action@3.5.9
+       with:
+         SSH: true
+         BASE_BRANCH: devel
+         BRANCH: gh-pages # The branch the action should deploy to.
+         FOLDER: downloads/schema_docs # The folder the action should deploy.
+         TARGET_FOLDER: docs
+         CLEAN: true
+
+     - name: Deploy Schemas 🚀
+       uses: JamesIves/github-pages-deploy-action@3.5.9
+       with:
+         SSH: true
+         BASE_BRANCH: devel
+         BRANCH: gh-pages # The branch the action should deploy to.
+         FOLDER: downloads/schemas # The folder the action should deploy.
+         TARGET_FOLDER: schemas
+         CLEAN: true

--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -21,6 +21,8 @@ supported_schemas = supported_type_schemas + [
 userhome = pwd.getpwuid(os.getuid())[5]
 BUILDTEST_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+SCHEMA_ROOT = os.path.join(BUILDTEST_ROOT, "buildtest", "schemas")
+
 # root of buildtest user home, default shell
 BUILDTEST_USER_HOME = os.path.join(userhome, ".buildtest")
 

--- a/buildtest/schemas/compiler-v1.0.schema.json
+++ b/buildtest/schemas/compiler-v1.0.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://buildtesters.github.io/schemas/schemas/compiler-v1.0.schema.json",
+  "$id": "https://buildtesters.github.io/buildtest/schemas/compiler-v1.0.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "compiler schema version 1.0",
   "description": "The compiler schema is of ``type: compiler`` in sub-schema which is used for compiling and running programs",
@@ -23,28 +23,28 @@
       "description": "A list of modules to load into test script"
     },
     "executor": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/executor"
+      "$ref": "global.schema.json#/definitions/executor"
     },
     "sbatch": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/sbatch"
+      "$ref": "global.schema.json#/definitions/sbatch"
     },
     "bsub": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/bsub"
+      "$ref": "global.schema.json#/definitions/bsub"
     },
     "env": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/env"
+      "$ref": "global.schema.json#/definitions/env"
     },
     "vars": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/env"
+      "$ref": "global.schema.json#/definitions/env"
     },
     "status": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/status"
+      "$ref": "global.schema.json#/definitions/status"
     },
     "skip": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/skip"
+      "$ref": "global.schema.json#/definitions/skip"
     },
     "tags": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/tags"
+      "$ref": "global.schema.json#/definitions/tags"
     },
     "pre_build":{
       "type": "string",

--- a/buildtest/schemas/global.schema.json
+++ b/buildtest/schemas/global.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://buildtesters.github.io/schemas/schemas/global.schema.json",
+  "$id": "https://buildtesters.github.io/buildtest/schemas/global.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "global schema",
   "description": "buildtest global schema is validated for all buildspecs. The global schema defines top-level structure of buildspec and defintions that are inherited for sub-schemas",
@@ -77,14 +77,20 @@
       "additionalProperties": false,
       "properties":
         {
-          "slurm_job_state_codes": {
+          "slurm_job_state": {
             "type":  "string",
             "enum": ["COMPLETED", "FAILED", "OUT_OF_MEMORY", "TIMEOUT"],
             "description": "This field can be used for checking Slurm Job State, if there is a match buildtest will report as ``PASS`` "
           },
           "returncode": {
-            "type":  "integer",
-            "description": "By default, returncode 0 is PASS, if you want to emulate a non-zero returncode to pass then specify an expected return code. buildtest will match actual returncode with one defined in this field, if there is a match buildtest will report as ``PASS``"
+            "description": "Specify a list of returncodes to match with script's exit code. buildtest will PASS test if script's exit code is found in list of returncodes. You must specify unique numbers as list and a minimum of 1 item in array",
+            "type": "array",
+            "uniqueItems": true,
+            "minItems": 1,
+            "items":
+            {
+              "type": "integer"
+            }
           },
           "regex": {
             "type": "object",

--- a/buildtest/schemas/script-v1.0.schema.json
+++ b/buildtest/schemas/script-v1.0.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://buildtesters.github.io/schemas/schemas/script-v1.0.schema.json",
+  "$id": "https://buildtesters.github.io/buildtest/schemas/script-v1.0.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "script schema version 1.0",
   "description": "The script schema is of ``type: script`` in sub-schema which is used for running shell scripts",
@@ -18,19 +18,19 @@
       "maxLength": 80
     },
     "sbatch": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/sbatch"
+      "$ref": "global.schema.json#/definitions/sbatch"
     },
     "bsub": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/bsub"
+      "$ref": "global.schema.json#/definitions/bsub"
     },
     "env": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/env"
+      "$ref": "global.schema.json#/definitions/env"
     },
     "vars": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/env"
+      "$ref": "global.schema.json#/definitions/env"
     },
     "executor": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/executor"
+      "$ref": "global.schema.json#/definitions/executor"
     },
     "shell": {
       "type": "string",
@@ -46,13 +46,13 @@
       "description": "A script to run using the default shell."
     },
     "status": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/status"
+      "$ref": "global.schema.json#/definitions/status"
     },
     "skip": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/skip"
+      "$ref": "global.schema.json#/definitions/skip"
     },
     "tags": {
-      "$ref": "https://buildtesters.github.io/schemas/schemas/global.schema.json#/definitions/tags"
+      "$ref": "global.schema.json#/definitions/tags"
     }
   }
 }

--- a/buildtest/schemas/settings.schema.json
+++ b/buildtest/schemas/settings.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://buildtesters.github.io/schemas/schemas/settings.schema.json",
+  "$id": "https://buildtesters.github.io/buildtest/schemas/settings.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "buildtest configuration schema",
   "type": "object",

--- a/tests/schema_tests/test_compiler.py
+++ b/tests/schema_tests/test_compiler.py
@@ -1,0 +1,103 @@
+import json
+import os
+import pytest
+import re
+import yaml
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+from buildtest.defaults import SCHEMA_ROOT
+
+here = os.path.dirname(os.path.abspath(__file__))
+schemaroot = os.path.join(os.path.dirname(here), "schemas")
+
+schema_name = "compiler"
+schema_file = f"{schema_name}-v1.0.schema.json"
+schema_path = os.path.join(SCHEMA_ROOT, schema_file)
+
+compiler_schema_examples = os.path.join(SCHEMA_ROOT, "examples", schema_file)
+
+
+def load_schema(path):
+    """load a schema from file. We assume a json file
+    """
+    with open(path, "r") as fd:
+        schema = json.loads(fd.read())
+    return schema
+
+
+def load_recipe(path):
+    """load a yaml recipe file
+    """
+    with open(path, "r") as fd:
+        content = yaml.load(fd.read(), Loader=yaml.SafeLoader)
+    return content
+
+
+def check_invalid_recipes(recipes, invalids, loaded, version):
+    for recipe in recipes:
+        assert recipe
+        assert re.search("(yml|yaml)$", recipe)
+        recipe_path = os.path.join(invalids, recipe)
+        content = load_recipe(recipe_path)
+
+        # Ensure version is correct in header
+        assert content["version"] == version
+        del content["version"]
+
+        # For each section, assume folder type and validate
+        for name in content["buildspecs"].keys():
+            with pytest.raises(ValidationError) as excinfo:
+                validate(instance=content["buildspecs"][name], schema=loaded)
+            print(excinfo.type, excinfo.value)
+            print("Testing %s from recipe %s should be invalid" % (name, recipe))
+
+
+def check_valid_recipes(recipes, valids, loaded, version):
+    for recipe in recipes:
+        assert recipe
+        assert re.search("(yml|yaml)$", recipe)
+        recipe_path = os.path.join(valids, recipe)
+        content = load_recipe(recipe_path)
+
+        # Ensure version is correct in header
+        assert content["version"] == version
+        del content["version"]
+
+        # For each section, assume folder type and validate
+        for name in content["buildspecs"].keys():
+            validate(instance=content["buildspecs"][name], schema=loaded)
+            print("Testing %s from recipe %s should be valid" % (name, recipe))
+
+
+def test_compiler_examples():
+
+    loaded = load_schema(schema_path)
+    assert isinstance(loaded, dict)
+
+    # Assert is named correctly
+    print("Getting version of %s" % schema_file)
+    match = re.search(
+        "%s-v(?P<version>[0-9]{1}[.][0-9]{1})[.]schema[.]json" % schema_name,
+        schema_file,
+    )
+    print(match)
+    assert match
+
+    # Ensure we found a version
+    assert match.groups()
+    version = match["version"]
+
+    invalids = os.path.join(compiler_schema_examples, "invalid")
+    valids = os.path.join(compiler_schema_examples, "valid")
+    print(invalids, valids)
+    assert invalids
+    assert valids
+
+    invalid_recipes = os.listdir(invalids)
+    valid_recipes = os.listdir(valids)
+
+    assert invalid_recipes
+    assert valid_recipes
+
+    check_invalid_recipes(invalid_recipes, invalids, loaded, version)
+    check_valid_recipes(valid_recipes, valids, loaded, version)

--- a/tests/schema_tests/test_global.py
+++ b/tests/schema_tests/test_global.py
@@ -1,0 +1,86 @@
+import json
+import os
+import re
+import pytest
+import yaml
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+from buildtest.defaults import SCHEMA_ROOT
+
+schema_name = "global"
+schema_file = f"{schema_name}.schema.json"
+schema_path = os.path.join(SCHEMA_ROOT, schema_file)
+
+global_schema_examples = os.path.join(SCHEMA_ROOT, "examples", schema_file)
+
+
+def load_schema(path):
+    """load a schema from file. We assume a json file
+    """
+    with open(path, "r") as fd:
+        schema = json.loads(fd.read())
+    return schema
+
+
+def load_recipe(path):
+    """load a yaml recipe file
+    """
+    with open(path, "r") as fd:
+        content = yaml.load(fd.read(), Loader=yaml.SafeLoader)
+    return content
+
+
+def check_invalid_recipes(recipes, invalids, loaded):
+    """This method validates all recipes found in tests/invalid/global with global schema: global/global.schema.json"""
+
+    for recipe in recipes:
+        assert recipe
+        assert re.search("(yml|yaml)$", recipe)
+
+        recipe_path = os.path.join(invalids, recipe)
+        content = load_recipe(recipe_path)
+
+        with pytest.raises(ValidationError) as excinfo:
+            validate(instance=content, schema=loaded)
+        print(excinfo.type, excinfo.value)
+        print("Recipe File: %s  should be invalid" % recipe_path)
+
+
+def check_valid_recipes(recipes, valids, loaded):
+    """This method validates all recipes found in tests/valid/global with global schema: global/global.schema.json"""
+
+    for recipe in recipes:
+        assert recipe
+        assert re.search("(yml|yaml)$", recipe)
+        recipe_path = os.path.join(valids, recipe)
+        content = load_recipe(recipe_path)
+
+        validate(instance=content, schema=loaded)
+        print("Recipe File: %s should be valid" % recipe_path)
+
+
+def test_global_examples():
+    """This validates all valid/invalid examples for global schema"""
+
+    loaded = load_schema(schema_path)
+    assert isinstance(loaded, dict)
+
+    invalid_dir = os.path.abspath(os.path.join(global_schema_examples, "invalid"))
+    valid_dir = os.path.abspath(os.path.join(global_schema_examples, "valid"))
+
+    assert invalid_dir
+    assert valid_dir
+
+    invalid_recipes = os.listdir(invalid_dir)
+    valid_recipes = os.listdir(valid_dir)
+
+    assert invalid_recipes
+    assert valid_recipes
+
+    print(f"Detected Invalid Global Directory: {invalid_dir}")
+    print(f"Detected Valid Global Directory: {valid_dir}")
+    print(f"Invalid Recipes: {invalid_recipes}")
+    print(f"Valid Recipes: {valid_recipes}")
+
+    check_invalid_recipes(invalid_recipes, invalid_dir, loaded)
+    check_valid_recipes(valid_recipes, valid_dir, loaded)

--- a/tests/schema_tests/test_script.py
+++ b/tests/schema_tests/test_script.py
@@ -1,0 +1,111 @@
+import json
+import os
+import re
+import pytest
+import yaml
+
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+from buildtest.defaults import SCHEMA_ROOT
+
+
+schema_name = "script"
+schema_file = f"{schema_name}-v1.0.schema.json"
+schema_path = os.path.join(SCHEMA_ROOT, schema_file)
+schema_examples = os.path.join(SCHEMA_ROOT, "examples", schema_file)
+
+
+def load_schema(path):
+    """load a schema from file. We assume a json file
+    """
+    with open(path, "r") as fd:
+        schema = json.loads(fd.read())
+    return schema
+
+
+def load_recipe(path):
+    """load a yaml recipe file
+    """
+    with open(path, "r") as fd:
+        content = yaml.load(fd.read(), Loader=yaml.SafeLoader)
+    return content
+
+
+def check_invalid_recipes(recipes, invalids, loaded, version):
+    for recipe in recipes:
+        assert recipe
+        assert re.search("(yml|yaml)$", recipe)
+        recipe_path = os.path.join(invalids, recipe)
+        content = load_recipe(recipe_path)
+
+        # Ensure version is correct in header
+        assert content["version"] == version
+        del content["version"]
+
+        # For each section, assume folder type and validate
+        for name in content["buildspecs"].keys():
+            with pytest.raises(ValidationError) as excinfo:
+                validate(instance=content["buildspecs"][name], schema=loaded)
+            print(excinfo.type, excinfo.value)
+            print("Testing %s from recipe %s should be invalid" % (name, recipe))
+
+
+def check_valid_recipes(recipes, valids, loaded, version):
+    for recipe in recipes:
+        assert recipe
+        assert re.search("(yml|yaml)$", recipe)
+        recipe_path = os.path.join(valids, recipe)
+        content = load_recipe(recipe_path)
+
+        # Ensure version is correct in header
+        assert content["version"] == version
+        del content["version"]
+
+        # For each section, assume folder type and validate
+        for name in content["buildspecs"].keys():
+            print(content["buildspecs"][name])
+            validate(instance=content["buildspecs"][name], schema=loaded)
+            print("Testing %s from recipe %s should be valid" % (name, recipe))
+
+
+def test_script_examples(tmp_path):
+    """the script test_organization is responsible for all the schemas
+       in the root of the repository, under <schema>/examples.
+       A schema specific test is intended to run tests that
+       are specific to a schema. In this case, this is the "script"
+       folder. Invalid examples should be under ./invalid/script.
+    """
+
+    print("Testing schema %s" % schema_file)
+    print("schema_path:", schema_path)
+    loaded = load_schema(schema_path)
+    assert isinstance(loaded, dict)
+
+    # Assert is named correctly
+    print("Getting version of %s" % schema_file)
+    match = re.search(
+        "%s-v(?P<version>[0-9]{1}[.][0-9]{1})[.]schema[.]json" % schema_name,
+        schema_file,
+    )
+    assert match
+
+    # Ensure we found a version
+    assert match.groups()
+    version = match["version"]
+
+    # Ensure a version folder exists with invalids
+    print("Checking that invalids exist for %s" % schema_file)
+    invalids = os.path.join(schema_examples, "invalid")
+    valids = os.path.join(schema_examples, "valid")
+
+    assert invalids
+    assert valids
+
+    invalid_recipes = os.listdir(invalids)
+    valid_recipes = os.listdir(valids)
+
+    assert invalid_recipes
+    assert valid_recipes
+
+    check_valid_recipes(valid_recipes, valids, loaded, version)
+    check_invalid_recipes(invalid_recipes, invalids, loaded, version)

--- a/tests/schema_tests/test_settings.py
+++ b/tests/schema_tests/test_settings.py
@@ -1,0 +1,46 @@
+import json
+import os
+import yaml
+from jsonschema import validate
+from buildtest.defaults import SCHEMA_ROOT
+
+
+schema_file = "settings.schema.json"
+settings_schema = os.path.join(SCHEMA_ROOT, schema_file)
+settings_schema_examples = os.path.join(SCHEMA_ROOT, "examples", schema_file)
+
+
+def load_schema(path):
+    """load a schema from file. We assume a json file"""
+    with open(path, "r") as fd:
+        schema = json.loads(fd.read())
+    return schema
+
+
+def load_recipe(path):
+    """load a yaml recipe file"""
+    with open(path, "r") as fd:
+        content = yaml.load(fd.read(), Loader=yaml.SafeLoader)
+    return content
+
+
+def test_settings_examples():
+
+    # load schema and ensure type is a dict
+    recipe = load_schema(settings_schema)
+
+    valid = os.path.join(settings_schema_examples, "valid")
+    assert valid
+
+    valid_recipes = os.listdir(valid)
+    assert valid_recipes
+    # check all valid recipes
+    for example in valid_recipes:
+
+        filepath = os.path.join(valid, example)
+        print(f"Loading Recipe File: {filepath}")
+        example_recipe = load_recipe(filepath)
+        assert example_recipe
+
+        print(f"Expecting Recipe File: {filepath} to be valid")
+        validate(instance=example_recipe, schema=recipe)


### PR DESCRIPTION
tests and schema deployment implemented in https://github.com/buildtesters/schemas to
buildtest.
Adding workflow to publish schemas and docs to buildtest domain into gh-pages.
Refactor regression tests to pick up new location for example tests for each schema
Change $id for all schemas