### PR TITLE
tags can be string or list, returncode can be int or list of ints

### DIFF
--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -140,13 +140,21 @@ class BaseExecutor:
 
             slurm_job_state_match = False
             if status.get("returncode"):
+                # returncode can be an integer or list of integers
+
+                buildspec_returncode = status["returncode"]
+
+                # if buildspec returncode field is integer we convert to list for check
+                if isinstance(buildspec_returncode, int):
+                    buildspec_returncode = list(buildspec_returncode)
+
                 self.logger.debug("Conducting Return Code check")
                 self.logger.debug(
                     "Status Return Code: %s   Result Return Code: %s"
-                    % (status["returncode"], self.result["returncode"])
+                    % (buildspec_returncode, self.result["returncode"])
                 )
                 # checks if test returncode matches returncode specified in Buildspec and assign boolean to returncode_match
-                returncode_match = self.result["returncode"] in status["returncode"]
+                returncode_match = self.result["returncode"] in buildspec_returncode
 
             if status.get("regex"):
                 self.logger.debug("Conducting Regular Expression check")

--- a/buildtest/schemas/compiler-v1.0.schema.json
+++ b/buildtest/schemas/compiler-v1.0.schema.json
@@ -13,7 +13,7 @@
       "description": "Select schema type to use when validating buildspec. This must be of set to ``compiler``"
     },
     "description": {
-      "$ref": "_definitions.schema.json#/definitions/description"
+      "$ref": "definitions.schema.json#/definitions/description"
     },
     "module": {
       "type": "array",

--- a/buildtest/schemas/definitions.schema.json
+++ b/buildtest/schemas/definitions.schema.json
@@ -3,6 +3,30 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "JSON Schema Definitions File. This file is used for declaring definitions that are referenced from other schemas",
   "definitions": {
+    "string_or_list": {
+      "oneOf": [
+        {"type": "string"},
+        {"$ref": "#/definitions/list_of_strings"}
+      ]
+    },
+    "list_of_strings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string"},
+      "uniqueItems": true
+    },
+    "list_of_ints": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "integer"},
+      "uniqueItems": true
+    },
+    "int_or_list": {
+      "oneOf": [
+        {"type": "integer"},
+        {"$ref": "#/definitions/list_of_ints"}
+      ]
+    },
     "env": {
       "type": "object",
       "description": "One or more key value pairs for an environment (key=value)",
@@ -21,12 +45,8 @@
       "maxLength": 80
     },
     "tags": {
-      "type": "array",
       "description": "Classify tests using a tag name, this can be used for categorizing test and building tests using ``--tags`` option",
-      "minItems": 1,
-      "items": {
-        "type": "string"
-      }
+      "$ref": "#definitions/string_or_list"
     },
     "skip": {
       "type": "boolean",
@@ -67,12 +87,7 @@
         },
         "returncode": {
           "description": "Specify a list of returncodes to match with script's exit code. buildtest will PASS test if script's exit code is found in list of returncodes. You must specify unique numbers as list and a minimum of 1 item in array",
-          "type": "array",
-          "uniqueItems": true,
-          "minItems": 1,
-          "items": {
-            "type": "integer"
-          }
+          "$ref": "#definitions/int_or_lists"
         },
         "regex": {
           "type": "object",

--- a/buildtest/schemas/examples/script-v1.0.schema.json/invalid/examples.yml
+++ b/buildtest/schemas/examples/script-v1.0.schema.json/invalid/examples.yml
@@ -77,7 +77,6 @@ buildspecs:
     status:
       returncode: []
 
-
   unique_returncodes:
     type: script
     executor: local.bash
@@ -85,6 +84,22 @@ buildspecs:
     run: exit 1
     status:
       returncode: [1, 2, 1]
+
+  non_int_returncodes:
+    type: script
+    executor: local.bash
+    description: The returncode must be an int and not a number
+    run: exit 1
+    status:
+      returncode:  1.0
+
+  non_int_returncodes_list:
+    type: script
+    executor: local.bash
+    description: The returncode must be a list of integers and no numbers
+    run: exit 1
+    status:
+      returncode:  [1, 2.0]
 
   invalid_shell_usr_bin_bash:
     type: script
@@ -114,11 +129,26 @@ buildspecs:
     skip: 1
     run: hostname
 
+  empty_tags:
+    type: script
+    executor: local.bash
+    description: tag list can't be empty, requires one item.
+    tags: []
+    run: hostname
+
+
+  non_unique_tags:
+    type: script
+    executor: local.bash
+    description: tag names must be unique
+    tags: ["network", "network"]
+    run: hostname
+
   invalid_tags_value:
     type: script
     executor: local.bash
     description: invalid tag value must be all string items
-    tags: ["compiler", 400 ]
+    tags: ["network", 400 ]
     run: hostname
 
   additionalProperties_test:

--- a/buildtest/schemas/examples/script-v1.0.schema.json/valid/examples.yml
+++ b/buildtest/schemas/examples/script-v1.0.schema.json/valid/examples.yml
@@ -88,13 +88,21 @@ buildspecs:
     shebang: "#!/usr/bin/env bash"
     run: hostname
 
-  status_returncode:
+  status_returncode_list:
     executor: local.bash
     type: script
-    description: This test pass because using a valid return code
+    description: The returncode can be a list of integers
     run: exit 0
     status:
       returncode: [0]
+
+  status_returncode_int:
+    executor: local.bash
+    type: script
+    description: The returncode can be an integer to match with single returncode
+    run: exit 0
+    status:
+      returncode: 0
 
   status_regex:
     executor: local.bash
@@ -144,15 +152,21 @@ buildspecs:
     skip: true
     run: hostname
 
-  tag_example:
+  tag_str_example:
+    type: script
+    executor: local.bash
+    description: tags can be defined as string
+    tags: network
+    run: hostname
+
+  tag_list_example:
     type: script
     executor: slurm.debug
-    description: This is a tag example
+    description: This is a tag example using list
     sbatch:
       - "-t 10:00:00"
       - "-p normal"
       - "-N 1"
       - "-n 8"
-    tags:
-      - "slurm"
+    tags: ["slurm"]
     run: hostname

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,9 +1,0 @@
-from buildtest.docs import buildtestdocs, schemadocs
-
-
-def test_buildtestdocs():
-    buildtestdocs()
-
-
-def test_schemadocs():
-    schemadocs()

--- a/tutorials/pass_returncode.yml
+++ b/tutorials/pass_returncode.yml
@@ -17,12 +17,20 @@ buildspecs:
     status:
       returncode: [1]
 
-  returncode_mismatch:
+  returncode_list_mismatch:
     executor: local.sh
     type: script
     description: exit 2 failed since it failed to match returncode 1
     run: exit 2
     tags: [tutorials, fail]
     status:
-      returncode: [1]
+      returncode: [1, 3]
 
+  returncode_match:
+    executor: local.sh
+    type: script
+    description: exit 128 matches returncode 128
+    run: exit 128
+    tags: [tutorials, pass]
+    status:
+      returncode: 128


### PR DESCRIPTION
tags field can be a string or list.
returncode field can be int or list.
Add valid/invalid tests for each field.
Update returncode logic to convert int to list if specified as an integer.
The returncode and tags must be unique items if specified as list. Previously
we could pass duplicate values in list which is incorrect.