### PR TITLE
Add custom RefResolver to resolve schema files locally 

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -75,10 +75,10 @@ class BuilderBase:
         # The type must match the type of the builder
         self.recipe = recipe
 
-        type = self.recipe["type"]
+        sub_schema_type = self.recipe["type"]
 
         self.metadata["schemafile"] = os.path.basename(
-            schema_table[f"{type}-v1.0.schema.json"]["path"]
+            schema_table[f"{sub_schema_type}-v1.0.schema.json"]["path"]
         )
 
         self.executor = self.recipe.get("executor")

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -75,8 +75,10 @@ class BuilderBase:
         # The type must match the type of the builder
         self.recipe = recipe
 
+        type = self.recipe["type"]
+
         self.metadata["schemafile"] = os.path.basename(
-            schema_table[self.recipe["type"]]["path"]
+            schema_table[f"{type}-v1.0.schema.json"]["path"]
         )
 
         self.executor = self.recipe.get("executor")

--- a/buildtest/buildsystem/parser.py
+++ b/buildtest/buildsystem/parser.py
@@ -8,7 +8,6 @@ expose functions to run builds.
 import logging
 import os
 import sys
-from jsonschema import validate
 from buildtest.config import load_settings
 from buildtest.executors.setup import BuildExecutor
 from buildtest.schemas.utils import load_recipe

--- a/buildtest/buildsystem/parser.py
+++ b/buildtest/buildsystem/parser.py
@@ -12,7 +12,7 @@ from jsonschema import validate
 from buildtest.config import load_settings
 from buildtest.executors.setup import BuildExecutor
 from buildtest.schemas.utils import load_recipe
-from buildtest.schemas.defaults import schema_table
+from buildtest.schemas.defaults import schema_table, custom_validator
 from buildtest.utils.file import resolve_path, is_dir
 
 from buildtest.buildsystem.base import (
@@ -91,10 +91,12 @@ class BuildspecParser:
         """
 
         self.logger.info(
-            f"Validating {self.buildspec} with schema: {schema_table['global']['path']}"
+            f"Validating {self.buildspec} with schema: {schema_table['global.schema.json']['path']}"
         )
-
-        validate(instance=self.recipe, schema=schema_table["global"]["recipe"])
+        custom_validator(
+            recipe=self.recipe, schema=schema_table["global.schema.json"]["recipe"]
+        )
+        # validate(instance=self.recipe, schema=schema_table["global"]["recipe"])
 
     # Validation
 
@@ -147,27 +149,50 @@ class BuildspecParser:
                 )
 
             # And that there is a version file
-            if self.schema_version not in schema_table[type]["versions"]:
+            if (
+                self.schema_version
+                not in schema_table[f"{type}-v{self.schema_version}.schema.json"][
+                    "versions"
+                ]
+            ):
                 sys.exit(
                     "version %s is not known for schema type %s. Valid options are: %s"
-                    % (self.schema_version, type, schema_table[type]["versions"])
+                    % (
+                        self.schema_version,
+                        type,
+                        schema_table[f"{type}-v{self.schema_version}.schema.json"][
+                            "versions"
+                        ],
+                    )
                 )
             self.logger.info(
                 "Checking version '%s' in version list: %s",
                 self.schema_version,
-                schema_table[type]["versions"],
+                schema_table[f"{type}-v{self.schema_version}.schema.json"]["versions"],
             )
 
             self.logger.info(
                 "Validating test - '%s' with schemafile: %s"
-                % (name, os.path.basename(schema_table[type]["path"]))
+                % (
+                    name,
+                    os.path.basename(
+                        schema_table[f"{type}-v{self.schema_version}.schema.json"][
+                            "path"
+                        ]
+                    ),
+                )
             )
 
-            self.schema_file = os.path.basename(schema_table[type]["path"])
-            validate(
-                instance=self.recipe["buildspecs"][name],
-                schema=schema_table[type]["recipe"],
+            self.schema_file = os.path.basename(
+                schema_table[f"{type}-v{self.schema_version}.schema.json"]["path"]
             )
+            custom_validator(
+                recipe=self.recipe["buildspecs"][name],
+                schema=schema_table[f"{type}-v{self.schema_version}.schema.json"][
+                    "recipe"
+                ],
+            )
+            # validate(instance=self.recipe["buildspecs"][name],schema=schema_table[type]["recipe"])
 
     # Builders
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -146,7 +146,7 @@ class BaseExecutor:
 
                 # if buildspec returncode field is integer we convert to list for check
                 if isinstance(buildspec_returncode, int):
-                    buildspec_returncode = list(buildspec_returncode)
+                    buildspec_returncode = [buildspec_returncode]
 
                 self.logger.debug("Conducting Return Code check")
                 self.logger.debug(

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -6,7 +6,6 @@ interact with a global configuration for buildtest.
 import argparse
 
 from buildtest import BUILDTEST_VERSION
-from buildtest.defaults import supported_schemas
 from buildtest.docs import buildtestdocs, schemadocs
 from buildtest.menu.buildspec import (
     func_buildspec_find,

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -22,6 +22,7 @@ from buildtest.menu.config import (
 
 from buildtest.menu.report import func_report
 from buildtest.menu.schema import func_schema
+from buildtest.schemas.defaults import schema_table
 
 
 def handle_kv_string(val):
@@ -312,7 +313,7 @@ class BuildTestParser:
             "--name",
             help="show schema by name (e.g., script)",
             metavar="Schema Name",
-            choices=supported_schemas,
+            choices=schema_table["names"],
         )
         parser_schema.add_argument(
             "-e",

--- a/buildtest/menu/schema.py
+++ b/buildtest/menu/schema.py
@@ -3,12 +3,7 @@ import os
 from jsonschema.exceptions import ValidationError
 from buildtest.buildsystem.parser import BuildspecParser
 from buildtest.config import check_settings
-from buildtest.schemas.utils import (
-    load_schema,
-    get_schema_fullpath,
-    here,
-)
-from buildtest.defaults import DEFAULT_SETTINGS_SCHEMA, supported_schemas
+from buildtest.schemas.utils import here
 from buildtest.schemas.defaults import schema_table
 from buildtest.utils.file import walk_tree, read_file
 

--- a/buildtest/menu/schema.py
+++ b/buildtest/menu/schema.py
@@ -9,6 +9,7 @@ from buildtest.schemas.utils import (
     here,
 )
 from buildtest.defaults import DEFAULT_SETTINGS_SCHEMA, supported_schemas
+from buildtest.schemas.defaults import schema_table
 from buildtest.utils.file import walk_tree, read_file
 
 
@@ -31,7 +32,7 @@ def func_schema(args):
     # the default behavior when "buildtest schema" is executed is to show list of all
     # schemas
     if not args.json and not args.example:
-        for schema in supported_schemas:
+        for schema in schema_table["names"]:
             print(schema)
         return
 
@@ -41,22 +42,15 @@ def func_schema(args):
             "Please specify a schema name with -n option when using -j or -e option"
         )
 
-    examples = None
-    # implements buildtest show schema --global
-    if args.name == "settings.schema.json":
-        schema = DEFAULT_SETTINGS_SCHEMA
-        examples = os.path.join(here, "examples", args.name)
-    elif args.name == "global.schema.json":
-        schema = os.path.join(here, "global.schema.json")
-        examples = os.path.join(here, "examples", args.name)
-    elif args.name in ["script-v1.0.schema.json", "compiler-v1.0.schema.json"]:
-        schema = get_schema_fullpath(args.name)
-        # the examples directory is found same location where schema file is located
-        examples = os.path.join(os.path.dirname(schema), "examples", args.name)
-
-    recipe = load_schema(schema)
     if args.json:
-        print(json.dumps(recipe, indent=2))
+        print(json.dumps(schema_table[args.name]["recipe"], indent=2))
+        return
+
+    # There are no examples for definitions schema
+    if args.name == "definitions.schema.json" and args.example:
+        raise SystemExit("There are no examples for definitions.schema.json")
+
+    examples = os.path.join(here, "examples", args.name)
 
     # get all examples for specified schema. We validate all examples and
     # and print content of all examples. If there is an error during validation

--- a/buildtest/schemas/compiler-v1.0.schema.json
+++ b/buildtest/schemas/compiler-v1.0.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://buildtesters.github.io/buildtest/schemas/compiler-v1.0.schema.json",
+  "$id": "compiler-v1.0.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "compiler schema version 1.0",
   "description": "The compiler schema is of ``type: compiler`` in sub-schema which is used for compiling and running programs",

--- a/buildtest/schemas/defaults.py
+++ b/buildtest/schemas/defaults.py
@@ -1,28 +1,98 @@
-from buildtest.schemas.utils import load_schema
 import os
+from jsonschema import RefResolver, Draft7Validator
+from buildtest.schemas.utils import load_schema
+
 
 here = os.path.dirname(os.path.abspath(__file__))
-
-global_schema_file = "global.schema.json"
-global_schema = load_schema(os.path.join(here, global_schema_file))
-
-script_schema_file = "script-v1.0.schema.json"
-script_schema = load_schema(os.path.join(here, script_schema_file))
-
-compiler_schema_file = "compiler-v1.0.schema.json"
-compiler_schema = load_schema(os.path.join(here, compiler_schema_file))
 
 
 schema_table = {}
 schema_table["types"] = ["script", "compiler"]
-schema_table["global"] = {}
-schema_table["global"]["path"] = os.path.join(here, global_schema_file)
-schema_table["global"]["recipe"] = global_schema
-schema_table["script"] = {}
-schema_table["script"]["versions"] = ["1.0"]
-schema_table["script"]["path"] = os.path.join(here, script_schema_file)
-schema_table["script"]["recipe"] = script_schema
-schema_table["compiler"] = {}
-schema_table["compiler"]["versions"] = ["1.0"]
-schema_table["compiler"]["path"] = os.path.join(here, compiler_schema_file)
-schema_table["compiler"]["recipe"] = compiler_schema
+schema_table["names"] = [
+    "global.schema.json",
+    "definitions.schema.json",
+    "settings.schema.json",
+    "compiler-v1.0.schema.json",
+    "script-v1.0.schema.json",
+]
+schema_table["global.schema.json"] = {}
+schema_table["global.schema.json"]["path"] = os.path.join(here, "global.schema.json")
+schema_table["global.schema.json"]["recipe"] = load_schema(
+    schema_table["global.schema.json"]["path"]
+)
+schema_table["script-v1.0.schema.json"] = {}
+schema_table["script-v1.0.schema.json"]["versions"] = ["1.0"]
+schema_table["script-v1.0.schema.json"]["path"] = os.path.join(
+    here, "script-v1.0.schema.json"
+)
+schema_table["script-v1.0.schema.json"]["recipe"] = load_schema(
+    schema_table["script-v1.0.schema.json"]["path"]
+)
+schema_table["compiler-v1.0.schema.json"] = {}
+schema_table["compiler-v1.0.schema.json"]["versions"] = ["1.0"]
+schema_table["compiler-v1.0.schema.json"]["path"] = os.path.join(
+    here, "compiler-v1.0.schema.json"
+)
+schema_table["compiler-v1.0.schema.json"]["recipe"] = load_schema(
+    schema_table["compiler-v1.0.schema.json"]["path"]
+)
+
+schema_table["definitions.schema.json"] = {}
+schema_table["definitions.schema.json"]["path"] = os.path.join(
+    here, "definitions.schema.json"
+)
+schema_table["definitions.schema.json"]["recipe"] = load_schema(
+    schema_table["definitions.schema.json"]["path"]
+)
+
+schema_table["settings.schema.json"] = {}
+schema_table["settings.schema.json"]["path"] = os.path.join(
+    here, "settings.schema.json"
+)
+schema_table["settings.schema.json"]["recipe"] = load_schema(
+    schema_table["settings.schema.json"]["path"]
+)
+
+
+schema_store = {
+    schema_table["global.schema.json"]["recipe"]["$id"]: schema_table[
+        "global.schema.json"
+    ]["recipe"],
+    schema_table["compiler-v1.0.schema.json"]["recipe"]["$id"]: schema_table[
+        "compiler-v1.0.schema.json"
+    ]["recipe"],
+    schema_table["script-v1.0.schema.json"]["recipe"]["$id"]: schema_table[
+        "script-v1.0.schema.json"
+    ]["recipe"],
+    schema_table["definitions.schema.json"]["recipe"]["$id"]: schema_table[
+        "definitions.schema.json"
+    ]["recipe"],
+    schema_table["settings.schema.json"]["recipe"]["$id"]: schema_table[
+        "settings.schema.json"
+    ]["recipe"],
+}
+
+resolver = RefResolver.from_schema(
+    schema_table["definitions.schema.json"]["recipe"], store=schema_store
+)
+
+
+def custom_validator(recipe, schema):
+    """This is a custom validator for validating JSON documents. We implement a
+    custom resolver for finding json schemas locally by implementing a schema store.
+    The input arguments ``recipe`` and ``schema`` is your input JSON recipe and schema
+    content for validating the recipe. This method uses Draft7Validator for validating
+    schemas.
+
+    :param recipe: Input recipe as JSON document
+    :type recipe: dict
+    :param schema: Input JSON Schema content to validate JSON document
+    :type schema: dict
+    """
+
+    # making sure input recipe and schema are dictionary
+    assert isinstance(recipe, dict)
+    assert isinstance(schema, dict)
+
+    validator = Draft7Validator(schema, resolver=resolver)
+    validator.validate(recipe)

--- a/buildtest/schemas/definitions.schema.json
+++ b/buildtest/schemas/definitions.schema.json
@@ -1,25 +1,26 @@
 {
-  "$id": "https://buildtesters.github.io/buildtest/schemas/definitions.schema.json",
+  "$id": "definitions.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "JSON Schema Definitions File. This file is used for declaring definitions that are referenced from other schemas",
   "definitions": {
+
+    "list_of_strings": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {"type": "string"}
+    },
     "string_or_list": {
       "oneOf": [
         {"type": "string"},
         {"$ref": "#/definitions/list_of_strings"}
       ]
     },
-    "list_of_strings": {
-      "type": "array",
-      "minItems": 1,
-      "items": {"type": "string"},
-      "uniqueItems": true
-    },
     "list_of_ints": {
       "type": "array",
+      "uniqueItems": true,
       "minItems": 1,
-      "items": {"type": "integer"},
-      "uniqueItems": true
+      "items": {"type": "integer"}
     },
     "int_or_list": {
       "oneOf": [
@@ -46,7 +47,7 @@
     },
     "tags": {
       "description": "Classify tests using a tag name, this can be used for categorizing test and building tests using ``--tags`` option",
-      "$ref": "#definitions/string_or_list"
+      "$ref": "#/definitions/string_or_list"
     },
     "skip": {
       "type": "boolean",
@@ -87,7 +88,7 @@
         },
         "returncode": {
           "description": "Specify a list of returncodes to match with script's exit code. buildtest will PASS test if script's exit code is found in list of returncodes. You must specify unique numbers as list and a minimum of 1 item in array",
-          "$ref": "#definitions/int_or_lists"
+          "$ref": "#/definitions/int_or_list"
         },
         "regex": {
           "type": "object",

--- a/buildtest/schemas/examples/script-v1.0.schema.json/invalid/examples.yml
+++ b/buildtest/schemas/examples/script-v1.0.schema.json/invalid/examples.yml
@@ -77,21 +77,13 @@ buildspecs:
     status:
       returncode: []
 
-  unique_returncodes:
-    type: script
-    executor: local.bash
-    description: The returncode list must be unique
-    run: exit 1
-    status:
-      returncode: [1, 2, 1]
-
   non_int_returncodes:
     type: script
     executor: local.bash
     description: The returncode must be an int and not a number
     run: exit 1
     status:
-      returncode:  1.0
+      returncode:  1.01
 
   non_int_returncodes_list:
     type: script
@@ -99,7 +91,7 @@ buildspecs:
     description: The returncode must be a list of integers and no numbers
     run: exit 1
     status:
-      returncode:  [1, 2.0]
+      returncode:  [1, 2.230]
 
   invalid_shell_usr_bin_bash:
     type: script
@@ -135,7 +127,6 @@ buildspecs:
     description: tag list can't be empty, requires one item.
     tags: []
     run: hostname
-
 
   non_unique_tags:
     type: script

--- a/buildtest/schemas/global.schema.json
+++ b/buildtest/schemas/global.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://buildtesters.github.io/buildtest/schemas/global.schema.json",
+  "$id": "global.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "global schema",
   "description": "buildtest global schema is validated for all buildspecs. The global schema defines top-level structure of buildspec and defintions that are inherited for sub-schemas",

--- a/buildtest/schemas/script-v1.0.schema.json
+++ b/buildtest/schemas/script-v1.0.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://buildtesters.github.io/buildtest/schemas/script-v1.0.schema.json",
+  "$id": "script-v1.0.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "script schema version 1.0",
   "description": "The script schema is of ``type: script`` in sub-schema which is used for running shell scripts",

--- a/docs/buildspecs/buildspec_overview.rst
+++ b/docs/buildspecs/buildspec_overview.rst
@@ -106,16 +106,36 @@ Return Code Matching
 
 buildtest can report PASS/FAIL based on returncode, by default a 0 exit code is PASS
 and everything else is FAIL. The returncode can be a list of exit codes to match.
-In this example we have three tests called ``exit1_fail``, ``exit1_pass`` and
-``returncode_mismatch``.  We expect **exit1_fail** and
-**returncode_mismatch** to FAIL while **exit1_pass** will PASS since returncode matches
+In this example we have four tests called ``exit1_fail``, ``exit1_pass``,
+``returncode_list_mismatch`` and ``returncode_int_match``.  We expect **exit1_fail** and
+**returncode_mismatch** to FAIL while **exit1_pass** and **returncode_int_match**
+will PASS.
 
 .. program-output:: cat ../tutorials/pass_returncode.yml
 
-To demonstrate we will build this test and pay close attention to the Status field
-in output.
+To demonstrate we will build this test and pay close attention to the **Status**
+column in output.
 
 .. program-output:: cat docgen/schemas/pass_returncode.txt
+
+
+The ``returncode`` field can be an integer or list of integers. If you specify
+a list of exit codes, buildtest will ``PASS`` test if actual exit code is found in
+list.
+
+A floating point exit-code is invalid::
+
+  returncode: 1.5
+
+If **returncode** is a list, all items must be integers and unique items.
+The list must contain **atleast** one item. The following examples are invalid
+values for returncode::
+
+  returncode: []
+
+  returncode: [1, 1.5]
+
+  returncode: [1, 2, 5, 5]
 
 Python example
 ---------------

--- a/docs/docgen/schemas/pass_returncode.txt
+++ b/docs/docgen/schemas/pass_returncode.txt
@@ -1,49 +1,50 @@
-$ buildtest build -b tutorials/pass_returncode.yml 
+$ buildtest build -b tutorials/pass_returncode.yml
 
 +-------------------------------+
 | Stage: Discovering Buildspecs |
-+-------------------------------+ 
-    
++-------------------------------+
+
 
 Discovered Buildspecs:
- 
+
 /Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
 
 +---------------------------+
 | Stage: Parsing Buildspecs |
-+---------------------------+ 
-    
++---------------------------+
+
  schemafile              | validstate   | buildspec
 -------------------------+--------------+-------------------------------------------------------------------
  script-v1.0.schema.json | True         | /Users/siddiq90/Documents/buildtest/tutorials/pass_returncode.yml
 
 +----------------------+
 | Stage: Building Test |
-+----------------------+ 
++----------------------+
 
- Name                | Type   | Executor   | Tags                  | Testpath
----------------------+--------+------------+-----------------------+----------------------------------------------------------------------------------------------------------------
- exit1_fail          | script | local.sh   | ['tutorials', 'fail'] | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_fail/3/stage/generate.sh
- exit1_pass          | script | local.sh   | ['tutorials', 'pass'] | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_pass/3/stage/generate.sh
- returncode_mismatch | script | local.sh   | ['tutorials', 'fail'] | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/returncode_mismatch/3/stage/generate.sh
+ Name                     | Type   | Executor   | Tags                  | Testpath
+--------------------------+--------+------------+-----------------------+----------------------------------------------------------------------------------------------------------------------
+ exit1_fail               | script | local.sh   | ['tutorials', 'fail'] | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_fail/49/stage/generate.sh
+ exit1_pass               | script | local.sh   | ['tutorials', 'pass'] | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_pass/44/stage/generate.sh
+ returncode_list_mismatch | script | local.sh   | ['tutorials', 'fail'] | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/returncode_list_mismatch/17/stage/generate.sh
+ returncode_int_match     | script | local.sh   | ['tutorials', 'pass'] | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/returncode_int_match/3/stage/generate.sh
 
 +----------------------+
 | Stage: Running Test  |
-+----------------------+ 
-    
- Name                | Executor   | Status   |   Returncode | TestPath
----------------------+------------+----------+--------------+----------------------------------------------------------------------------------------------------------------
- exit1_fail          | local.sh   | FAIL     |            1 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_fail/3/stage/generate.sh
- exit1_pass          | local.sh   | PASS     |            1 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_pass/3/stage/generate.sh
- returncode_mismatch | local.sh   | FAIL     |            2 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/returncode_mismatch/3/stage/generate.sh
++----------------------+
+
+ Name                     | Executor   | Status   |   Returncode | TestPath
+--------------------------+------------+----------+--------------+----------------------------------------------------------------------------------------------------------------------
+ exit1_fail               | local.sh   | FAIL     |            1 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_fail/49/stage/generate.sh
+ exit1_pass               | local.sh   | PASS     |            1 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/exit1_pass/44/stage/generate.sh
+ returncode_list_mismatch | local.sh   | FAIL     |            2 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/returncode_list_mismatch/17/stage/generate.sh
+ returncode_int_match     | local.sh   | PASS     |          128 | /Users/siddiq90/Documents/buildtest/var/tests/local.sh/pass_returncode/returncode_int_match/3/stage/generate.sh
 
 +----------------------+
 | Stage: Test Summary  |
-+----------------------+ 
-    
-Executed 3 tests
-Passed Tests: 1/3 Percentage: 33.333%
-Failed Tests: 2/3 Percentage: 66.667%
++----------------------+
 
+Executed 4 tests
+Passed Tests: 2/4 Percentage: 50.000%
+Failed Tests: 2/4 Percentage: 50.000%
 
 

--- a/tests/schema_tests/test_compiler.py
+++ b/tests/schema_tests/test_compiler.py
@@ -3,9 +3,10 @@ import os
 import pytest
 import re
 import yaml
-from jsonschema import validate
+
 from jsonschema.exceptions import ValidationError
 from buildtest.defaults import SCHEMA_ROOT
+from buildtest.schemas.defaults import custom_validator
 
 here = os.path.dirname(os.path.abspath(__file__))
 schemaroot = os.path.join(os.path.dirname(here), "schemas")
@@ -47,7 +48,7 @@ def check_invalid_recipes(recipes, invalids, loaded, version):
         # For each section, assume folder type and validate
         for name in content["buildspecs"].keys():
             with pytest.raises(ValidationError) as excinfo:
-                validate(instance=content["buildspecs"][name], schema=loaded)
+                custom_validator(recipe=content["buildspecs"][name], schema=loaded)
             print(excinfo.type, excinfo.value)
             print("Testing %s from recipe %s should be invalid" % (name, recipe))
 
@@ -65,7 +66,7 @@ def check_valid_recipes(recipes, valids, loaded, version):
 
         # For each section, assume folder type and validate
         for name in content["buildspecs"].keys():
-            validate(instance=content["buildspecs"][name], schema=loaded)
+            custom_validator(recipe=content["buildspecs"][name], schema=loaded)
             print("Testing %s from recipe %s should be valid" % (name, recipe))
 
 

--- a/tests/schema_tests/test_global.py
+++ b/tests/schema_tests/test_global.py
@@ -3,9 +3,10 @@ import os
 import re
 import pytest
 import yaml
-from jsonschema import validate
+
 from jsonschema.exceptions import ValidationError
 from buildtest.defaults import SCHEMA_ROOT
+from buildtest.schemas.defaults import custom_validator
 
 schema_name = "global"
 schema_file = f"{schema_name}.schema.json"
@@ -41,7 +42,7 @@ def check_invalid_recipes(recipes, invalids, loaded):
         content = load_recipe(recipe_path)
 
         with pytest.raises(ValidationError) as excinfo:
-            validate(instance=content, schema=loaded)
+            custom_validator(recipe=content, schema=loaded)
         print(excinfo.type, excinfo.value)
         print("Recipe File: %s  should be invalid" % recipe_path)
 
@@ -55,7 +56,7 @@ def check_valid_recipes(recipes, valids, loaded):
         recipe_path = os.path.join(valids, recipe)
         content = load_recipe(recipe_path)
 
-        validate(instance=content, schema=loaded)
+        custom_validator(recipe=content, schema=loaded)
         print("Recipe File: %s should be valid" % recipe_path)
 
 

--- a/tests/schema_tests/test_script.py
+++ b/tests/schema_tests/test_script.py
@@ -7,6 +7,7 @@ import yaml
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 from buildtest.defaults import SCHEMA_ROOT
+from buildtest.schemas.defaults import custom_validator
 
 
 schema_name = "script"
@@ -45,9 +46,10 @@ def check_invalid_recipes(recipes, invalids, loaded, version):
         # For each section, assume folder type and validate
         for name in content["buildspecs"].keys():
             with pytest.raises(ValidationError) as excinfo:
-                validate(instance=content["buildspecs"][name], schema=loaded)
-            print(excinfo.type, excinfo.value)
-            print("Testing %s from recipe %s should be invalid" % (name, recipe))
+                print("Testing %s from recipe %s should be invalid" % (name, recipe))
+                custom_validator(recipe=content["buildspecs"][name], schema=loaded)
+            print(excinfo.exconly())
+            # print("Testing %s from recipe %s should be invalid" % (name, recipe))
 
 
 def check_valid_recipes(recipes, valids, loaded, version):
@@ -64,7 +66,7 @@ def check_valid_recipes(recipes, valids, loaded, version):
         # For each section, assume folder type and validate
         for name in content["buildspecs"].keys():
             print(content["buildspecs"][name])
-            validate(instance=content["buildspecs"][name], schema=loaded)
+            custom_validator(recipe=content["buildspecs"][name], schema=loaded)
             print("Testing %s from recipe %s should be valid" % (name, recipe))
 
 

--- a/tests/schema_tests/test_settings.py
+++ b/tests/schema_tests/test_settings.py
@@ -1,8 +1,9 @@
 import json
 import os
 import yaml
-from jsonschema import validate
+
 from buildtest.defaults import SCHEMA_ROOT
+from buildtest.schemas.defaults import custom_validator
 
 
 schema_file = "settings.schema.json"
@@ -43,4 +44,4 @@ def test_settings_examples():
         assert example_recipe
 
         print(f"Expecting Recipe File: {filepath} to be valid")
-        validate(instance=example_recipe, schema=recipe)
+        custom_validator(recipe=example_recipe, schema=recipe)

--- a/tutorials/pass_returncode.yml
+++ b/tutorials/pass_returncode.yml
@@ -26,7 +26,7 @@ buildspecs:
     status:
       returncode: [1, 3]
 
-  returncode_match:
+  returncode_int_match:
     executor: local.sh
     type: script
     description: exit 128 matches returncode 128


### PR DESCRIPTION
…ching from internet.

Change $id field in schema.
Add method custom_validator that should be used for validating JSON document with schemas
found in buildtest.
Refactor schema tests to use custom_validator method.
Update schema_table dictionary.
Refactor code for buildtest schema. We can show JSON file for definitions.schema.json
but if they pass --examples for definitions schema we raise error because there are
no examples for this schema.
Update documentation on returncode section