### PR TITLE
fix job timeout issue during poll stage

### DIFF
--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -33,6 +33,7 @@ class SlurmExecutor(BaseExecutor):
         "AllocTRES",
         "ConsumedEnergyRaw",
         "CPUTimeRaw",
+        "Elapsed",
         "End",
         "ExitCode",
         "JobID",
@@ -236,15 +237,18 @@ class SlurmExecutor(BaseExecutor):
 
         self.result["starttime"] = job_data["Start"]
         self.result["endtime"] = job_data["End"]
+        self.result["runtime"] = job_data["Elapsed"]
 
         if self.builder.job_state == "CANCELLED":
             return
 
         self.builder.metadata["outfile"] = os.path.join(
-            job_data["WorkDir"].rstrip(), f"{self.builder.metadata['name']}.out",
+            job_data["WorkDir"].rstrip(),
+            f"{self.builder.metadata['name']}.out",
         )
         self.builder.metadata["errfile"] = os.path.join(
-            job_data["WorkDir"].rstrip(), f"{self.builder.metadata['name']}.err",
+            job_data["WorkDir"].rstrip(),
+            f"{self.builder.metadata['name']}.err",
         )
 
         shutil.copy2(

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -333,7 +333,13 @@ def build_phase(builders, printTable=False):
         table["testpath"].append(builder.metadata["testpath"])
 
     if printTable:
-        print(tabulate(table, headers=table.keys(), tablefmt="presto",))
+        print(
+            tabulate(
+                table,
+                headers=table.keys(),
+                tablefmt="presto",
+            )
+        )
 
 
 def run_phase(builders, executor, config_dict, printTable=False):
@@ -446,8 +452,8 @@ def run_phase(builders, executor, config_dict, printTable=False):
         # if no items in poll_queue terminate, this will happen as jobs complete polling
         # and they are removed from queue.
 
-        # keep track of tests that are cancelled by job scheduler
-        cancelled_jobs = set()
+        # keep track of ignored jobs by job scheduler these include jobs that failed abnormally or cancelled by scheduler
+        ignore_jobs = set()
         while poll_queue:
 
             print("\n")
@@ -467,20 +473,26 @@ def run_phase(builders, executor, config_dict, printTable=False):
                     )
                     poll_queue.remove(builder)
 
-                # add invalid jobs to cancelled_jobs list which are ignored from output
+                # add invalid jobs to ignore_jobs list which are ignored from output
                 # and not updated in report
                 if poll_info["ignore_job"]:
-                    cancelled_jobs.add(builder)
+                    ignore_jobs.add(builder)
 
-        # remove any cancelled builders from output since these jobs were CANCELLED and there is no output
-        if cancelled_jobs:
+        # remove any builders where for jobs that need to be ignored
+        if ignore_jobs:
             # convert set to list
-            cancelled_jobs = list(cancelled_jobs)
-            for builder in cancelled_jobs:
+            ignore_jobs = list(ignore_jobs)
+            for builder in ignore_jobs:
                 valid_builders.remove(builder)
 
             print("Cancelled Tests:")
-            [print(builder.metadata["name"]) for builder in cancelled_jobs]
+            [print(builder.metadata["name"]) for builder in ignore_jobs]
+
+        # after removing jobs from valid_builders list there is chance we have no jobs to report
+        # in that case we return from method
+        if not valid_builders:
+            print("After polling all jobs we found no valid builders to process")
+            return
 
         table = {
             "name": [],
@@ -603,5 +615,6 @@ def func_build_subcmd(args, config_opts):
         return
 
     valid_builders = run_phase(builders, executor, config_opts, printTable=True)
-
-    update_report(valid_builders)
+    # only update report if we have a list of valid builders returned from run_phase
+    if valid_builders:
+        update_report(valid_builders)

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -459,15 +459,17 @@ def run_phase(builders, executor, config_dict, printTable=False):
             logger.debug(f"Polling Jobs: {poll_queue}")
 
             for builder in poll_queue:
-                state = executor.poll(builder)
+                poll_info = executor.poll(builder)
                 # remove builder from poll_queue when state is True
-                if state:
+                if poll_info["job_complete"]:
                     logger.debug(
                         f"{builder} poll complete, removing test from poll queue"
                     )
                     poll_queue.remove(builder)
 
-                if builder.job_state == "CANCELLED":
+                # add invalid jobs to cancelled_jobs list which are ignored from output
+                # and not updated in report
+                if poll_info["ignore_job"]:
                     cancelled_jobs.add(builder)
 
         # remove any cancelled builders from output since these jobs were CANCELLED and there is no output

--- a/docs/buildspecs/batch_support.rst
+++ b/docs/buildspecs/batch_support.rst
@@ -161,9 +161,10 @@ via ``sacct`` using the following format fields:
 -    AllocTRES
 -    ConsumedEnergyRaw
 -    CPUTimeRaw
+-    Elapsed
 -    End
 -    ExitCode
--    "JobID
+-    JobID
 -    JobName
 -    NCPUS
 -    NNodes


### PR DESCRIPTION
This PR address few issues
 - Invalid jobs including cancelled jobs are ignored 
- There was a bug where after polling where we could have no valid builders, now we add checks to mitigate this error
 - Add Elapsed field in sacct which shows up in `runtime` property in report