### PR TITLE
autodetect compilers based on modules

### DIFF
--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -62,9 +62,10 @@ def check_settings(settings_path=None, executor_check=True, retrieve_settings=Fa
         if cobalt_executors:
             validate_cobalt_executors(cobalt_executors)
 
-        if user_schema.get("modules_tool") != system.system["modules_tool"]:
+        if user_schema.get("moduletool") != "N/A" and user_schema.get("moduletool") != system.system["moduletool"]:
+
             raise BuildTestError(
-                f"Cannot find modules_tool: {user_schema.get('modules_tool')} from configuration, please confirm if you have environment-modules or lmod and specify the appropriate tool."
+                f"Cannot find modules_tool: {user_schema.get('moduletool')} from configuration, please confirm if you have environment-modules or lmod and specify the appropriate tool."
             )
 
     if retrieve_settings:

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -61,7 +61,10 @@ def check_settings(settings_path=None, executor_check=True, retrieve_settings=Fa
         if cobalt_executors:
             validate_cobalt_executors(cobalt_executors)
 
-        if user_schema.get("moduletool") != "N/A" and user_schema.get("moduletool") != system.system["moduletool"]:
+        if (
+            user_schema.get("moduletool") != "N/A"
+            and user_schema.get("moduletool") != system.system["moduletool"]
+        ):
 
             raise BuildTestError(
                 f"Cannot find modules_tool: {user_schema.get('moduletool')} from configuration, please confirm if you have environment-modules or lmod and specify the appropriate tool."

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 from jsonschema import validate
 
 from buildtest.schemas.utils import load_schema, load_recipe

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -250,7 +250,9 @@ class CobaltExecutor(BaseExecutor):
         )
         """
 
-        cobaltlog = os.path.join(self.builder.stage_dir, str(self.builder.metadata["jobid"]) + ".cobaltlog")
+        cobaltlog = os.path.join(
+            self.builder.stage_dir, str(self.builder.metadata["jobid"]) + ".cobaltlog"
+        )
         self.logger.debug(f"Cobalt Log File written to {cobaltlog}")
         if os.path.exists(cobaltlog):
             content = read_file(cobaltlog)

--- a/buildtest/executors/lsf.py
+++ b/buildtest/executors/lsf.py
@@ -6,7 +6,6 @@ when initializing the executors.
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 import time

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -17,7 +17,7 @@ from buildtest.menu.config import (
     func_config_validate,
     func_config_view,
     func_config_compiler,
-    func_compiler_find
+    func_compiler_find,
 )
 
 from buildtest.menu.report import func_report
@@ -264,8 +264,12 @@ class BuildTestParser:
         compiler_config = subparsers_config.add_parser(
             "compilers", help="search or find compilers "
         )
-        subparsers_compiler_find = compiler_config.add_subparsers(description="Find new compilers and add them to detected compiler section")
-        compiler_find = subparsers_compiler_find.add_parser("find", help = "Find compilers")
+        subparsers_compiler_find = compiler_config.add_subparsers(
+            description="Find new compilers and add them to detected compiler section"
+        )
+        compiler_find = subparsers_compiler_find.add_parser(
+            "find", help="Find compilers"
+        )
 
         parser_config_view = subparsers_config.add_parser(
             "view", help="View Buildtest Configuration File"

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -17,6 +17,7 @@ from buildtest.menu.config import (
     func_config_validate,
     func_config_view,
     func_config_compiler,
+    func_compiler_find
 )
 
 from buildtest.menu.report import func_report
@@ -263,6 +264,8 @@ class BuildTestParser:
         compiler_config = subparsers_config.add_parser(
             "compilers", help="search or find compilers "
         )
+        subparsers_compiler_find = compiler_config.add_subparsers(description="Find new compilers and add them to detected compiler section")
+        compiler_find = subparsers_compiler_find.add_parser("find", help = "Find compilers")
 
         parser_config_view = subparsers_config.add_parser(
             "view", help="View Buildtest Configuration File"
@@ -270,6 +273,7 @@ class BuildTestParser:
         parser_config_validate = subparsers_config.add_parser(
             "validate", help="Validate buildtest settings file with schema."
         )
+
         parser_config_summary = subparsers_config.add_parser(
             "summary", help="Provide summary of buildtest settings."
         )
@@ -289,11 +293,13 @@ class BuildTestParser:
         compiler_config.add_argument(
             "-l", "--list", action="store_true", help="List all compilers "
         )
+
         parser_config_view.set_defaults(func=func_config_view)
         parser_config_validate.set_defaults(func=func_config_validate)
         parser_config_summary.set_defaults(func=func_config_summary)
 
         compiler_config.set_defaults(func=func_config_compiler)
+        compiler_find.set_defaults(func=func_compiler_find)
 
     def report_menu(self):
         """This method implements the ``buildtest report`` command options"""

--- a/buildtest/schemas/examples/settings.schema.json/valid/cobalt-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/cobalt-example.yml
@@ -1,4 +1,5 @@
 editor: vi
+moduletool: lmod
 executors:
   defaults:
      launcher: qsub

--- a/buildtest/schemas/examples/settings.schema.json/valid/combined_executor.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/combined_executor.yml
@@ -1,4 +1,5 @@
 editor: vi
+moduletool: N/A
 executors:
   local:
     bash:
@@ -18,3 +19,9 @@ executors:
       options:
         - "-q batch"
         - "-t 00:10"
+  cobalt:
+    normal:
+      launcher: qsub
+      options:
+        - "-n 1"
+        - "-t 10"

--- a/buildtest/schemas/examples/settings.schema.json/valid/local-executor.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/local-executor.yml
@@ -1,4 +1,5 @@
 editor: vi
+moduletool: N/A
 executors:
   local:
     bash:
@@ -30,8 +31,6 @@ executors:
     python:
       description: submit jobs on local machine using python shell
       shell: python
-
-modules_tool: environment-modules
 
 compilers:
   find:

--- a/buildtest/schemas/examples/settings.schema.json/valid/lsf-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/lsf-example.yml
@@ -1,4 +1,5 @@
 editor: vi
+moduletool: lmod
 executors:
   defaults:
     pollinterval: 10

--- a/buildtest/schemas/examples/settings.schema.json/valid/slurm-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/slurm-example.yml
@@ -1,4 +1,5 @@
 editor: emacs
+moduletool: lmod
 buildspec_roots:
   - $HOME/buildtest-cori
 testdir: /tmp/buildtest

--- a/buildtest/schemas/settings.schema.json
+++ b/buildtest/schemas/settings.schema.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "buildtest configuration schema",
   "type": "object",
-  "required": ["executors", "editor"],
+  "required": ["executors", "editor", "moduletool"],
   "additionalProperties": false,
   "properties": {
       "additionalProperties": false,
@@ -22,10 +22,10 @@
         "type": "string",
         "description": "Specify full path to test directory where buildtest will write tests."
       },
-      "modules_tool": {
+      "moduletool": {
         "type": "string",
         "description": "Specify modules tool used for interacting with ``module`` command. ",
-        "enum": ["environment-modules", "lmod"]
+        "enum": ["environment-modules", "lmod", "N/A"]
       },
       "compilers": {
         "type": "object",
@@ -111,7 +111,7 @@
       "executors": {
         "type": "object",
         "additionalProperties": false,
-        "description": "The executor section is used for declaring your executors that are responsible for running jobs. The executor section can be ``local``, ``lsf``, ``slurm``, ``ssh``. The executors are referenced in buildspec using ``executor`` field.",
+        "description": "The executor section is used for declaring your executors that are responsible for running jobs. The executor section can be ``local``, ``lsf``, ``slurm``, ``cobalt``. The executors are referenced in buildspec using ``executor`` field.",
         "properties": {
            "defaults": {
             "type": "object",
@@ -234,6 +234,7 @@
       },
       "local": {
           "type": "object",
+          "description": "An instance object of local executor",
           "additionalProperties": false,
           "required": ["shell"],
           "properties": {
@@ -247,6 +248,7 @@
       "slurm": {
           "type": "object",
           "additionalProperties": false,
+          "description": "An instance object of slurm executor",
           "properties": {
               "description": {"type": "string", "description": "description field for documenting your executor"},
               "launcher": { "type": "string", "enum": ["sbatch"], "description": "Specify the slurm batch scheduler to use. This overrides the default ``launcher`` field. This must be ``sbatch``. " },
@@ -254,38 +256,40 @@
               "cluster": {"type":  "string", "description": "Specify the slurm cluster you want to use ``-M <cluster>``"},
               "partition": {"type":  "string", "description": "Specify the slurm partition you want to use ``-p <partition>``"},
               "qos": {"type":  "string", "description": "Specify the slurm qos you want to use ``-q <qos>``"},
-              "before_script": { "#ref":  "#/definitions/script" },
-              "after_script": { "#ref":  "#/definitions/script" },
-              "max_pend_time": {"$ref":  "#/definitions/max_pend_time"},
-              "account": {"$ref":  "#/definitions/account"}
+              "before_script": { "description": "The ``before_script`` section can be used to specify commands before start of test. The script will be sourced in active shell.", "#ref":  "#/definitions/script" },
+              "after_script": { "description": "The ``after_script`` section can be used to specify commands at end of test. The script will be sourced in active shell.","#ref":  "#/definitions/script" },
+              "max_pend_time": {"description": "overrides default ``max_pend_time`` value", "$ref":  "#/definitions/max_pend_time"},
+              "account": {"description": "overrides default ``account`` value", "$ref":  "#/definitions/account"}
            }
        },
       "lsf": {
           "type": "object",
+          "description": "An instance object of lsf executor",
           "additionalProperties": false,
           "properties": {
               "description": {"type": "string", "description": "description field for documenting your executor"},
               "launcher": { "type": "string", "enum": ["bsub"], "description": "Specify the lsf batch scheduler to use. This overrides the default ``launcher`` field. It must be ``bsub``. " },
               "options": { "type": "array", "items": {"type": "string"}, "description": "Specify any options for ``bsub`` for this executor when running all jobs associated to this executor" },
               "queue": {"type":  "string", "description": "Specify the lsf queue you want to use ``-q <queue>``"},
-              "before_script": { "#ref":  "#/definitions/script" },
-              "after_script": { "#ref":  "#/definitions/script" },
-              "max_pend_time": {"$ref":  "#/definitions/max_pend_time"},
-              "account": {"$ref":  "#/definitions/account"}
+              "before_script": { "description": "The ``before_script`` section can be used to specify commands before start of test. The script will be sourced in active shell.", "#ref":  "#/definitions/script" },
+              "after_script": { "description": "The ``after_script`` section can be used to specify commands at end of test. The script will be sourced in active shell.","#ref":  "#/definitions/script" },
+              "max_pend_time": {"description": "overrides default ``max_pend_time`` value", "$ref":  "#/definitions/max_pend_time"},
+              "account": {"description": "overrides default ``account`` value", "$ref":  "#/definitions/account"}
           }
        },
       "cobalt": {
           "type": "object",
+          "description": "An instance object of cobalt executor",
           "additionalProperties": false,
           "properties": {
               "description": {"type": "string", "description": "description field for documenting your executor"},
               "launcher": { "type": "string", "enum": ["qsub"], "description": "Specify the cobalt batch scheduler to use. This overrides the default ``launcher`` field. It must be ``qsub``. " },
               "options": { "type": "array", "items": {"type": "string"}, "description": "Specify any options for ``qsub`` for this executor when running all jobs associated to this executor" },
               "queue": {"type":  "string", "description": "Specify the lsf queue you want to use ``-q <queue>``"},
-              "before_script": { "#ref":  "#/definitions/script" },
-              "after_script": { "#ref":  "#/definitions/script" },
-              "max_pend_time": {"$ref":  "#/definitions/max_pend_time"},
-              "account": {"$ref":  "#/definitions/account"}
+              "before_script": { "description": "The ``before_script`` section can be used to specify commands before start of test. The script will be sourced in active shell.", "#ref":  "#/definitions/script" },
+              "after_script": { "description": "The ``after_script`` section can be used to specify commands at end of test. The script will be sourced in active shell.","#ref":  "#/definitions/script" },
+              "max_pend_time": {"description": "overrides default ``max_pend_time`` value", "$ref":  "#/definitions/max_pend_time"},
+              "account": {"description": "overrides default ``account`` value", "$ref":  "#/definitions/account"}
           }
        }
     }

--- a/buildtest/settings/config.yml
+++ b/buildtest/settings/config.yml
@@ -1,4 +1,5 @@
 editor: vi
+moduletool: N/A
 executors:
   local:
     bash:

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -86,13 +86,13 @@ class BuildTestSystem:
         of configuration check
         """
 
-        self.system["modules_tool"] = None
+        self.system["moduletool"] = None
 
         if os.getenv("LMOD_VERSION"):
-            self.system["modules_tool"] = "lmod"
+            self.system["moduletool"] = "lmod"
         # 3.x module versions define MODULE_VERSION while 4.5 version has MODULES_CMD, it doesn't have MODULE_VERSION set
         elif os.getenv("MODULE_VERSION") or os.getenv("MODULES_CMD"):
-            self.system["modules_tool"] = "environment-modules"
+            self.system["moduletool"] = "environment-modules"
 
 
 class Scheduler:

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -9,8 +9,6 @@ import os
 import platform
 import shutil
 import sys
-
-from buildtest.exceptions import BuildTestError
 from buildtest.utils.command import BuildTestCommand
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML>=5.2
 jsonschema
 tabulate
 distro
+lmodule==0.1

--- a/setup.csh
+++ b/setup.csh
@@ -24,7 +24,6 @@
 set command=($_)
 set sourced_file=`readlink -f $command[2]`
 set buildtest_root=`dirname "$sourced_file"`
-echo "buildtest root is ${buildtest_root}"
 
 echo "Installing buildtest dependencies"
 pip install -r ${buildtest_root}/requirements.txt > /dev/null
@@ -39,5 +38,4 @@ else
 endif
 
 set buildtest_path=`which buildtest`
-echo "Adding ${bin} to PATH variable"
 echo "buildtest command: ${buildtest_path}"

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,6 @@
 # SOFTWARE.
 
 buildtest_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
-echo "buildtest root is ${buildtest_root}"
 
 echo "Installing buildtest dependencies"
 pip install -r ${buildtest_root}/requirements.txt &> /dev/null
@@ -33,5 +32,4 @@ export PATH=${bin}:$PATH
 export PYTHONPATH=${buildtest_root}:$PYTHONPATH
 
 buildtest_path=$(which buildtest)
-echo "Adding ${bin} to PATH variable"
 echo "buildtest command: ${buildtest_path}"

--- a/tests/buildsystem/test_base.py
+++ b/tests/buildsystem/test_base.py
@@ -14,7 +14,7 @@ def test_BuildspecParser(tmp_path):
 
     # Examples folder
     examples_dir = os.path.join(testroot, "examples", "buildspecs")
-    # An empty path evaluated to be a directory should exit
+    # Invalid path to buildspec file should exit
     with pytest.raises(SystemExit):
         BuildspecParser("")
 


### PR DESCRIPTION
This PR adds command `buildtest config compilers find`  which auto detects compiler sections based on modules. We make use of lmodule API for detecting compilers using spider. For environment-modules we detect this manually, soon this feature could be added in Lmodule api.

buildtest will update configuration file after find is complete. We test all modules before adding them. 
Minor updates to schema descriptions for some fields. 
The `module_tool` field is now changed to `moduletool` in configuration file