### PR TITLE
add check for pip when installing buildtest. Add installation CI workflow

### DIFF
--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -25,9 +25,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Buildtest Installation for ${{ matrix.os }}, ${{ matrix.python-version }} 
-      run: |
-        sudo apt-get install -y tcsh zsh
+    - name: Buildtest Installation for os - ${{ matrix.os }}, python version - ${{ matrix.python-version }} 
+      run: |        
         echo $SHELL
         $SHELL --version
         git --version

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -1,0 +1,38 @@
+name: buildtest installation
+
+on:
+  pull_request:
+    branches: [ devel ]
+
+
+jobs:
+
+  buildtest-installation:
+    runs-on: ${{ matrix.os }} 
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        python-version: [3.6, 3.7, 3.8]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      
+    - name: Setup Python ${{ matrix.python-version }} for OS: ${{ matrix.os }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Buildtest Installation
+      run: |
+        sudo apt-get install -y tcsh zsh
+        echo $SHELL
+        $SHELL --version
+        git --version
+        pip install -U pip
+        python --version
+        source setup.sh
+        which buildtest
+        buildtest --version

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -1,4 +1,4 @@
-name: buildtest installation
+name: installation
 
 on:
   pull_request:
@@ -20,12 +20,12 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
       
-    - name: Setup Python ${{ matrix.python-version }} for OS: ${{ matrix.os }}
+    - name: Setup Python ${{ matrix.python-version }} 
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Buildtest Installation
+    - name: Buildtest Installation for ${{ matrix.os }}, ${{ matrix.python-version }} 
       run: |
         sudo apt-get install -y tcsh zsh
         echo $SHELL

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }} 
 
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
         python-version: [3.6, 3.7, 3.8]
@@ -26,7 +27,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Buildtest Installation for os - ${{ matrix.os }}, python version - ${{ matrix.python-version }} 
-      run: |        
+      env:
+        OS: $ {{ matrix.os }}
+      run: |
+        echo $OS
         echo $SHELL
         $SHELL --version
         git --version

--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -28,9 +28,9 @@ jobs:
 
     - name: Buildtest Installation for os - ${{ matrix.os }}, python version - ${{ matrix.python-version }} 
       env:
-        OS: $ {{ matrix.os }}
+        OS: ${{ matrix.os }}
       run: |
-        echo $OS
+        if [ "OS" == "ubuntu-latest" ] ; then apt-get install -y tcsh zsh; else brew install tcsh zsh ;  fi        
         echo $SHELL
         $SHELL --version
         git --version

--- a/setup.csh
+++ b/setup.csh
@@ -1,4 +1,4 @@
-#!/bin/csh
+#!/bin/csh -v
 # MIT License
 
 # Copyright (c) 2017-2021, Shahzeb Siddiqui and Vanessa Sochat
@@ -24,6 +24,13 @@
 set command=($_)
 set sourced_file=`readlink -f $command[2]`
 set buildtest_root=`dirname "$sourced_file"`
+
+set pip=pip
+
+if ( ! -x `command -v $pip` ) then 
+  echo "cannot find program $pip, please install $pip"
+  exit 1
+endif
 
 echo "Installing buildtest dependencies"
 pip install -r ${buildtest_root}/requirements.txt > /dev/null

--- a/setup.sh
+++ b/setup.sh
@@ -22,9 +22,15 @@
 # SOFTWARE.
 
 buildtest_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
+pip=pip3
+
+if ! [ -x "$(command -v $pip)" ]; then 
+  echo "cannot find program $pip, please install $pip"
+  exit 1
+fi
 
 echo "Installing buildtest dependencies"
-pip install -r ${buildtest_root}/requirements.txt &> /dev/null
+$pip install -r ${buildtest_root}/requirements.txt &> /dev/null
 
 bin=${buildtest_root}/bin
 export PATH=${bin}:$PATH


### PR DESCRIPTION
@adityakavalur i fixed the pip installation that we discussed in https://nersc.slack.com/archives/D016ZR5TJ07/p1611940039031100. I added installation workflow to test buildtest on ubuntu and macOS. 