### PR TITLE
modify output of buildspec find, fix bug  when building tests by tag when buildspec cache not found

### DIFF
--- a/.gitlab/cori.yml
+++ b/.gitlab/cori.yml
@@ -4,8 +4,34 @@ variables:
   SCHEDULER_PARAMETERS: "-N 1 -M escori -q compile -t 30"
 
 stages:
-  - validate
   - regression
+  - validate
+
+cori_pr_regression_test:
+  tags: ["cori"]
+  stage: regression
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "push" || $CI_PIPELINE_SOURCE == "web"'
+      when: manual
+
+  script:
+    - whoami
+    - env | grep CI_
+    - module load python
+    - git branch
+    - conda create -n buildtest python=3.8
+    - source activate buildtest
+    - source setup.sh
+    - pip install -r docs/requirements.txt
+    - rm -rf ~/.buildtest/
+    - coverage run -m pytest -vra tests
+    - coverage report -m
+    # CODECOV_TOKEN environment must be set, this value is stored in CI/CD variable SECRET_CODECOV_TOKEN at https://software.nersc.gov/siddiq90/buildtest/-/settings/ci_cd
+    - export CODECOV_TOKEN=$SECRET_CODECOV_TOKEN
+    - bash <(curl -s https://codecov.io/bash)
+    - source deactivate
+    - conda env remove -n buildtest -y
+
 
 validate_cori_testsuite:
   tags: ["cori"]
@@ -18,38 +44,11 @@ validate_cori_testsuite:
     - conda create -n buildtest python=3.8
     - source activate buildtest
     - source setup.sh    
-    - git clone https://github.com/buildtesters/buildtest-cori/
+    - git clone https://github.com/buildtesters/buildtest-cori
     - cd buildtest-cori
     - mkdir -p $HOME/.buildtest
     - cp .buildtest/config.yml $HOME/.buildtest/config.yml
     - buildtest config validate
-    - buildtest buildspec find --root $PWD
+    - buildtest buildspec find --root buildspecs
     - source deactivate 
-    - conda env remove -n buildtest -y
-    
-cori_pr_regression_test:
-  tags: ["cori"]
-  stage: regression
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event" || $CI_PIPELINE_SOURCE == "push" || $CI_PIPELINE_SOURCE == "web"'
-      when: manual
-    
-  script: 
-    - env | grep CI_
-    - echo $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME
-    - module load python
-    - echo "$CI_PIPELINE_SOURCE"
-    - whoami
-    - git branch
-    - conda create -n buildtest python=3.8
-    - source activate buildtest
-    - source setup.sh    
-    - pip install -r docs/requirements.txt
-    - rm -rf ~/.buildtest/
-    - coverage run -m pytest -vra tests
-    - coverage report -m
-    # CODECOV_TOKEN environment must be set, this value is stored in CI/CD variable SECRET_CODECOV_TOKEN at https://gitlab.nersc.gov/nersc/consulting/buildtest/-/settings/ci_cd
-    - export CODECOV_TOKEN=$SECRET_CODECOV_TOKEN
-    - bash <(curl -s https://codecov.io/bash)
-    - source deactivate
     - conda env remove -n buildtest -y

--- a/.gitlab/olcf.yml
+++ b/.gitlab/olcf.yml
@@ -1,8 +1,5 @@
 # This pipeline is run at OLCF at gitlab instance: https://code.ornl.gov
 
-#variables:
-#  SCHEDULER_PARAMETERS: "-N 1 -M escori -q compile -t 30"
-
 stages:
   - regression
 
@@ -27,7 +24,7 @@ ascent_pr_regression_test:
     - rm -rf ~/.buildtest/
     - coverage run -m pytest -vra tests
     - coverage report -m
-    # CODECOV_TOKEN environment must be set, this value is stored in CI/CD variable SECRET_CODECOV_TOKEN at https://code.ornl.gov/shahzebsiddiqui/buildtest/-/settings/ci_cd
+    # CODECOV_TOKEN environment must be set, this value is stored in CI/CD variable SECRET_CODECOV_TOKEN at https://code.ornl.gov/ecpcitest/buildtest/-/settings/ci_cd
     - export CODECOV_TOKEN=$SECRET_CODECOV_TOKEN
     - bash <(curl -s https://codecov.io/bash)
     - source deactivate

--- a/buildtest/menu/buildspec.py
+++ b/buildtest/menu/buildspec.py
@@ -145,15 +145,6 @@ class BuildspecCache:
         with open(BUILDSPEC_CACHE_FILE, "w") as fd:
             json.dump(self.update_cache, fd, indent=2)
 
-        print("\n")
-        print("Invalid buildspecs")
-        print("{:_<80}".format(""))
-        for file in self.invalid_buildspecs:
-            print(file)
-
-        print(f"Found {len(self.invalid_buildspecs)} invalid buildspecs")
-        print("{:_<80}".format(""))
-
         print("\n\n")
         print(f"Updating buildspec cache file: {BUILDSPEC_CACHE_FILE}")
         # write invalid buildspecs to file if any found
@@ -206,6 +197,21 @@ class BuildspecCache:
                 print(f"Validated {self.count}/{len(buildspecs)} buildspecs")
 
         print(f"Validated {self.count}/{len(buildspecs)} buildspecs")
+
+        # print invalid buildspecs if found
+        if len(self.invalid_buildspecs) > 0:
+            print("\n")
+            print("Invalid buildspecs")
+            print("{:_<80}".format(""))
+            for file in self.invalid_buildspecs:
+                print(file)
+
+            print(f"Found {len(self.invalid_buildspecs)} invalid buildspecs")
+            print("{:_<80}".format(""))
+
+        print("\n")
+        print(f"Adding {len(valid_buildspecs)} buildspec files to cache")
+
         return valid_buildspecs
 
     def build_cache(self):
@@ -252,7 +258,6 @@ class BuildspecCache:
 
             # if maintainer field specified add all maintainers from buildspec to list
             if parser.recipe.get("maintainers"):
-                print(parser.buildspec, parser.recipe["maintainers"])
 
                 for author in parser.recipe["maintainers"]:
                     if not self.update_cache["maintainers"].get(author):
@@ -302,6 +307,12 @@ class BuildspecCache:
         self.update_cache["unique_executors"] = list(
             set(self.update_cache["unique_executors"])
         )
+        count = 0
+
+        for file in self.update_cache["buildspecs"].keys():
+            count += len(self.update_cache["buildspecs"][file].keys())
+
+        print(f"There are {count} tests in buildspec cache")
         self._write_buildspec_cache()
 
     def check_filter_fields(self):
@@ -387,9 +398,9 @@ class BuildspecCache:
         return False
 
     def find_buildspecs(self):
-        """This method will find buildspecs based on cache content. We skip any
-        tests based on executor filter, tag filter or type filter and build
-        a table of tests that will be printed using print_buildspecs method.
+        """ This method will find buildspecs based on cache content. We skip any
+            tests based on executor filter, tag filter or type filter and build
+            a table of tests that will be printed using ``print_buildspecs`` method.
         """
 
         for buildspecfile in self.cache["buildspecs"].keys():
@@ -428,24 +439,24 @@ class BuildspecCache:
                     self.table["description"].append(description)
 
     def get_buildspecfiles(self):
-        """This method implements ``buildtest buildspec find --buildspec-files``
-        which reports all buildspec files in cache.
+        """ This method implements ``buildtest buildspec find --buildspec-files``
+            which reports all buildspec files in cache.
         """
 
         table = {"buildspecs": self.cache["buildspecs"].keys()}
         print(tabulate(table, headers=table.keys(), tablefmt="grid"))
 
     def get_tags(self):
-        """This method implements ``buildtest buildspec find --tags`` which
-        reports a list of unique tags from all buildspecs in cache file.
+        """ This method implements ``buildtest buildspec find --tags`` which
+            reports a list of unique tags from all buildspecs in cache file.
         """
 
         table = {"Tags": self.cache["unique_tags"]}
         print(tabulate(table, headers=table.keys(), tablefmt="grid"))
 
     def get_executors(self):
-        """This method implements ``buildtest buildspec find --list-executors``
-        which reports all executors from cache.
+        """ This method implements ``buildtest buildspec find --list-executors``
+            which reports all executors from cache.
         """
 
         table = {"executors": self.cache["unique_executors"]}
@@ -453,8 +464,8 @@ class BuildspecCache:
         print(tabulate(table, headers=table.keys(), tablefmt="grid"))
 
     def print_by_executors(self):
-        """This method prints executors by tests and implements
-        ``buildtest buildspec find --group-by-executor`` command
+        """ This method prints executors by tests and implements
+            ``buildtest buildspec find --group-by-executor`` command
         """
 
         table = {"executor": [], "name": [], "description": []}
@@ -468,8 +479,8 @@ class BuildspecCache:
         print(tabulate(table, headers=table.keys(), tablefmt="grid"))
 
     def print_by_tags(self):
-        """This method prints tags by tests and implements
-        ``buildtest buildspec find --group-by-tags`` command
+        """ This method prints tags by tests and implements
+            ``buildtest buildspec find --group-by-tags`` command
         """
 
         table = {"tags": [], "name": [], "description": []}
@@ -488,8 +499,8 @@ class BuildspecCache:
         print(tabulate(self.table, headers=self.table.keys(), tablefmt="grid"))
 
     def print_maintainer(self):
-        """This method prints maintainers from buildspec cache file which implements
-        ``buildtest buildspec find --maintainers`` command.
+        """ This method prints maintainers from buildspec cache file which implements
+            ``buildtest buildspec find --maintainers`` command.
         """
 
         table = {"maintainers": []}
@@ -500,8 +511,8 @@ class BuildspecCache:
         print(tabulate(table, headers=table.keys(), tablefmt="grid"))
 
     def print_maintainers_by_buildspecs(self):
-        """This method prints maintainers breakdown by buildspecs. This method
-        implements ``buildtest buildspec find --maintainers-by-buildspecs
+        """ This method prints maintainers breakdown by buildspecs. This method
+            implements ``buildtest buildspec find --maintainers-by-buildspecs``
         """
 
         table = {"maintainers": [], "buildspec": []}
@@ -513,8 +524,9 @@ class BuildspecCache:
 
     @staticmethod
     def print_filter_fields():
-        """This method prints filter fields available for buildspec cache. This
-        method implements command ``buildtest buildspec find --helpfilter``"""
+        """ This method prints filter fields available for buildspec cache. This
+            method implements command ``buildtest buildspec find --helpfilter``
+        """
 
         filter_field_table = [
             ["executor", "Filter by executor name", "STRING"],
@@ -532,8 +544,9 @@ class BuildspecCache:
 
     @staticmethod
     def print_format_fields():
-        """This method prints format fields available for buildspec cache. This
-        method implements command ``buildtest buildspec find --helpformat``"""
+        """ This method prints format fields available for buildspec cache. This
+            method implements command ``buildtest buildspec find --helpformat``
+        """
 
         format_fields = [
             ["name", "Format by test name"],
@@ -546,15 +559,13 @@ class BuildspecCache:
 
         print(
             tabulate(
-                format_fields,
-                headers=["Field", "Description"],
-                tablefmt="simple",
+                format_fields, headers=["Field", "Description"], tablefmt="simple",
             )
         )
 
     def print_paths(self):
-        """This method print buildspec paths, this implements command
-        ``buildtest buildspec find --paths``
+        """ This method print buildspec paths, this implements command
+            ``buildtest buildspec find --paths``
         """
 
         for path in self.paths:
@@ -562,17 +573,17 @@ class BuildspecCache:
 
 
 def func_buildspec_find(args):
-    """Entry point for ``buildtest buildspec find``. This method
-    will attempt to read for buildspec cache file (BUILDSPEC_CACHE_FILE)
-    if found and print a list of all buildspecs. Otherwise, it will
-    find and load all buildspecs and validate them using BuildspecParser class.
-    BuildspecParser will raise SystemError or ValidationError if a buildspec
-    is invalid which will be added to list of invalid buildspecs. Finally we
-    print a list of all valid buildspecs and any invalid buildspecs are
-    written to file along with error message.
+    """ Entry point for ``buildtest buildspec find``. This method
+        will attempt to read for buildspec cache file (BUILDSPEC_CACHE_FILE)
+        if found and print a list of all buildspecs. Otherwise, it will
+        find and load all buildspecs and validate them using BuildspecParser class.
+        BuildspecParser will raise SystemError or ValidationError if a buildspec
+        is invalid which will be added to list of invalid buildspecs. Finally we
+        print a list of all valid buildspecs and any invalid buildspecs are
+        written to file along with error message.
 
-    :param args: Input argument from command line passed from argparse
-    :return: A list of valid buildspecs found in all repositories.
+        :param args: Input argument from command line passed from argparse
+        :return: A list of valid buildspecs found in all repositories.
     """
 
     bp_cache = BuildspecCache(


### PR DESCRIPTION
@adityakavalur  This PR should fix issue reported in https://nersc.slack.com/archives/D016ZR5TJ07/p1611940039031100 regarding building by tags and executor when buildspec cache not present.