### PR TITLE
add option --latest and --oldest in 'buildtest report' to retrieve

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 CHANGELOG
 =========
 
+v0.9.3 (TBD)
+-------------
+
+
+- Change Copyright and License to include UC - LBNL - `#611 <https://github.com/buildtesters/buildtest/pull/611>`_
+- Add dependabot for github actions and pypi packages - `#615 <https://github.com/buildtesters/buildtest/pull/615>`_
+- Add option to query buildspecs by maintainers and breakdown by buildspecs using `--maintainers` and `--maintainers-by-buildspecs` see `#599 <https://github.com/buildtesters/buildtest/pull/599>`_
+- Add option to filter tests by tags using `buildtest build --filter-tags`, the behavior of `buildtest build --tags` is used to for discovery of buildspecs `#587 <https://github.com/buildtesters/buildtest/pull/587>`_
+
+
 v0.9.2 (Jan 12th, 2021)
 -----------------------
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-| |license| |docs| |codecov| |slack| |release| |ascent_pipeline_status| |cori_pipeline_status| |installation| |clichecks| |regressiontest| |buildtest_scripts|  |gh_pages_master| |gh_pages_devel| |checkurls| |dailyurlcheck| |codefactor| |blackformat|  |black| |issues| |open_pr| |commit_activity_yearly| |commit_activity_monthly| |core_infrastructure|
+| |license| |docs| |codecov| |slack| |release| |ascent_pipeline_status| |cori_pipeline_status| |installation| |clichecks| |regressiontest| |buildtest_scripts|  |gh_pages_master| |gh_pages_devel| |checkurls| |dailyurlcheck| |codefactor| |blackformat|  |black| |issues| |open_pr| |commit_activity_yearly| |commit_activity_monthly| |core_infrastructure| |zenodo|
 
 .. |docs| image:: https://readthedocs.org/projects/buildtest/badge/?version=latest
     :alt: Documentation Status
@@ -67,6 +67,9 @@
 
 .. |dailyurlcheck| image:: https://github.com/buildtesters/buildtest/workflows/Daily%20Check%20URLs/badge.svg
    :target: https://github.com/buildtesters/buildtest/actions
+
+.. |zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3967143.svg
+   :target: https://doi.org/10.5281/zenodo.3967143
 
 buildtest
 ---------

--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -362,6 +362,16 @@ class BuildTestParser:
             action="store_true",
             help="Report a list of filter fields to be used with --filter option",
         )
+        parser_report.add_argument(
+            "--latest",
+            help="Retrieve latest record of particular test",
+            action="store_true",
+        )
+        parser_report.add_argument(
+            "--oldest",
+            help="Retrieve oldest record of particular test",
+            action="store_true",
+        )
         ##################### buildtest report   ###########################
 
         parser_report.set_defaults(func=func_report)

--- a/tests/menu/test_report.py
+++ b/tests/menu/test_report.py
@@ -17,6 +17,8 @@ def test_report_format():
         helpfilter = False
         format = None
         filter = None
+        oldest = False
+        latest = False
 
     # run 'buildtest report'
     func_report(args)
@@ -26,6 +28,8 @@ def test_report_format():
         helpfilter = False
         format = "name,state,returncode,buildspec"
         filter = None
+        oldest = False
+        latest = False
 
     # run 'buildtest report --format name,state,returncode,buildspec'
     func_report(args)
@@ -35,6 +39,8 @@ def test_report_format():
         helpfilter = False
         format = "badfield,state,returncode"
         filter = None
+        oldest = False
+        latest = False
 
     # specify invalid format field 'badfield'
     with pytest.raises(SystemExit):
@@ -48,6 +54,8 @@ def test_report_helpformat():
         helpfilter = False
         format = None
         filter = None
+        oldest = False
+        latest = False
 
     func_report(args)
 
@@ -59,6 +67,8 @@ def test_report_filter():
         helpfilter = True
         format = None
         filter = None
+        oldest = False
+        latest = False
 
     # run 'buildtest report --helpfilter'
     func_report(args)
@@ -68,6 +78,8 @@ def test_report_filter():
         helpfilter = False
         filter = {"state": "PASS"}
         format = None
+        oldest = False
+        latest = False
 
     # run 'buildtest report --filter state=PASS'
     func_report(args)
@@ -77,6 +89,8 @@ def test_report_filter():
         helpfilter = False
         filter = {"state": "PASS"}
         format = "name,state"
+        oldest = False
+        latest = False
 
     # run 'buildtest report --filter state=PASS --format name,state'
     func_report(args)
@@ -86,6 +100,8 @@ def test_report_filter():
         helpfilter = False
         filter = {"state": "UNKNOWN"}
         format = "name,state"
+        oldest = False
+        latest = False
 
     # run 'buildtest report --filter state=UNKNOWN --format name,state',
     # this raises error because UNKNOWN is not valid value for state field
@@ -97,6 +113,8 @@ def test_report_filter():
         helpfilter = False
         filter = {"returncode": "0", "executor": "local.bash"}
         format = "name,returncode,executor"
+        oldest = False
+        latest = False
 
     # run 'buildtest report --filter returncode=0,executor=local.bash --format name,returncode,executor
     func_report(args)
@@ -110,6 +128,8 @@ def test_report_filter():
             )
         }
         format = "name,returncode,buildspec"
+        oldest = False
+        latest = False
 
     # run 'buildtest report --filter buildspec=tutorials/pass_returncode.yml --format name,returncode,buildspec
     func_report(args)
@@ -119,6 +139,8 @@ def test_report_filter():
         helpfilter = False
         filter = {"name": "exit1_pass"}
         format = "name,returncode,state"
+        oldest = False
+        latest = False
 
     # run 'buildtest report --filter name=exit1_pass --format name,returncode,state
     func_report(args)
@@ -130,6 +152,8 @@ def test_report_filter():
             "buildspec": "".join(random.choice(string.ascii_letters) for i in range(10))
         }
         format = "name,returncode,state"
+        oldest = False
+        latest = False
 
     # the filter argument buildspec is a random string which will be invalid file
     # and we expect an exception to be raised
@@ -141,6 +165,8 @@ def test_report_filter():
         helpfilter = False
         filter = {"buildspec": "$HOME/.bashrc"}
         format = "name,returncode,state"
+        oldest = False
+        latest = False
 
     # run 'buildtest report --filter buildspec=$HOME/.bashrc --format name,returncode,state
     # this will raise error even though file is valid it won't be found in cache
@@ -157,6 +183,8 @@ def test_report_filter():
             "returncode": 0,
         }
         format = "name,returncode,state,executor,tags"
+        oldest = False
+        latest = False
 
     # run 'buildtest report --filter tags=tutorials,executor=local.bash,state=PASS,returncode=0 --format name,returncode,state,executor,tags
     func_report(args)
@@ -177,6 +205,8 @@ def test_func_report_when_BUILD_REPORT_missing():
         helpfilter = False
         filter = None
         format = None
+        oldest = False
+        latest = False
 
     with pytest.raises(SystemExit):
         func_report(args)


### PR DESCRIPTION
oldest and latest record. One can specify either option or both. This
will work across with filter option.
If both options are specified we will report oldest and latest record.
Update CHANGELOG and add zenodo badge