### PR TITLE
add singularity container tests for building, pulling, running and inspect containers.

### DIFF
--- a/general_tests/containers/singularity/build.yml
+++ b/general_tests/containers/singularity/build.yml
@@ -1,0 +1,29 @@
+version: "1.0"
+buildspecs:
+  build_sif_from_dockerimage:
+    type: script
+    executor: local.bash
+    description: build sif image from docker image docker://godlovedc/lolcow
+    tags: [containers, singularity]
+    run: |
+      singularity build mylolcow_latest.sif docker://godlovedc/lolcow
+      singularity inspect mylolcow_latest.sif
+
+  build_sandbox_image:
+    type: script
+    executor: local.bash
+    description: build sandbox image from docker image docker://godlovedc/lolcow
+    tags: [containers, singularity]
+    run: singularity build --sandbox mylolcow_latest_sandbox docker://godlovedc/lolcow
+ 
+  build_remoteimages:
+    type: script
+    executor: local.bash
+    description: build remote hosted image from AWS
+    tags: [containers, singularity]
+    vars:
+      IMAGE: alpine_oci_archive.sif
+    run: |
+      singularity pull  https://s3.amazonaws.com/singularity-ci-public/alpine-oci-archive.tar
+      singularity build $IMAGE oci-archive://alpine-oci-archive.tar
+      singularity exec $IMAGE cat /etc/os-release

--- a/general_tests/containers/singularity/inspect.yml
+++ b/general_tests/containers/singularity/inspect.yml
@@ -1,0 +1,19 @@
+version: "1.0"
+buildspecs:
+  inspect_image:
+    type: script
+    executor: local.bash
+    description: Inspect image via 'singularity inspect'
+    tags: [containers, singularity]
+    vars:
+      IMAGE: alpine.sif
+    run: |
+      singularity pull $IMAGE library://alpine:latest 
+      singularity inspect --all $IMAGE
+      singularity inspect -d $IMAGE
+      singularity inspect -e $IMAGE
+      singularity inspect -j $IMAGE
+      singularity inspect -l $IMAGE
+      singularity inspect -r $IMAGE
+      singularity inspect -s $IMAGE
+      singularity inspect -t $IMAGE

--- a/general_tests/containers/singularity/pull.yml
+++ b/general_tests/containers/singularity/pull.yml
@@ -1,0 +1,34 @@
+version: "1.0"
+buildspecs:
+  pullImage_dockerhub:
+    type: script
+    executor: local.bash
+    description: Pull image docker://godlovedc/lolcow from DockerHub
+    tags: [containers, singularity]
+    vars:
+      IMAGE: lolcow_latest.sif
+    run: |
+      singularity pull $IMAGE docker://godlovedc/lolcow 
+      singularity inspect $IMAGE
+
+  pullImage_sylabscloud:
+    type: script
+    executor: local.bash
+    description: Pull image library://alpine:latest from Sylabs Cloud
+    tags: [containers, singularity]
+    vars:
+      IMAGE: alpine.sif
+    run: |
+      singularity pull $IMAGE library://alpine:latest
+      singularity inspect $IMAGE
+
+  pullImage_shub:
+    type: script
+    executor: local.bash
+    description: Pull image shub://vsoch/singularity-images from SingularityHub    
+    tags: [containers, singularity]
+    vars: 
+      IMAGE: singularity-images.sif
+    run: |
+      singularity pull $IMAGE shub://vsoch/singularity-images    
+      singularity inspect $IMAGE

--- a/general_tests/containers/singularity/run.yml
+++ b/general_tests/containers/singularity/run.yml
@@ -1,0 +1,13 @@
+version: "1.0"
+buildspecs:
+  runImage:
+    type: script
+    executor: local.bash
+    description: run container docker://godlovedc/lolcow
+    tags: [containers, singularity]
+    run: |
+      singularity run docker://godlovedc/lolcow
+      singularity exec docker://godlovedc/lolcow fortune
+
+
+  


### PR DESCRIPTION
Running singularity tests with version 3.6.0

```
$ singularity --version
singularity version 3.6.4-1

$ buildtest build -b general_tests/containers/

+-------------------------------+
| Stage: Discovering Buildspecs |
+-------------------------------+ 
    

Discovered Buildspecs:
 
/gpfs/mira-home/shahzebsiddiqui/buildtest/general_tests/containers/singularity/run.yml
/gpfs/mira-home/shahzebsiddiqui/buildtest/general_tests/containers/singularity/pull.yml
/gpfs/mira-home/shahzebsiddiqui/buildtest/general_tests/containers/singularity/build.yml
/gpfs/mira-home/shahzebsiddiqui/buildtest/general_tests/containers/singularity/inspect.yml

+---------------------------+
| Stage: Parsing Buildspecs |
+---------------------------+ 
    
 schemafile              | validstate   | buildspec
-------------------------+--------------+--------------------------------------------------------------------------------------------
 script-v1.0.schema.json | True         | /gpfs/mira-home/shahzebsiddiqui/buildtest/general_tests/containers/singularity/run.yml
 script-v1.0.schema.json | True         | /gpfs/mira-home/shahzebsiddiqui/buildtest/general_tests/containers/singularity/pull.yml
 script-v1.0.schema.json | True         | /gpfs/mira-home/shahzebsiddiqui/buildtest/general_tests/containers/singularity/build.yml
 script-v1.0.schema.json | True         | /gpfs/mira-home/shahzebsiddiqui/buildtest/general_tests/containers/singularity/inspect.yml

+----------------------+
| Stage: Building Test |
+----------------------+ 

 name                       | id       | type   | executor   | tags                          | testpath
----------------------------+----------+--------+------------+-------------------------------+---------------------------------------------------------------------------------------------------------------------
 runImage                   | 8d5ef77a | script | local.bash | ['containers', 'singularity'] | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/run/runImage/0/stage/generate.sh
 pullImage_dockerhub        | e9aac5fe | script | local.bash | ['containers', 'singularity'] | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/pull/pullImage_dockerhub/0/stage/generate.sh
 pullImage_sylabscloud      | cedc7a0d | script | local.bash | ['containers', 'singularity'] | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/pull/pullImage_sylabscloud/0/stage/generate.sh
 pullImage_shub             | 8a81fd6c | script | local.bash | ['containers', 'singularity'] | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/pull/pullImage_shub/0/stage/generate.sh
 build_sif_from_dockerimage | 6751198c | script | local.bash | ['containers', 'singularity'] | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/build/build_sif_from_dockerimage/0/stage/generate.sh
 build_sandbox_image        | 72ddf614 | script | local.bash | ['containers', 'singularity'] | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/build/build_sandbox_image/0/stage/generate.sh
 build_remoteimages         | a3493c51 | script | local.bash | ['containers', 'singularity'] | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/build/build_remoteimages/0/stage/generate.sh
 inspect_image              | 1d18b6c0 | script | local.bash | ['containers', 'singularity'] | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/inspect/inspect_image/0/stage/generate.sh



+----------------------+
| Stage: Running Test  |
+----------------------+ 
    
 name                       | id       | executor   | status   |   returncode | testpath
----------------------------+----------+------------+----------+--------------+---------------------------------------------------------------------------------------------------------------------
 runImage                   | 8d5ef77a | local.bash | PASS     |            0 | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/run/runImage/0/stage/generate.sh
 pullImage_dockerhub        | e9aac5fe | local.bash | PASS     |            0 | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/pull/pullImage_dockerhub/0/stage/generate.sh
 pullImage_sylabscloud      | cedc7a0d | local.bash | PASS     |            0 | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/pull/pullImage_sylabscloud/0/stage/generate.sh
 pullImage_shub             | 8a81fd6c | local.bash | PASS     |            0 | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/pull/pullImage_shub/0/stage/generate.sh
 build_sif_from_dockerimage | 6751198c | local.bash | PASS     |            0 | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/build/build_sif_from_dockerimage/0/stage/generate.sh
 build_sandbox_image        | 72ddf614 | local.bash | PASS     |            0 | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/build/build_sandbox_image/0/stage/generate.sh
 build_remoteimages         | a3493c51 | local.bash | PASS     |            0 | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/build/build_remoteimages/0/stage/generate.sh
 inspect_image              | 1d18b6c0 | local.bash | PASS     |            0 | /gpfs/mira-home/shahzebsiddiqui/buildtest/var/tests/local.bash/inspect/inspect_image/0/stage/generate.sh

+----------------------+
| Stage: Test Summary  |
+----------------------+ 

Executed 8 tests
Passed Tests: 8/8 Percentage: 100.000%
Failed Tests: 0/8 Percentage: 0.000%



Writing Logfile to: /tmp/buildtest/buildtest_lj6qkr24.log
```

List of singularity tests 
```
$ buildtest buildspec find --filter tags=singularity
+----------------------------+--------+------------+-------------------------------+-----------------------------------------------------------------+
| name                       | type   | executor   | tags                          | description                                                     |
+============================+========+============+===============================+=================================================================+
| build_sif_from_dockerimage | script | local.bash | ['containers', 'singularity'] | build sif image from docker image docker://godlovedc/lolcow     |
+----------------------------+--------+------------+-------------------------------+-----------------------------------------------------------------+
| build_sandbox_image        | script | local.bash | ['containers', 'singularity'] | build sandbox image from docker image docker://godlovedc/lolcow |
+----------------------------+--------+------------+-------------------------------+-----------------------------------------------------------------+
| build_remoteimages         | script | local.bash | ['containers', 'singularity'] | build remote hosted image from AWS                              |
+----------------------------+--------+------------+-------------------------------+-----------------------------------------------------------------+
| inspect_image              | script | local.bash | ['containers', 'singularity'] | Inspect image via 'singularity inspect'                         |
+----------------------------+--------+------------+-------------------------------+-----------------------------------------------------------------+
| pullImage_dockerhub        | script | local.bash | ['containers', 'singularity'] | Pull image docker://godlovedc/lolcow from DockerHub             |
+----------------------------+--------+------------+-------------------------------+-----------------------------------------------------------------+
| pullImage_sylabscloud      | script | local.bash | ['containers', 'singularity'] | Pull image library://alpine:latest from Sylabs Cloud            |
+----------------------------+--------+------------+-------------------------------+-----------------------------------------------------------------+
| pullImage_shub             | script | local.bash | ['containers', 'singularity'] | Pull image shub://vsoch/singularity-images from SingularityHub  |
+----------------------------+--------+------------+-------------------------------+-----------------------------------------------------------------+
| runImage                   | script | local.bash | ['containers', 'singularity'] | run container docker://godlovedc/lolcow                         |
+----------------------------+--------+------------+-------------------------------+-----------------------------------------------------------------+
```

Test Report
```
$ buildtest report --filter tags=singularity --format name,id,tags,state,returncode,starttime,endtime,runtime
+----------------------------+----------+------------------------+---------+--------------+---------------------+---------------------+-----------+
| name                       | id       | tags                   | state   |   returncode | starttime           | endtime             |   runtime |
+============================+==========+========================+=========+==============+=====================+=====================+===========+
| runImage                   | 8d5ef77a | containers singularity | PASS    |            0 | 2021/02/16 17:30:59 | 2021/02/16 17:31:02 |  2.75807  |
+----------------------------+----------+------------------------+---------+--------------+---------------------+---------------------+-----------+
| pullImage_dockerhub        | e9aac5fe | containers singularity | PASS    |            0 | 2021/02/16 17:31:02 | 2021/02/16 17:31:03 |  1.19935  |
+----------------------------+----------+------------------------+---------+--------------+---------------------+---------------------+-----------+
| pullImage_sylabscloud      | cedc7a0d | containers singularity | PASS    |            0 | 2021/02/16 17:31:03 | 2021/02/16 17:31:04 |  0.810403 |
+----------------------------+----------+------------------------+---------+--------------+---------------------+---------------------+-----------+
| pullImage_shub             | 8a81fd6c | containers singularity | PASS    |            0 | 2021/02/16 17:31:04 | 2021/02/16 17:31:07 |  2.53426  |
+----------------------------+----------+------------------------+---------+--------------+---------------------+---------------------+-----------+
| build_sif_from_dockerimage | 6751198c | containers singularity | PASS    |            0 | 2021/02/16 17:31:07 | 2021/02/16 17:31:13 |  6.29205  |
+----------------------------+----------+------------------------+---------+--------------+---------------------+---------------------+-----------+
| build_sandbox_image        | 72ddf614 | containers singularity | PASS    |            0 | 2021/02/16 17:31:13 | 2021/02/16 17:31:33 | 20.6361   |
+----------------------------+----------+------------------------+---------+--------------+---------------------+---------------------+-----------+
| build_remoteimages         | a3493c51 | containers singularity | PASS    |            0 | 2021/02/16 17:31:33 | 2021/02/16 17:31:35 |  1.27199  |
+----------------------------+----------+------------------------+---------+--------------+---------------------+---------------------+-----------+
| inspect_image              | 1d18b6c0 | containers singularity | PASS    |            0 | 2021/02/16 17:31:35 | 2021/02/16 17:31:38 |  3.43551  |
+----------------------------+----------+------------------------+---------+--------------+---------------------+---------------------+-----------+
```
