### PR TITLE
BUILDTEST_ROOT environment is declared upon sourcing setup script.

### DIFF
--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -70,6 +70,12 @@ def main():
     else:
         print(f"Writing Logfile to: {dest_logfile}")
 
+    # store copy of logfile at $BUILDTEST_ROOT/buildtest.log. A convenient location for user to
+    # find logfile for last build, this will be overwritten for every subsequent build.
+    shutil.copy2(
+        dest_logfile, os.path.join(os.getenv("BUILDTEST_ROOT"), "buildtest.log")
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/setup.sh
+++ b/setup.sh
@@ -36,10 +36,12 @@ echo "Installing buildtest dependencies"
 $pip install -r ${buildtest_root}/requirements.txt &> /dev/null
 
 bin=${buildtest_root}/bin
+export BUILDTEST_ROOT=$buildtest_root
 export PATH=${bin}:$PATH
 # add PYTHONPATH for buildtest to persist in shell environment
 export PYTHONPATH=${buildtest_root}:$PYTHONPATH
 
+echo "BUILDTEST_ROOT: $BUILDTEST_ROOT"
 buildtest_path=$(which buildtest)
 echo "buildtest command: ${buildtest_path}"
 


### PR DESCRIPTION
Fix logic in csh setup to properly detect root of buildtest for Linux and Mac.
We make buildtest write logfile in $BUILDTEST_ROOT/buildtest.log in addition
to its temporary directory location. This is a convenient location for user
to find last logfile they can just "cat $BUILDTEST/buildtest.log" to see
last logfile as pose to remembering the logpath