### PR TITLE
set LANG to utf8 encoding because tabulate can't print tables

### DIFF
--- a/setup.csh
+++ b/setup.csh
@@ -57,6 +57,9 @@ if (! $?BUILDTEST_ROOT) then
 endif
 
 
+# error printing tables from tabulate when utf8 encoding not set. See https://github.com/buildtesters/buildtest/issues/665
+setenv LANG en_US.utf8
+
 set pip=pip
 
 if ( ! -x `command -v $pip` ) then 

--- a/setup.sh
+++ b/setup.sh
@@ -32,6 +32,9 @@ if ! [ -x "$(command -v $pip)" ]; then
   exit 1
 fi
 
+# error printing tables from tabulate when utf8 encoding not set. See https://github.com/buildtesters/buildtest/issues/665
+export LANG=en_US.utf8
+
 echo "Installing buildtest dependencies"
 $pip install -r ${buildtest_root}/requirements.txt &> /dev/null
 


### PR DESCRIPTION
properly on system that don't have this set. See https://github.com/buildtesters/buildtest/issues/665