### PR TITLE
apply re.match to match hostnames when detecting system

### DIFF
--- a/buildtest/schemas/examples/settings.schema.json/valid/cobalt-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/cobalt-example.yml
@@ -1,6 +1,6 @@
 system:
   generic:
-    hostnames: ['localhost']
+    hostnames: ['.*']
 
     moduletool: lmod
     load_default_buildspecs: True

--- a/buildtest/schemas/examples/settings.schema.json/valid/combined_executor.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/combined_executor.yml
@@ -1,6 +1,6 @@
 system:
   generic:
-    hostnames: ['localhost']
+    hostnames: ['.*']
 
     moduletool: N/A
     load_default_buildspecs: True

--- a/buildtest/schemas/examples/settings.schema.json/valid/local-executor.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/local-executor.yml
@@ -1,6 +1,6 @@
 system:
   generic:
-    hostnames: ['localhost']
+    hostnames: ['.*']
 
     logdir: $BUILDTEST_ROOT/logs
     testdir: $BUILDTEST_ROOT/tests

--- a/buildtest/schemas/examples/settings.schema.json/valid/lsf-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/lsf-example.yml
@@ -1,6 +1,6 @@
 system:
   generic:
-    hostnames: ['localhost']
+    hostnames: ['.*']
 
     moduletool: lmod
     load_default_buildspecs: False

--- a/buildtest/schemas/examples/settings.schema.json/valid/slurm-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/slurm-example.yml
@@ -1,6 +1,6 @@
 system:
   generic:
-    hostnames: ['localhost']
+    hostnames: ['.*']
 
     moduletool: lmod
     load_default_buildspecs: True

--- a/buildtest/settings/config.yml
+++ b/buildtest/settings/config.yml
@@ -1,6 +1,6 @@
 system:
   generic:
-    hostnames: ["localhost"]
+    hostnames: [".*"]
     # specify module system used at your site (environment-modules, lmod)
     moduletool: N/A
 

--- a/docs/configuring_buildtest/overview.rst
+++ b/docs/configuring_buildtest/overview.rst
@@ -43,14 +43,46 @@ cluster called ``generic`` which is a dummy cluster used for running tutorial ex
 
     "required": ["executors", "moduletool", "load_default_buildspecs","hostnames", "compilers"]
 
-The ``hostnames`` is a list of nodes that belong to the cluster where buildtest should be run. Generally,
-these hosts should be your login nodes in your cluster. The ``hostnames`` is a host entries for instance if you
-want to configure buildtest to run from nodes ``login1``, ``login2``, ``login3`` you can do the following::
+The ``hostnames`` field is a list of nodes that belong to the cluster where buildtest should be run. Generally,
+these hosts should be your login nodes in your cluster. buildtest will process **hostnames** field across
+all system entry using `re.match <https://docs.python.org/3/library/re.html#re.match>`_ until a hostname is found, if
+none is found we report an error.
 
-    hostnames: ["login1", "login2", "login3"]
 
-We have two keywords ``localhost`` and ``*`` used to match your current system regardless of name. buildtest will
-process each system record and review the **hostnames** property to determine the correct system until one is found.
+In this example we defined two systems `machine`, `machine2` with the following hostnames.
+
+.. code-block:: yaml
+
+    system:
+      machine1:
+        hostnames:  ['loca$', '^1DOE']
+      machine2:
+        hostnames: ['BOB|JOHN']
+
+In this example, none of the host entries match with hostname `DOE-7086392.local` so we get an error
+since buildtest needs to detect a system before proceeding.
+
+.. code-block:: shell
+
+      buildtest.exceptions.BuildTestError: "Based on current system hostname: DOE-7086392.local we cannot find a matching system  ['machine1', 'machine2'] based on current hostnames: {'machine1': ['loca$', '^1DOE'], 'machine2': ['BOB|JOHN']} "
+
+
+Let's assume you we have a system named ``mycluster`` that should  run on nodes ``login1``, ``login2``, and ``login3``.
+You can specify hostnames as follows.
+
+.. code-block:: yaml
+
+    system:
+      mycluster:
+        hostnames: ["login1", "login2", "login3"]
+
+Alternately, you can use regular expression to condense this list
+
+.. code-block:: yaml
+
+    system:
+      mycluster:
+        hostnames: ["login[1-3]"]
 
 If your system supports module-system (`environment-modules <https://modules.readthedocs.io/en/latest/>`_ or `Lmod <Mhttps://lmod.readthedocs.io/en/latest/index.html>`_) you
 will need to define the ``moduletool`` property. For more details see :ref:`configuring module tool <module_configuration>`. The

--- a/tests/settings/ascent.yml
+++ b/tests/settings/ascent.yml
@@ -1,24 +1,27 @@
-moduletool: lmod
-load_default_buildspecs: false
-executors:
-  defaults:
-    launcher: bsub
-    pollinterval: 30
-    max_pend_time: 60
-    account: gen014ecpci
-  local:
-    bash:
-      description: submit jobs on local machine using bash shell
-      shell: bash
-    sh:
-      description: submit jobs on local machine using sh shell
-      shell: sh
-    csh:
-      description: submit jobs on local machine using csh shell
-      shell: csh
-    python:
-      description: submit jobs on local machine using python shell
-      shell: python
-  lsf:
-    batch:
-      queue: batch
+system:
+  ascent:
+    hostnames: [login1.ascent.olcf.ornl.gov]
+    moduletool: lmod
+    load_default_buildspecs: false
+    executors:
+      defaults:
+        launcher: bsub
+        pollinterval: 30
+        max_pend_time: 60
+        account: gen014ecpci
+      local:
+        bash:
+          description: submit jobs on local machine using bash shell
+          shell: bash
+        sh:
+          description: submit jobs on local machine using sh shell
+          shell: sh
+        csh:
+          description: submit jobs on local machine using csh shell
+          shell: csh
+        python:
+          description: submit jobs on local machine using python shell
+          shell: python
+      lsf:
+        batch:
+          queue: batch

--- a/tests/settings/ascent.yml
+++ b/tests/settings/ascent.yml
@@ -25,3 +25,12 @@ system:
       lsf:
         batch:
           queue: batch
+
+    compilers:
+      compiler:
+        gcc:
+          builtin_gcc:
+            cc: /usr/bin/gcc
+            cxx: /usr/bin/g++
+            fc: /usr/bin/gfortran
+

--- a/tests/settings/cori.config.yml
+++ b/tests/settings/cori.config.yml
@@ -1,6 +1,6 @@
 system:
   cori:
-    hostnames: [cori01, cori02, cori03, cori04, cori05, cori06, cori07, cori08, cori09, cori10, cori11, cori12]
+    hostnames: ["cori*"]
     moduletool: environment-modules
     load_default_buildspecs: false
     compilers:


### PR DESCRIPTION
for more flexibility when specifying hostnames. Each entry in hostnames
field is a pattern search with current hostname.
Fix bug where we didn't search all system entries before raising exception.
Update documentation on hostnames and example configuration, default configuration, and
ascent and cori configuration