### PR TITLE
increase test coverage for BatchScript, CompilerBuilder class and update documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-| |docs| |codecov| |slack| |release| |ascent_pipeline_status| |cori_pipeline_status| |installation| |regressiontest| |gh_pages_master| |gh_pages_devel| |checkurls| |dailyurlcheck| |codefactor| |blackformat|  |black| |issues| |open_pr| |commit_activity_yearly| |commit_activity_monthly| |core_infrastructure| |zenodo|
+| |license| |docs| |codecov| |slack| |release| |ascent_pipeline_status| |cori_pipeline_status| |installation| |regressiontest| |gh_pages_master| |gh_pages_devel| |checkurls| |dailyurlcheck| |codefactor| |blackformat|  |black| |issues| |open_pr| |commit_activity_yearly| |commit_activity_monthly| |core_infrastructure| |zenodo|
 
 .. |docs| image:: https://readthedocs.org/projects/buildtest/badge/?version=latest
     :alt: Documentation Status
@@ -7,6 +7,8 @@
 
 .. |slack| image:: http://hpcbuildtest.herokuapp.com/badge.svg
     :target: http://hpcbuildtest.slack.com
+
+.. |license| image:: https://img.shields.io/github/license/buildtesters/buildtest.svg
 
 .. |ascent_pipeline_status| image::  https://code.ornl.gov/ecpcitest/buildtest/badges/devel/pipeline.svg
    :target: https://code.ornl.gov/ecpcitest/buildtest/-/commits/devel

--- a/docs/buildspecs/batch_support.rst
+++ b/docs/buildspecs/batch_support.rst
@@ -607,7 +607,7 @@ it won't be present in the report (``buildtest report``). In this example, we on
 had one test so upon job cancellation we found there was no tests to report hence,
 buildtest will terminate after run stage.
 
-.. code-block::
+.. code-block:: console
     :emphasize-lines: 85-86
     :linenos:
 

--- a/docs/buildspecs/buildspec_overview.rst
+++ b/docs/buildspecs/buildspec_overview.rst
@@ -8,7 +8,9 @@ A buildspec can be composed of several test sections. The buildspec file is
 validated with the :ref:`global_schema` and each test section is validated with
 a sub-schema defined by the ``type`` field.
 
-Let's start off with a simple example declaring variables::
+Let's start off with a simple example declaring variables:
+
+.. code-block:: yaml
 
     version: "1.0"
     buildspecs:
@@ -35,9 +37,11 @@ with a schema ``script-v1.0.schema.json``. In future, we can support multiple ve
 of subschema for backwards compatibility.
 
 
-Shown below is schema definition for script-v1.0.schema.json ::
+Shown below is schema header for script-v1.0.schema.json.
 
-    {
+.. code-block:: json
+
+
       "$id": "script-v1.0.schema.json",
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "script schema version 1.0",
@@ -45,8 +49,7 @@ Shown below is schema definition for script-v1.0.schema.json ::
       "type": "object",
       "required": ["type", "run", "executor"],
       "additionalProperties": false,
-      ...
-    }
+
 
 The ``"type": "object"`` means sub-schema is a JSON `object <http://json-schema.org/understanding-json-schema/reference/object.html>`_
 where we define a list of key/value pair. The sub-schemas are of type ``object``
@@ -66,7 +69,9 @@ the test script.
 
 Let's look at a more interesting example, shown below is a multi line run
 example using the `script` schema with test name called
-**systemd_default_target**, shown below is the content of test::
+**systemd_default_target**, shown below is the content of test:
+
+.. code-block:: yaml
 
     version: "1.0"
     buildspecs:
@@ -87,7 +92,9 @@ The test name **systemd_default_target** defined in **buildspec** section is
 validated with the following pattern ``"^[A-Za-z_][A-Za-z0-9_]*$"``. This test
 will use the executor **generic.local.bash** which means it will use the Local Executor
 with an executor name `bash` defined in the buildtest settings. The default
-buildtest settings will provide a bash executor as follows::
+buildtest settings will provide a bash executor as follows:
+
+.. code-block:: yaml
 
     system:
       generic:
@@ -112,8 +119,6 @@ buildtest will mark test state. By default, a returncode of **0** is **PASS** an
 non-zero is a **FAIL**. Currently buildtest reports only two states: ``PASS``, ``FAIL``.
 In this example, buildtest will match the actual returncode with one defined
 in key ``returncode`` in the status section.
-
-
 
 .. _script_schema:
 
@@ -151,6 +156,8 @@ with list of expected returncodes specified by `returncode` field.
 
 Shown below are examples of invalid returncodes::
 
+.. code-block:: yaml
+
   # empty list is not allowed
   returncode: []
 
@@ -180,7 +187,9 @@ this test, we define a duplicate tag **network** which is not allowed.
 
 .. program-output:: cat ../tutorials/invalid_tags.yml
 
-If we run this test and inspect the logs we will see an error message in schema validation::
+If we run this test and inspect the logs we will see an error message in schema validation:
+
+.. code-block:: console
 
     2020-09-29 10:56:43,175 [parser.py:179 - _validate() ] - [INFO] Validating test - 'duplicate_string_tags' with schemafile: script-v1.0.schema.json
     2020-09-29 10:56:43,175 [buildspec.py:397 - parse_buildspecs() ] - [ERROR] ['network', 'network'] is not valid under any of the given schemas
@@ -206,7 +215,9 @@ variable with default shell (bash), csh, and tcsh
 .. program-output:: cat tutorials/environment.yml
 
 Environment variables are defined using ``export`` in bash, sh, zsh while csh and
-tcsh use ``setenv``. Shown below is a generated test script for csh test::
+tcsh use ``setenv``. Shown below is a generated test script for csh test:
+
+.. code-block:: shell
 
     #!/bin/csh
     source /Users/siddiq90/Documents/buildtest/var/executors/generic.local.csh/before_script.sh
@@ -244,7 +255,9 @@ Next we build this test by running ``buildtest build -b tutorials/vars.yml``.
 
 .. program-output:: cat docgen/schemas/vars.txt
 
-If we inspect the output file we see the following result::
+If we inspect the output file we see the following result:
+
+.. code-block:: shell
 
     1+2= 3
     this is a literal string ':'
@@ -253,9 +266,11 @@ If we inspect the output file we see the following result::
     siddiq90
     /Users/siddiq90/.anyconnect /Users/siddiq90/.DS_Store /Users/siddiq90/.serverauth.555 /Users/siddiq90/.CFUserTextEncoding /Users/siddiq90/.wget-hsts /Users/siddiq90/.bashrc /Users/siddiq90/.zshrc /Users/siddiq90/.coverage /Users/siddiq90/.serverauth.87055 /Users/siddiq90/.zsh_history /Users/siddiq90/.lesshst /Users/siddiq90/.git-completion.bash /Users/siddiq90/buildtest.log /Users/siddiq90/darhan.log /Users/siddiq90/ascent.yml /Users/siddiq90/.cshrc /Users/siddiq90/github-tokens /Users/siddiq90/.zcompdump /Users/siddiq90/.serverauth.543 /Users/siddiq90/.bash_profile /Users/siddiq90/.Xauthority /Users/siddiq90/.python_history /Users/siddiq90/.gitconfig /Users/siddiq90/output.txt /Users/siddiq90/.bash_history /Users/siddiq90/.viminfo
 
-Shown below is the generated testscript::
+Shown below is the generated testscript:
 
-   #!/bin/bash
+.. code-block:: shell
+
+    #!/bin/bash
     source /Users/siddiq90/Documents/buildtest/var/executors/generic.local.bash/before_script.sh
     X=1
     Y=2
@@ -279,13 +294,15 @@ Customize Shell
 -----------------
 
 buildtest will default to ``bash`` shell when running test, but we can configure shell
-option using the ``shell`` field. The shell field is defined in schema as follows::
+option using the ``shell`` field. The shell field is defined in schema as follows:
+
+.. code-block:: json
 
     "shell": {
-          "type": "string",
-          "description": "Specify a shell launcher to use when running jobs. This sets the shebang line in your test script. The ``shell`` key can be used with ``run`` section to describe content of script and how its executed",
-          "pattern": "^(/bin/bash|/bin/sh|/bin/csh|/bin/tcsh|/bin/zsh|bash|sh|csh|tcsh|zsh|python).*"
-        },
+      "type": "string",
+      "description": "Specify a shell launcher to use when running jobs. This sets the shebang line in your test script. The ``shell`` key can be used with ``run`` section to describe content of script and how its executed",
+      "pattern": "^(/bin/bash|/bin/sh|/bin/csh|/bin/tcsh|/bin/zsh|bash|sh|csh|tcsh|zsh|python).*"
+    },
 
 The shell pattern is a regular expression where one can specify a shell name along
 with shell options. The shell will configure the `shebang <https://en.wikipedia.org/wiki/Shebang_(Unix)>`_
@@ -295,7 +312,9 @@ field.
 .. program-output:: cat tutorials/shell_examples.yml
 
 The generated test-script for buildspec **_bin_sh_shell** will specify shebang
-**/bin/sh** because we specified ``shell: /bin/sh``::
+**/bin/sh** because we specified ``shell: /bin/sh``:
+
+.. code-block:: shell
 
     #!/bin/sh
     source /Users/siddiq90/Documents/buildtest/var/executors/generic.local.sh/before_script.sh
@@ -306,7 +325,9 @@ If you don't specify a shell path such as ``shell: sh``, then buildtest will res
 path by looking in $PATH and build the shebang line.
 
 In test **shell_options** we specify ``shell: "sh -x"``, buildtest will tack on the
-shell options into the shebang line. The generated test for this script is the following::
+shell options into the shebang line. The generated test for this script is the following:
+
+.. code-block:: shell
 
     #!/bin/sh -x
     source /Users/siddiq90/Documents/buildtest/var/executors/generic.local.sh/before_script.sh
@@ -343,7 +364,9 @@ Now let's run this test as we see the following.
 .. program-output:: cat docgen/getting_started/shebang.txt
 
 If we look at the generated test for **bash_login_shebang** we see the shebang line
-is passed into the script::
+is passed into the script:
+
+.. code-block:: shell
 
     #!/bin/bash -l
     source /Users/siddiq90/Documents/buildtest/var/executors/generic.local.bash/before_script.sh

--- a/docs/buildspecs/buildspec_overview.rst
+++ b/docs/buildspecs/buildspec_overview.rst
@@ -154,21 +154,21 @@ The ``returncode`` field can be an integer or list of integers but it may not ac
 duplicate values. If you specify a list of exit codes, buildtest will check actual returncode
 with list of expected returncodes specified by `returncode` field.
 
-Shown below are examples of invalid returncodes::
+Shown below are examples of invalid returncodes:
 
 .. code-block:: yaml
 
-  # empty list is not allowed
-  returncode: []
+      # empty list is not allowed
+      returncode: []
 
-  # floating point is not accepted in list
-  returncode: [1, 1.5]
+      # floating point is not accepted in list
+      returncode: [1, 1.5]
 
-  # floating point not accepted
-  returncode: 1.5
+      # floating point not accepted
+      returncode: 1.5
 
-  # duplicates are not allowed
-  returncode: [1, 2, 5, 5]
+      # duplicates are not allowed
+      returncode: [1, 2, 5, 5]
 
 
 Classifying tests with tags

--- a/docs/buildspecs/compiler.rst
+++ b/docs/buildspecs/compiler.rst
@@ -12,7 +12,9 @@ Compilation Examples
 ----------------------
 
 We assume the reader has basic understanding of :ref:`global_schema`
-validation. Shown below is the schema definition for compiler schema::
+validation. Shown below is the schema header definition for compiler schema:
+
+.. code-block:: json
 
       "$id": "compiler-v1.0.schema.json",
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -46,7 +48,9 @@ Shown below is an example build for the buildspec example
 
 .. program-output:: cat docgen/schemas/gnu_hello.txt
 
-The generated test for test name **hello_f** is the following::
+The generated test for test name **hello_f** is the following:
+
+.. code-block:: shell
 
     #!/bin/bash
     source /Users/siddiq90/Documents/buildtest/var/executors/generic.local.bash/before_script.sh
@@ -63,7 +67,7 @@ will be discussed later.
 The ``builtin_gcc`` compiler is defined below this can be retrieved by running
 ``buildtest config compilers``. The ``-y`` will display compilers in YAML format.
 
-::
+.. code-block:: console
 
     $ buildtest config compilers -y
     gcc:
@@ -100,7 +104,7 @@ we select all compilers with regular expression ``^(builtin_gcc|gcc)`` that is s
 Currently, we have 3 compilers defined in buildtest settings, shown below is a listing
 of all compilers. We used ``buildtest config compilers find`` to :ref:`detect compilers <detect_compilers>`.
 
-.. code-block::
+.. code-block:: console
 
     $ buildtest config compilers -l
     builtin_gcc
@@ -112,7 +116,9 @@ of all compilers. We used ``buildtest config compilers find`` to :ref:`detect co
 
 
 We expect buildtest to select all three compilers based on our regular expression. In the following
-build, notice we have three tests for ``vecadd_gnu`` one for each compiler::
+build, notice we have three tests for ``vecadd_gnu`` one for each compiler:
+
+.. code-block:: console
 
     $ buildtest build -b tutorials/compilers/vecadd.yml
 
@@ -175,7 +181,7 @@ The ``load`` is a list of modules to load via ``module load``.
 
 Shown below is the compiler configuration.
 
-.. code-block::
+.. code-block:: yaml
     :emphasize-lines: 14-17,22-25
     :linenos:
 
@@ -207,7 +213,7 @@ Shown below is the compiler configuration.
 
 If we take a closer look at the generated test we see the modules are loaded into the test script.
 
-.. code-block::
+.. code-block:: shell
     :emphasize-lines: 4
     :linenos:
 
@@ -220,7 +226,7 @@ If we take a closer look at the generated test we see the modules are loaded int
     source /Users/siddiq90/Documents/buildtest/var/executors/local.bash/after_script.sh
 
 
-.. code-block::
+.. code-block:: shell
     :emphasize-lines: 4
     :linenos:
 
@@ -247,7 +253,7 @@ by excluding ``gcc/10.2.0-37fmsw7`` compiler. This is specified by ``exclude: [g
 Notice when we build this test, buildtest will exclude **gcc/10.2.0-37fmsw7** compiler
 and test is not created during build phase.
 
-.. code-block::
+.. code-block:: console
     :linenos:
     :emphasize-lines: 11
 
@@ -317,7 +323,9 @@ and ``gcc/10.2.0-37fmsw7`` to use ``-O3`` for **cflags** .
 
 .. program-output:: cat ../tutorials/compilers/gnu_hello_c.yml
 
-Next we run this test, and we get three tests for test name **hello_c**::
+Next we run this test, and we get three tests for test name **hello_c**.
+
+.. code-block:: console
 
     $ buildtest build -b tutorials/compilers/gnu_hello_c.yml
 
@@ -375,7 +383,7 @@ Next we run this test, and we get three tests for test name **hello_c**::
 If we inspect the following test, we see the compiler flags are associated with the compiler. The test below
 is for `builtin_gcc` which use the default ``-O1`` compiler flag as shown below.
 
-.. code-block::
+.. code-block:: shell
     :emphasize-lines: 4
     :linenos:
 
@@ -387,7 +395,7 @@ is for `builtin_gcc` which use the default ``-O1`` compiler flag as shown below.
 
 The test for **gcc/10.2.0-37fmsw7** and **gcc/9.3.0-n7p74fd** have cflags ``-O3`` and ``-O2`` set in their respective tests.
 
-.. code-block::
+.. code-block:: shell
     :emphasize-lines: 5
     :linenos:
 
@@ -399,7 +407,7 @@ The test for **gcc/10.2.0-37fmsw7** and **gcc/9.3.0-n7p74fd** have cflags ``-O3`
     ./$_EXEC
     source /Users/siddiq90/Documents/buildtest/var/executors/local.bash/after_script.sh
 
-.. code-block::
+.. code-block:: shell
     :emphasize-lines: 5
     :linenos:
 
@@ -426,7 +434,7 @@ compiler group
 Shown below is one of the generated test. Notice on line 4 buildtest will set OMP_NUM_THREADS
 environment variable.
 
-.. code-block::
+.. code-block:: shell
     :emphasize-lines: 4
     :linenos:
 
@@ -447,7 +455,9 @@ when running program. This will override the default value of 2.
 
 .. program-output:: cat ../tutorials/compilers/envvar_override.yml
 
-Next we build this test as follows::
+Next we build this test as follows:
+
+.. code-block:: console
 
 
     $ buildtest build -b tutorials/compilers/envvar_override.yml
@@ -503,7 +513,7 @@ Next we build this test as follows::
 
 Now let's inspect the test for **gcc/10.2.0-37fmsw7** and notice buildtest is using 4 threads for running OpenMP example
 
-.. code-block::
+.. code-block:: console
     :linenos:
     :emphasize-lines: 34-37, 53
 
@@ -613,7 +623,7 @@ If we build this test, notice that test id **9320ca41** failed which corresponds
 ``gcc/10.2.0-37fmsw7`` compiler test. The test fails because it fails to pass on
 regular expression even though we have a returncode of 0.
 
-.. code-block::
+.. code-block:: console
     :linenos:
     :emphasize-lines: 31,42
 
@@ -680,7 +690,9 @@ next example, we will build an OpenMP reduction test using gcc, intel and cray c
 test, we use ``name`` field to select compilers that start with **gcc**, **intel** and **PrgEnv-cray**
 as compiler names. The ``default`` section is organized by compiler groups which inherits compiler flags
 for all compilers. OpenMP flag for gcc, intel and cray differ for instance one must use ``-fopenmp`` for gcc,
-``--qopenmp`` for intel and ``-h omp`` for cray. ::
+``--qopenmp`` for intel and ``-h omp`` for cray.
+
+.. code-block:: yaml
 
     version: "1.0"
     buildspecs:
@@ -705,7 +717,9 @@ for all compilers. OpenMP flag for gcc, intel and cray differ for instance one m
 
 In this example `OMP_NUM_THREADS` environment variable under the ``all`` section which
 will be used for all compiler groups. This example was built on Cori, we expect this
-test to run against every gcc, intel and PrgEnv-cray compiler module::
+test to run against every gcc, intel and PrgEnv-cray compiler module:
+
+.. code-block:: console
 
     cori$ buildtest build -b reduction.yml
 
@@ -805,7 +819,7 @@ test to run against every gcc, intel and PrgEnv-cray compiler module::
 If we inspect one of these tests from each compiler group we will see OMP_NUM_THREADS
 is set in all tests along with the appropriate compiler flag.
 
-.. code-block::
+.. code-block:: shell
    :linenos:
    :emphasize-lines: 4-6
 
@@ -818,7 +832,7 @@ is set in all tests along with the appropriate compiler flag.
     ./$_EXEC
     source /global/u1/s/siddiq90/buildtest/var/executors/local.bash/after_script.sh
 
-.. code-block::
+.. code-block:: shell
    :linenos:
    :emphasize-lines: 4-6
 
@@ -831,7 +845,7 @@ is set in all tests along with the appropriate compiler flag.
     ./$_EXEC
     source /global/u1/s/siddiq90/buildtest/var/executors/local.bash/after_script.sh
 
-.. code-block::
+.. code-block:: shell
    :linenos:
    :emphasize-lines: 4-6
 
@@ -861,7 +875,7 @@ If we build this test and see generated test, we notice buildtest customized the
 for launching binary. buildtest will directly replace content in ``run`` section into the
 shell-script. If no ``run`` field is specified buildtest will run the binary in standalone mode (``./$_EXEC``).
 
-.. code-block::
+.. code-block:: shell
    :linenos:
    :emphasize-lines: 6
 
@@ -873,7 +887,7 @@ shell-script. If no ``run`` field is specified buildtest will run the binary in 
     ./$_EXEC 100 120
     source /Users/siddiq90/Documents/buildtest/var/executors/local.bash/after_script.sh
 
-.. code-block::
+.. code-block:: shell
    :linenos:
    :emphasize-lines: 6
 
@@ -897,7 +911,9 @@ Currently, buildtest cannot detect if program is serial or MPI to infer appropri
 compiler wrapper. If ``cc`` wasn't specified, buildtest would infer `icc` as compiler
 wrapper for C program. This program is run using ``srun`` job launcher, we can control
 how test is executed using the ``run`` property. This test required we swap intel
-modules and load `impi/2020` module::
+modules and load `impi/2020` module.
+
+.. code-block:: yaml
 
     version: "1.0"
     buildspecs:
@@ -923,7 +939,9 @@ modules and load `impi/2020` module::
                 swap: [intel, intel/19.1.2.254]
 
 The generated test is as follows, note that buildtest will insert ``module load`` before ``module swap``
-command::
+command.
+
+.. code-block:: shell
 
     #!/bin/bash
     #SBATCH -N 1
@@ -941,7 +959,9 @@ command::
 
 
 Shown below is a sample build for this buildspec, buildtest will dispatch  job and poll
-job until its complete::
+job until its complete.
+
+.. code-block:: console
 
     $ buildtest build -b laplace_mpi.yml
 
@@ -1041,7 +1061,9 @@ Shown below is an example buildspec with pre/post section.
 .. program-output:: cat ../tutorials/compilers/pre_post_build_run.yml
 
 
-The format of the test structure is the following::
+The format of the test structure is as follows.
+
+.. code-block:: shell
 
     #!{shebang path} -- defaults to #!/bin/bash depends on executor name (local.bash, local.sh)
     {job directives} -- sbatch or bsub field
@@ -1057,7 +1079,9 @@ The format of the test structure is the following::
     {run executable} -- run field
     {post run commands} -- post_run field
 
-The generated test for this buildspec is the following::
+The generated test for this buildspec is the following:
+
+.. code-block:: shell
 
     #!/bin/bash
     source /Users/siddiq90/Documents/buildtest/var/executors/local.bash/before_script.sh

--- a/docs/buildspecs/global.rst
+++ b/docs/buildspecs/global.rst
@@ -11,7 +11,9 @@ For more details see `Global Schema Documentation <https://buildtesters.github.i
 Global Keys in buildspec
 --------------------------
 
-Shown below is the start of the global.schema.json::
+Shown below is the start of the global.schema.json
+
+.. code-block:: json
 
   "$id": "global.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -31,7 +33,9 @@ Shown below is an example buildspec.
 .. program-output:: cat ../tutorials/hello_world.yml
 
 
-In this example, the global schema validates the following section::
+In this example, the global schema validates the following section:
+
+.. code-block:: yaml
 
     version: "1.0"
     buildspecs:
@@ -43,7 +47,9 @@ In this example, the global schema validates the following section::
 The field ``version`` ``buildspecs`` and ``maintainers`` are validated with **global.schema.json**
 using `jsonschema.validate <https://python-jsonschema.readthedocs.io/en/stable/_modules/jsonschema/validators/#validate>`_
 method. The test section within ``hello_world`` is validated by sub-schema by looking up schema based
-on ``type`` field::
+on ``type`` field:
+
+.. code-block:: yaml
 
     hello_world:
       executor: generic.local.bash
@@ -61,14 +67,17 @@ Test Names
 -----------
 
 The **buildspecs** property is a JSON object that defines one or more test. This
-is defined in JSON as follows::
+is defined in JSON as follows:
+
+.. code-block:: json
 
     "buildspecs": {
-         "type": "object",
-         "description": "This section is used to define one or more tests (buildspecs). Each test must be unique name",
-         "propertyNames": {
-           "pattern": "^[A-Za-z_.][A-Za-z0-9_.]*$",
-           "maxLength": 32
+      "type": "object",
+       "description": "This section is used to define one or more tests (buildspecs). Each test must be unique name",
+       "propertyNames": {
+          "pattern": "^[A-Za-z_.][A-Za-z0-9_.]*$",
+          "maxLength": 32
+       }
     }
 
 The test names take the following pattern ``"^[A-Za-z_.][A-Za-z0-9_.]*$"`` and limited

--- a/docs/configuring_buildtest/command_line_interface.rst
+++ b/docs/configuring_buildtest/command_line_interface.rst
@@ -24,7 +24,9 @@ schema **settings.schema.json**. If validation is successful you will get the fo
 If there is an error during validation, the output from **jsonschema.exceptions.ValidationError**
 will be displayed in terminal. For example the error below indicates that
 ``moduletool`` property was expecting one of the values
-[``environment-modules``, ``lmod``, ``N/A``] but it recieved a value of ``none``::
+[``environment-modules``, ``lmod``, ``N/A``] but it recieved a value of ``none``:
+
+.. code-block:: console
 
     $ buildtest config validate
     Traceback (most recent call last):
@@ -72,7 +74,7 @@ YAML format. If you prefer json format you can use ``--json`` option. Shown belo
 `executors` defined in your buildtest configuration.
 
 .. program-output:: cat docgen/config_executors.txt
-
+   :shell:
 
 Configuration Summary
 ----------------------
@@ -81,7 +83,7 @@ You can get a summary of buildtest using ``buildtest config summary``, this will
 display information from several sources into one single command along.
 
 .. program-output:: cat docgen/config-summary.txt
-
+   :shell:
 
 Example Configurations
 -----------------------
@@ -92,6 +94,7 @@ or short option (``-e``), which will validate each example with schema file
 ``settings.schema.json``.
 
 .. program-output:: cat docgen/schemas/settings-examples.txt
+   :shell:
 
 If you want to retrieve full json schema file for buildtest configuration you can
 run ``buildtest schema -n settings.schema.json --json`` or short option ``-j``.

--- a/docs/configuring_buildtest/compilers.rst
+++ b/docs/configuring_buildtest/compilers.rst
@@ -12,7 +12,9 @@ Compiler Declaration
 ---------------------
 
 
-Shown below is a declaration of ``builtin_gcc`` provided by default::
+Shown below is a declaration of ``builtin_gcc`` provided by default.
+
+.. code-block:: yaml
 
     compilers:
       compiler:

--- a/docs/configuring_buildtest/overview.rst
+++ b/docs/configuring_buildtest/overview.rst
@@ -96,7 +96,9 @@ Configuring Module Tool
 ------------------------
 
 You should configure the ``moduletool`` property to the module-system installed
-at your site. Valid options are the following::
+at your site. Valid options are the following:
+
+.. code-block:: yaml
 
     # environment-modules
     moduletool: environment-modules
@@ -116,7 +118,9 @@ buildspec roots
 buildtest can discover buildspec using ``buildspec_roots`` keyword. This field is a list
 of directory paths to search for buildspecs. For example we clone the repo
 https://github.com/buildtesters/buildtest-cori at **$HOME/buildtest-cori** and assign
-this to **buildspec_roots** as follows::
+this to **buildspec_roots** as follows:
+
+.. code-block:: yaml
 
     buildspec_roots:
       - $HOME/buildtest-cori
@@ -155,29 +159,42 @@ Executor Declaration
 
 The ``executors`` is a JSON `object`, that defines one or more executors. The executors
 are grouped by their type followed by executor name. In this example we define two
-local executors ``bash``, ``sh`` and one slurm executor called ``regular```::
+local executors ``bash``, ``sh`` and one slurm executor called ``regular```:
+
+.. code-block:: yaml
 
   system:
-   generic:
-    executors:
-      local:
-        bash:
-        sh:
-      slurm:
-        regular:
+    generic:
+      executors:
+        local:
+          bash:
+            shell: bash
+            description: bash shell
+          sh:
+            shell: sh
+            description: sh shell
+        slurm:
+          regular:
+            queue: regular
 
 The **LocalExecutors** are defined in section `local` where each executor must be
 unique name. The *LocalExecutors* can be ``bash``, ``sh``, ``csh``, ``tcsh`` and ``python`` shell and they are
-referenced in buildspec using ``executor`` field in the following format::
+referenced in buildspec using ``executor`` field in the following format:
+
+.. code-block:: yaml
 
     executor: <system>.<type>.<name>
 
 For instance, if a buildspec wants to reference the LocalExecutor `bash` from the `generic`
-cluster, you would specify the following in the buildspec::
+cluster, you would specify the following in the buildspec:
+
+.. code-block:: yaml
 
      executor: generic.local.bash
 
-In our example configuration, we defined a local `bash` executor as follows::
+In our example configuration, we defined a local `bash` executor as follows:
+
+.. code-block:: yaml
 
     executors:
       # define local executors for running jobs locally
@@ -191,7 +208,9 @@ The local executors requires the ``shell`` key which takes the pattern
 Any buildspec that references this executor will submit job using ``bash`` shell.
 
 You can pass options to shell which will get passed into each job submission.
-For instance if you want all bash scripts to run in login shell you can specify ``bash --login``::
+For instance if you want all bash scripts to run in login shell you can specify ``bash --login``:
+
+.. code-block:: yaml
 
     executors:
       local:
@@ -225,7 +244,7 @@ example, in example below buildtest will write log files ``$HOME/Documents/build
 buildtest will resolve variable expansion to get real path on filesystem.
 
 
-::
+.. code-block:: yaml
 
     # location of log directory
     logdir: $HOME/Documents/buildtest/var/logs
@@ -255,7 +274,9 @@ one test. For this reason, we support ``before_script`` and ``after_script`` sec
 per executor which is of string type where you can specify multi-line commands.
 
 This can be demonstrated with an executor name **local.e4s** responsible for
-building `E4S Testsuite <https://github.com/E4S-Project/testsuite>`_::
+building `E4S Testsuite <https://github.com/E4S-Project/testsuite>`_
+
+.. code-block:: yaml
 
     local:
       e4s:
@@ -271,7 +292,9 @@ building `E4S Testsuite <https://github.com/E4S-Project/testsuite>`_::
 The `e4s` executor attempts to clone E4S Testsuite in $SCRATCH and activate
 a spack environment and run the initialize script ``source setup.sh``. buildtest
 will write a ``before_script.sh`` and ``after_script.sh`` for every executor.
-This can be found in ``var/executors`` directory as shown below::
+This can be found in ``var/executors`` directory as shown below
+
+.. code-block:: console
 
     $ tree var/executors/
     var/executors/
@@ -309,7 +332,9 @@ Default Executor Settings
 ---------------------------
 
 One can define default executor configurations for all executors using the ``defaults`` property. Shown below is an
-example::
+example
+
+.. code-block:: yaml
 
     executors:
       defaults:
@@ -335,7 +360,9 @@ Max Pend Time
 ---------------
 
 The **max_pend_time** option can be overridden per executor level for example the
-section below overrides the default to 300 seconds::
+section below overrides the default to 300 seconds:
+
+.. code-block:: yaml
 
         bigmem:
           description: bigmem jobs
@@ -361,7 +388,9 @@ Specifying QoS (Slurm)
 At Cori, jobs are submitted via qos instead of partition so we model a slurm executor
 named by qos. The ``qos`` field instructs which Slurm QOS to use when submitting job. For
 example we defined a slurm executor named **haswell_debug** which will submit jobs to **debug**
-qos on the haswell partition as follows::
+qos on the haswell partition as follows:
+
+.. code-block:: yaml
 
     executors:
       slurm:

--- a/docs/configuring_buildtest/site_examples.rst
+++ b/docs/configuring_buildtest/site_examples.rst
@@ -14,41 +14,49 @@ The default launcher is `bsub` which can be defined under ``defaults``. The
 ``pollinterval`` will poll LSF jobs every 10 seconds using ``bjobs``. The
 ``pollinterval`` accepts a range between **10 - 300** seconds as defined in
 schema. In order to avoid polling scheduler excessively pick a number that is best
-suitable for your site::
+suitable for your site
 
-    moduletool: lmod
-    load_default_buildspecs: true
-    executors:
-      defaults:
-        launcher: bsub
-        pollinterval: 10
-        max_pend_time: 45
+.. code-block:: yaml
 
-      local:
-        bash:
-          description: submit jobs on local machine using bash shell
-          shell: bash
-
-        sh:
-          description: submit jobs on local machine using sh shell
-          shell: sh
-
-        csh:
-          description: submit jobs on local machine using csh shell
-          shell: csh
-
-        python:
-          description: submit jobs on local machine using python shell
-          shell: python
-      lsf:
-        batch:
-          queue: batch
-          description: Submit job to batch queue
-
-        test:
-          queue: test
-          description: Submit job to test queue
-
+    system:
+      ascent:
+        moduletool: lmod
+        load_default_buildspecs: false
+        executors:
+          defaults:
+            launcher: bsub
+            pollinterval: 10
+            max_pend_time: 60
+            account: gen014ecpci
+          local:
+            bash:
+              description: submit jobs on local machine using bash shell
+              shell: bash
+            sh:
+              description: submit jobs on local machine using sh shell
+              shell: sh
+            csh:
+              description: submit jobs on local machine using csh shell
+              shell: csh
+            python:
+              description: submit jobs on local machine using python shell
+              shell: python
+          lsf:
+            batch:
+              queue: batch
+            test:
+              queue: test
+        compilers:
+          find:
+            gcc: ^(gcc)
+            pgi: ^(pgi)
+            cuda: ^(cuda)
+          compiler:
+            gcc:
+              builtin_gcc:
+                cc: /usr/bin/gcc
+                cxx: /usr/bin/g++
+                fc: /usr/bin/gfortran
 
 JLSE @ ANL
 -----------
@@ -62,42 +70,38 @@ for all batch executors. In each cobalt executor the ``queue`` property will spe
 the queue name to submit job, for instance the executor ``yarrow`` with ``queue: yarrow``
 will submit job using ``qsub -q yarrow`` when using this executor.
 
-::
+.. code-block:: yaml
 
-    buildspec_roots:
-      - $HOME/jlse_tests
-    executors:
-      defaults:
-         launcher: qsub
-         pollinterval: 10
-         max_pend_time: 10
-
-      local:
-        bash:
-          description: submit jobs on local machine using bash shell
-          shell: bash
-
-        sh:
-          description: submit jobs on local machine using sh shell
-          shell: sh
-
-        csh:
-          description: submit jobs on local machine using csh shell
-          shell: csh
-
-        python:
-          description: submit jobs on local machine using python shell
-          shell: python
-
-      cobalt:
-        yarrow:
-          queue: yarrow
-
-        yarrow_debug:
-          queue: yarrow_debug
-
-        iris:
-          queue: iris
-
-        iris_debug:
-          queue: iris_debug
+    system:
+      jlse:
+        hostnames:
+        - jlselogin*
+        moduletool: environment-modules
+        load_default_buildspecs: false
+        executors:
+          defaults:
+            launcher: qsub
+            pollinterval: 10
+            max_pend_time: 300
+          local:
+            bash:
+              description: submit jobs on local machine using bash shell
+              shell: bash
+            sh:
+              description: submit jobs on local machine using sh shell
+              shell: sh
+            csh:
+              description: submit jobs on local machine using csh shell
+              shell: csh
+            python:
+              description: submit jobs on local machine using python shell
+              shell: python
+          cobalt:
+            yarrow:
+              queue: yarrow
+            yarrow_debug:
+              queue: yarrow_debug
+            iris:
+              queue: iris
+            iris_debug:
+              queue: iris_debug

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,12 +10,14 @@ docs at https://buildtest.readthedocs.io/en/devel/.
 Status
 -----------
 
-| |docs| |codecov| |slack| |regressiontest|
+| |license| |docs| |codecov| |slack| |regressiontest|
 
 .. |docs| image:: https://readthedocs.org/projects/buildtest/badge/?version=latest
     :alt: Documentation Status
     :scale: 100%
     :target: https://buildtest.readthedocs.io/en/latest/?badge=latest
+
+.. |license| image:: https://img.shields.io/github/license/buildtesters/buildtest.svg
 
 .. |slack| image:: http://hpcbuildtest.herokuapp.com/badge.svg
     :target: http://hpcbuildtest.slack.com
@@ -56,7 +58,9 @@ Useful Links
 
 - Snyk: https://app.snyk.io/org/buildtesters/
 
-- Slack Channel: http://hpcbuildtest.slack.com. Click `Here  <https://hpcbuildtest.herokuapp.com/>`_ to Join Slack 
+- Slack Channel: http://hpcbuildtest.slack.com
+
+- Slack Invite: https://hpcbuildtest.herokuapp.com
 
 Description
 ------------

--- a/docs/what_is_buildtest.rst
+++ b/docs/what_is_buildtest.rst
@@ -57,7 +57,9 @@ Preview of buildtest
 ----------------------
 
 buildtest will process YAML files called **buildspecs** (build specification) and
-generate test scripts. There are several ways to discover buildspecs that may include::
+generate test scripts. There are several ways to discover buildspecs that may include:
+
+.. code-block:: console
 
   # process a single file
   $ buildtest build -b /path/to/file.yml
@@ -83,13 +85,17 @@ generate test scripts. There are several ways to discover buildspecs that may in
   # combine all options together
   $ buildtest build -b example.yml -b system --tags network -x system/kernel.yml
 
-buildtest will keep track of all test that can be queried using::
+buildtest will keep track of all test that can be queried using:
+
+.. code-block:: console
 
   # report all tests
   $ buildtest report
 
 Alternately, one can filter and format rows/columns of the report table which
-can be useful when you want to analyze test results. This can be done using::
+can be useful when you want to analyze test results. This can be done using:
+
+.. code-block:: console
 
   $ buildtest report --filter KEY1=VALUE1,KEY2=VALUE2 --format <field1>,<field2>
 
@@ -101,7 +107,9 @@ can be useful when you want to analyze test results. This can be done using::
 
 A single buildspec is composed of one or more tests and buildtest will run all tests
 by default. buildtest will assign a unique id for every test, if you want to inspect
-a particular test you can run the following::
+a particular test you can run the following:
+
+.. code-block:: console
 
   $ buildtest inspect <ID>
 
@@ -110,7 +118,9 @@ one only needs to specify a few characters and buildtest will detect if its a un
 
 buildtest can discover and validate buildspecs with corresponding JSON schema. This
 feature is handy when you want to see all tests in your acceptance test. To see
-all buildspecs you need to use ``buildtest buildspec find``::
+all buildspecs you need to use ``buildtest buildspec find``:
+
+.. code-block:: console
 
     # build your buildspec cache and report all validated buildspecs
     $ buildtest buildspec find
@@ -129,7 +139,9 @@ all buildspecs you need to use ``buildtest buildspec find``::
 
 buildtest has a command line interface to buildtest schemas. We provide a list of
 available schemas, including schema content and schema examples validated for
-each schema. This can be queried as follows::
+each schema. This can be queried as follows:
+
+.. code-block:: console
 
   # show available schemas
   $ buildtest schema

--- a/tests/buildsystem/invalid_builds/invalid_file.yml
+++ b/tests/buildsystem/invalid_builds/invalid_file.yml
@@ -6,7 +6,7 @@ buildspecs:
     description: Can't find source file name
     source: /path/to/invalidfile
     compilers:
-      name: ["gcc"]
+      name: ["^(builtin_gcc)$"]
       default:
         gcc:
           cflags: -O3

--- a/tests/buildsystem/invalid_builds/invalid_lang_ext.yml
+++ b/tests/buildsystem/invalid_builds/invalid_lang_ext.yml
@@ -6,7 +6,7 @@ buildspecs:
     description: Invalid file extension XYZ when detecting compiler language
     source: src/file.XYZ
     compilers:
-      name: ["gcc"]
+      name: ["^(builtin_gcc)$"]
       default:
         gcc:
           cflags: -O3

--- a/tests/buildsystem/test_base.py
+++ b/tests/buildsystem/test_base.py
@@ -38,12 +38,20 @@ def test_BuildspecParser(tmp_path):
             BuildspecParser(buildspecfile, executors)
 
     directory = os.path.join(here, "invalid_builds")
-    # invalid builds
+    # invalid builds for compiler schema tests. These tests will raise BuildTestError exception upon building
+    # even though they are valid buildspecs.
     for buildspec in walk_tree(directory, ".yml"):
         buildspecfile = os.path.join(directory, buildspec)
         print("Processing buildspec", buildspecfile)
+        bp = BuildspecParser(buildspecfile, executors)
+
         with pytest.raises(BuildTestError):
-            BuildspecParser(buildspecfile, executors)
+            builder = Builder(
+                bp=bp, buildexecutor=executors, filters=[], testdir="/tmp"
+            )
+            builders = builder.get_builders()
+            for test in builders:
+                test.build()
 
     # Examples folder
     valid_buildspecs_directory = os.path.join(here, "valid_buildspecs")

--- a/tests/buildsystem/test_base.py
+++ b/tests/buildsystem/test_base.py
@@ -37,6 +37,14 @@ def test_BuildspecParser(tmp_path):
         with pytest.raises(BuildTestError):
             BuildspecParser(buildspecfile, executors)
 
+    directory = os.path.join(here, "invalid_builds")
+    # invalid builds
+    for buildspec in walk_tree(directory, ".yml"):
+        buildspecfile = os.path.join(directory, buildspec)
+        print("Processing buildspec", buildspecfile)
+        with pytest.raises(BuildTestError):
+            BuildspecParser(buildspecfile, executors)
+
     # Examples folder
     valid_buildspecs_directory = os.path.join(here, "valid_buildspecs")
 

--- a/tests/buildsystem/test_batch.py
+++ b/tests/buildsystem/test_batch.py
@@ -1,4 +1,8 @@
-from buildtest.buildsystem.batch import LSFBatchScript, SlurmBatchScript
+from buildtest.buildsystem.batch import (
+    LSFBatchScript,
+    SlurmBatchScript,
+    CobaltBatchScript,
+)
 
 
 def test_batchscript_example1():
@@ -33,6 +37,18 @@ def test_batchscript_example1():
     assert expected_header == header
     print("actual header %s and expected header: %s" % (header, expected_header))
 
+    script = CobaltBatchScript(batch_cmds)
+    header = script.get_headers()
+
+    expected_header = [
+        "#COBALT --project biology",
+        "#COBALT --proccount 1",
+        "#COBALT --queue debug",
+        "#COBALT --time 10",
+    ]
+
+    assert header == expected_header
+
 
 def test_batchscript_example2():
     batch_cmds = {
@@ -56,3 +72,14 @@ def test_batchscript_example2():
     # tasks-per-node is not valid option in LSF so this option is skipped. bsub commands are processed first before batch
     expected_header = ["#BSUB -W 10", "#BSUB -q normal", "#BSUB -n 2"]
     assert expected_header == header
+
+    qsub_cmd = ["--time 10", "--queue debug"]
+    script = CobaltBatchScript(batch_cmds, qsub_cmd)
+    header = script.get_headers()
+    print(header)
+    expected_header = [
+        "#COBALT --time 10",
+        "#COBALT --queue debug",
+        "#COBALT --proccount 2",
+    ]
+    assert header == expected_header

--- a/tests/buildsystem/valid_buildspecs/gnu_hello_c.yml
+++ b/tests/buildsystem/valid_buildspecs/gnu_hello_c.yml
@@ -1,0 +1,16 @@
+version: "1.0"
+buildspecs:
+  hello_c:
+    type: compiler
+    description: "Hello World C Compilation"
+    executor: generic.local.bash
+    tags: [tutorials, compile]
+    source: "$BUILDTEST_ROOT/tutorials/compilers/src/hello.c"
+    compilers:
+      name: ["^(builtin_gcc|gcc)"]
+      default:
+        gcc:
+          cflags: -O1
+      config:
+        builtin_gcc:
+          cflags: -O2

--- a/tests/buildsystem/valid_buildspecs/gnu_hello_fortran.yml
+++ b/tests/buildsystem/valid_buildspecs/gnu_hello_fortran.yml
@@ -1,0 +1,14 @@
+version: "1.0"
+buildspecs:
+  hello_f:
+    type: compiler
+    description: "Hello World Fortran Compilation"
+    executor: generic.local.bash
+    tags: [tutorials, compile]
+    source: "$BUILDTEST_ROOT/tutorials/compilers/src/hello.f90"
+    compilers:
+      name: ["^(builtin_gcc)$"]
+      default:
+        gcc:
+          fflags: -Wall
+          sbatch: ["-N 1", "-t 10", "-q regular"]

--- a/tests/buildsystem/valid_buildspecs/pre_post_build_run.yml
+++ b/tests/buildsystem/valid_buildspecs/pre_post_build_run.yml
@@ -1,0 +1,24 @@
+version: "1.0"
+buildspecs:
+  pre_post_build_run:
+    type: compiler
+    description: example using pre_build, post_build, pre_run, post_run example
+    executor: generic.local.bash
+    tags: [tutorials, compile]
+    source: "$BUILDTEST_ROOT/tutorials/compilers/src/hello.c"
+    compilers:
+      name: ["^(builtin_gcc)$"]
+      default:
+        gcc:
+          cflags: -Wall
+        all:
+          pre_build: |
+            echo "This is a pre-build section"
+            gcc --version
+          post_build: |
+            echo "This is post-build section"
+          pre_run: |
+            echo "This is pre-run section"
+            export FOO=BAR
+          post_run: |
+            echo "This is post-run section"


### PR DESCRIPTION
add example tests for compiler schema in regression test to increase test coverage
update documentation code-block reference to use 'yaml', 'json', 'console', 'shell'
when appropriate.
Add license badge