### PR TITLE
fix bug with buildtest buildspec find where it wasn't able to rebuild buildspec cache using --roots option

### DIFF
--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -94,10 +94,11 @@ def main():
     if args.subcommands == "buildspec":
         buildspec_find(args=args, settings_file=settings_file)
         return
-    else:
-        if args.subcommands and args.func:
-            args.func(args)
-        return
+
+    if args.subcommands and args.func:
+        args.func(args)
+
+
 
 
 if __name__ == "__main__":

--- a/buildtest/menu/buildspec.py
+++ b/buildtest/menu/buildspec.py
@@ -5,7 +5,7 @@ import os
 from tabulate import tabulate
 from jsonschema.exceptions import ValidationError
 from buildtest.buildsystem.parser import BuildspecParser
-from buildtest.config import buildtest_configuration, BuildtestConfiguration
+from buildtest.config import check_settings, BuildtestConfiguration
 from buildtest.defaults import (
     BUILDSPEC_CACHE_FILE,
     BUILDSPEC_DEFAULT_PATH,
@@ -47,6 +47,7 @@ class BuildspecCache:
         :type roots: list, required
         """
         self.settings = settings_file or DEFAULT_SETTINGS_FILE
+        self.configuration = check_settings(self.settings, executor_check=True)
         self.filter = filterfields
         self.format = formatfields
         # if --root is not specified we set to empty list instead of None
@@ -78,15 +79,13 @@ class BuildspecCache:
         and general tests.
         """
 
-        config_opts = buildtest_configuration.target_config
-
-        buildspec_paths = config_opts.get("buildspec_roots") or []
+        buildspec_paths = self.configuration.target_config.get("buildspec_roots") or []
 
         if buildspec_paths:
             self.roots += buildspec_paths
 
         # only load default buildspecs if 'load_default_buildspecs' set to True
-        if config_opts.get("load_default_buildspecs"):
+        if self.configuration.target_config.get("load_default_buildspecs"):
             self.paths += BUILDSPEC_DEFAULT_PATH
 
         # for every root buildspec defined in configuration or via --root option,


### PR DESCRIPTION
This PR address a bug in `buildtest buildspec find` where no root buildspecs were searched.

```
(buildtest) siddiq90@cori02:~/github/buildtest-cori> buildtest buildspec find --roots buildspecs --rebuild
Clearing cache file: /global/u1/s/siddiq90/github/buildtest/var/buildspec-cache.json
Traceback (most recent call last):
  File "/global/homes/s/siddiq90/github/buildtest/bin/buildtest", line 17, in <module>
    buildtest.main.main()
  File "/global/u1/s/siddiq90/github/buildtest/buildtest/main.py", line 95, in main
    buildspec_find(args=args, settings_file=settings_file)
  File "/global/u1/s/siddiq90/github/buildtest/buildtest/menu/buildspec.py", line 598, in buildspec_find
    cache = BuildspecCache(
  File "/global/u1/s/siddiq90/github/buildtest/buildtest/menu/buildspec.py", line 62, in __init__
    self.build()
  File "/global/u1/s/siddiq90/github/buildtest/buildtest/menu/buildspec.py", line 127, in build
    self.build_cache()
  File "/global/u1/s/siddiq90/github/buildtest/buildtest/menu/buildspec.py", line 258, in build_cache
    buildspecs = self._discover_buildspecs()
  File "/global/u1/s/siddiq90/github/buildtest/buildtest/menu/buildspec.py", line 143, in _discover_buildspecs
    raise BuildTestError(
buildtest.exceptions.BuildTestError: 'Unable to search any buildspecs, please specify a directory'

```