### PR TITLE
Fix scheduler detection logic Cobalt vs PBS on Theta and JLSE

### DIFF
--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -2,7 +2,6 @@ import logging
 import json
 import os
 import re
-import socket
 from buildtest.defaults import (
     USER_SETTINGS_FILE,
     DEFAULT_SETTINGS_FILE,
@@ -49,7 +48,9 @@ class BuildtestConfiguration:
         host_lookup = {}
 
         # get hostname fqdn
-        hostname = socket.gethostname()
+        cmd = BuildTestCommand("hostname -f")
+        cmd.execute()
+        hostname = " ".join(cmd.get_output())
 
         # for every system record we lookup 'hostnames' entry and apply re.match against current hostname. If found we break from loop
         for name in self.config["system"].keys():

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -147,11 +147,11 @@ class BuildtestConfiguration:
         :type lsf_executors: dict
         """
         lsf = LSF()
-        queue_dict = lsf.get_queues()
+        assert hasattr(lsf,"queues")
 
         queue_list = []
         valid_queue_state = "Open:Active"
-        record = queue_dict["RECORDS"]
+        record = lsf.queues["RECORDS"]
         # retrieve all queues from json record
         for name in record:
             queue_list.append(name["QUEUE_NAME"])
@@ -163,7 +163,7 @@ class BuildtestConfiguration:
             if queue:
                 if queue not in queue_list:
                     raise BuildTestError(
-                        f"{lsf_executors[executor]['queue']} not a valid partition!. Please select one of the following partitions: {queue_list}"
+                        f"{lsf_executors[executor]['queue']} not a valid queue!. Please select one of the following queue: {queue_list}"
                     )
 
                 # check queue record for Status
@@ -190,16 +190,20 @@ class BuildtestConfiguration:
         :type slurm_executor: dict
         """
 
-        slurm_object = Slurm()
+        slurm = Slurm()
+        # make sure slurm attributes slurm.partitions, slurm.qos, slurm.clusters are set
+        assert hasattr(slurm,"partitions")
+        assert hasattr(slurm, "qos")
+        assert hasattr(slurm, "clusters")
 
         for executor in slurm_executor:
 
             # if 'partition' key defined check if its valid partition
             if slurm_executor[executor].get("partition"):
 
-                if slurm_executor[executor]["partition"] not in slurm_object.partitions:
+                if slurm_executor[executor]["partition"] not in slurm.partitions:
                     raise BuildTestError(
-                        f"{slurm_executor[executor]['partition']} not a valid partition!. Please select one of the following partitions: {slurm_object.partitions}"
+                        f"{slurm_executor[executor]['partition']} not a valid partition!. Please select one of the following partitions: {slurm.partitions}"
                     )
 
                 query = (
@@ -217,28 +221,29 @@ class BuildtestConfiguration:
             # check if 'qos' key is valid qos
             if (
                 slurm_executor[executor].get("qos")
-                and slurm_executor[executor].get("qos") not in slurm_object.qos
+                and slurm_executor[executor].get("qos") not in slurm.qos
             ):
                 raise BuildTestError(
-                    f"{slurm_executor[executor]['qos']} not a valid qos! Please select one of the following qos: {slurm_object.qos}"
+                    f"{slurm_executor[executor]['qos']} not a valid qos! Please select one of the following qos: {slurm.qos}"
                 )
 
             # check if 'cluster' key is valid slurm cluster
             if (
                 slurm_executor[executor].get("cluster")
-                and slurm_executor[executor].get("cluster") not in slurm_object.clusters
+                and slurm_executor[executor].get("cluster") not in slurm.clusters
             ):
                 raise BuildTestError(
-                    f"{slurm_executor[executor]['cluster']} not a valid slurm cluster! Please select one of the following slurm clusters: {slurm_object.clusters}"
+                    f"{slurm_executor[executor]['cluster']} not a valid slurm cluster! Please select one of the following slurm clusters: {slurm.clusters}"
                 )
 
     def _validate_cobalt_executors(self, cobalt_executor):
-        """Validate cobalt queue property by running ```qstat -Q <queue>``. If
+        """Validate cobalt queue property by running ```qstat -Ql <queue>``. If
         its a non-zero exit code then queue doesn't exist otherwise it is a valid
         queue.
         """
 
         cobalt = Cobalt()
+        assert hasattr(cobalt, "queues")
 
         for executor in cobalt_executor:
             queue = cobalt_executor[executor].get("queue")
@@ -278,6 +283,7 @@ class BuildtestConfiguration:
         """
 
         pbs = PBS()
+        assert hasattr(pbs,"queues")
         for executor in pbs_executor:
             queue = pbs_executor[executor].get("queue")
             if queue not in pbs.queues:

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -2,7 +2,7 @@ import logging
 import json
 import os
 import re
-
+import socket
 from buildtest.defaults import (
     USER_SETTINGS_FILE,
     DEFAULT_SETTINGS_FILE,
@@ -49,7 +49,7 @@ class BuildtestConfiguration:
         host_lookup = {}
 
         # get hostname fqdn
-        hostname = " ".join(BuildTestCommand("hostname -f").get_output())
+        hostname = socket.gethostname()
 
         # for every system record we lookup 'hostnames' entry and apply re.match against current hostname. If found we break from loop
         for name in self.config["system"].keys():

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -271,7 +271,7 @@ class LSF(Scheduler):
 class Cobalt(Scheduler):
     """The Cobalt class checks for Cobalt binaries and gets a list of Cobalt queues"""
     # specify a set of Cobalt commands to check for file existence
-    binaries = ["qsub", "qstat", "qdel", "nodelist", "qcancel","showres", "partlist"]
+    binaries = ["qsub", "qstat", "qdel", "nodelist", "showres", "partlist"]
 
     def __init__(self):
         self.logger = logging.getLogger(__name__)

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -113,7 +113,7 @@ class BuildTestSystem:
 class Scheduler:
     """This is a base Scheduler class used for implementing common methods for
     detecting Scheduler details. The subclass implement specific queries that
-    are scheduler specific. The ``Slurm``, ``LSF`` and ``Cobalt`` class inherit
+    are scheduler specific. The ``Slurm``, ``LSF``, ``PBS`` and ``Cobalt`` class inherit
     from Base Class ``Scheduler``.
     """
 
@@ -141,7 +141,7 @@ class Slurm(Scheduler):
     in $PATH and return if slurm cluster is in valid state.
     """
 
-    # all of these commands are used later when submitting, polling or cancelling job
+    # specify a set of Slurm commands to check for file existence
     binaries = ["sbatch", "sacct", "sacctmgr", "sinfo", "scancel"]
 
     def __init__(self):
@@ -149,11 +149,14 @@ class Slurm(Scheduler):
         self.logger = logging.getLogger(__name__)
 
         self.check()
-        self.partitions = self.get_partitions()
-        self.clusters = self.get_clusters()
-        self.qos = self.get_qos()
 
-    def get_partitions(self):
+        # retrieve slurm partitions, qos, and cluster only if slurm is detected.
+        if self.state:
+            self.partitions = self._get_partitions()
+            self.clusters = self._get_clusters()
+            self.qos = self._get_qos()
+
+    def _get_partitions(self):
         """Get list of all partitions slurm partitions using ``sinfo -a -h -O partitionname``. The output
            is a list of queue names
 
@@ -175,7 +178,7 @@ class Slurm(Scheduler):
         partitions = [partition.rstrip() for partition in out]
         return partitions
 
-    def get_clusters(self):
+    def _get_clusters(self):
         """Get list of slurm clusters by running ``sacctmgr list cluster -P -n format=Cluster``.
            The output is a list of slurm clusters something as follows::
 
@@ -193,7 +196,7 @@ class Slurm(Scheduler):
         slurm_clusters = [clustername.rstrip() for clustername in out]
         return slurm_clusters
 
-    def get_qos(self):
+    def _get_qos(self):
         """Retrieve a list of all slurm qos by running ``sacctmgr list qos -P -n  format=Name``. The output
         is a list of qos. Shown below is an example output
 
@@ -218,7 +221,7 @@ class Slurm(Scheduler):
 
 class LSF(Scheduler):
     """The LSF class checks for LSF binaries and returns a list of LSF queues"""
-
+    # specify a set of LSF commands to check for file existence
     binaries = ["bsub", "bqueues", "bkill", "bjobs"]
 
     def __init__(self):
@@ -226,10 +229,32 @@ class LSF(Scheduler):
         self.logger = logging.getLogger(__name__)
 
         self.check()
-        self.queues = self.get_queues()
 
-    def get_queues(self):
-        """Return json dictionary of available LSF Queues and their queue states"""
+        # retrieve LSF queues if LSF is detected
+        if self.state:
+            self.queues = self._get_queues()
+
+    def _get_queues(self):
+        """Return json dictionary of available LSF Queues and their queue states.
+        The command we run is the following: ``bqueues -o 'queue_name status' -json`` which
+        returns a JSON record of all queue details.
+        $ bqueues -o 'queue_name status' -json
+            {
+              "COMMAND":"bqueues",
+              "QUEUES":2,
+              "RECORDS":[
+                {
+                  "QUEUE_NAME":"batch",
+                  "STATUS":"Open:Active"
+                },
+                {
+                  "QUEUE_NAME":"test",
+                  "STATUS":"Open:Active"
+                }
+              ]
+            }
+
+        """
 
         query = "bqueues -o 'queue_name status' -json"
         cmd = BuildTestCommand(query)
@@ -245,16 +270,18 @@ class LSF(Scheduler):
 
 class Cobalt(Scheduler):
     """The Cobalt class checks for Cobalt binaries and gets a list of Cobalt queues"""
-
-    binaries = ["qsub", "qstat", "qdel"]
+    # specify a set of Cobalt commands to check for file existence
+    binaries = ["qsub", "qstat", "qdel", "nodelist", "qcancel","showres", "partlist"]
 
     def __init__(self):
         self.logger = logging.getLogger(__name__)
 
         self.check()
-        self.queues = self.get_queues()
 
-    def get_queues(self):
+        if self.state:
+            self.queues = self._get_queues()
+
+    def _get_queues(self):
         """Get all Cobalt queues by running ``qstat -Ql`` and parsing output"""
 
         query = "qstat -Ql"
@@ -278,7 +305,8 @@ class Cobalt(Scheduler):
 class PBS(Scheduler):
     """The PBS class checks for Cobalt binaries and gets a list of Cobalt queues"""
 
-    binaries = ["qsub", "qstat", "qdel"]
+    # specify a set of PBS commands to check for file existence
+    binaries = ["qsub", "qstat", "qdel", "qstart", "qhold", "qmgr"]
 
     def __init__(self):
         self.logger = logging.getLogger(__name__)

--- a/tests/test_ascent.py
+++ b/tests/test_ascent.py
@@ -6,7 +6,9 @@ from buildtest.utils.command import BuildTestCommand
 
 def test_ascent():
     # this test must run on Ascent system with domain '.ascent.olcf.ornl.gov' otherwise its skipped
-    hostname = " ".join(BuildTestCommand("hostname -f").get_output())
+    cmd = BuildTestCommand("hostname -f")
+    cmd.execute()
+    hostname = " ".join(cmd.get_output())
     if not hostname.endswith("ascent.olcf.ornl.gov"):
         pytest.skip("This test must run on domain ascent.olcf.ornl.gov")
 

--- a/tests/test_ascent.py
+++ b/tests/test_ascent.py
@@ -1,14 +1,13 @@
 import os
 import pytest
+import socket
 from buildtest.menu.build import BuildTest
-from buildtest.utils.command import BuildTestCommand
 
 
 def test_ascent():
     # this test must run on Ascent system with domain '.ascent.olcf.ornl.gov' otherwise its skipped
-    cmd = BuildTestCommand("hostname -f")
-    cmd.execute()
-    hostname = " ".join(cmd.get_output())
+
+    hostname = socket.getfqdn()
     if not hostname.endswith("ascent.olcf.ornl.gov"):
         pytest.skip("This test must run on domain ascent.olcf.ornl.gov")
 

--- a/tests/test_cori.py
+++ b/tests/test_cori.py
@@ -1,16 +1,15 @@
 import os
 import pytest
+import socket
 from buildtest.menu.build import BuildTest
-from buildtest.utils.command import BuildTestCommand
+
 
 def test_cori():
     # This test must run on Cori Login nodes which are cori[01-20].nersc.gov.
-    cmd = BuildTestCommand("hostname -f")
-    cmd.execute()
-    hostname = " ".join(cmd.get_output())
-    if not hostname.endswith("nersc.gov") or not hostname.startswith("cori"):
+    hostname = socket.getfqdn()
+    if not hostname.startswith("cori"):
         pytest.skip(
-            "This test runs only on domain 'nersc.gov' with machine names that start with 'cori*'"
+            "This test runs on Cori Login nodes ('cori*')"
         )
 
     here = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_cori.py
+++ b/tests/test_cori.py
@@ -5,8 +5,9 @@ from buildtest.utils.command import BuildTestCommand
 
 def test_cori():
     # This test must run on Cori Login nodes which are cori[01-20].nersc.gov.
-    hostname = " ".join(BuildTestCommand("hostname -f").get_output())
-
+    cmd = BuildTestCommand("hostname -f")
+    cmd.execute()
+    hostname = " ".join(cmd.get_output())
     if not hostname.endswith("nersc.gov") or not hostname.startswith("cori"):
         pytest.skip(
             "This test runs only on domain 'nersc.gov' with machine names that start with 'cori*'"

--- a/tests/test_jlse.py
+++ b/tests/test_jlse.py
@@ -5,7 +5,9 @@ from buildtest.utils.command import BuildTestCommand
 
 
 def test_jlse():
-    hostname = " ".join(BuildTestCommand("hostname -f").get_output())
+    cmd = BuildTestCommand("hostname -f")
+    cmd.execute()
+    hostname = " ".join(cmd.get_output())
     if not hostname.endswith("alcf.anl.gov"):
         pytest.skip("Test runs only on JLSE Login Nodes with domain name alcf.anl.gov")
 

--- a/tests/test_jlse.py
+++ b/tests/test_jlse.py
@@ -1,13 +1,10 @@
 import os
 import pytest
+import socket
 from buildtest.menu.build import BuildTest
-from buildtest.utils.command import BuildTestCommand
-
 
 def test_jlse():
-    cmd = BuildTestCommand("hostname -f")
-    cmd.execute()
-    hostname = " ".join(cmd.get_output())
+    hostname = socket.getfqdn()
     if not hostname.endswith("alcf.anl.gov"):
         pytest.skip("Test runs only on JLSE Login Nodes with domain name alcf.anl.gov")
 


### PR DESCRIPTION
The schedulers were not detected properly when trying to check Cobalt and PBS binaries on Theta and JLSE. The issue is some scheduler binaries `qsub`, `qstat`, `qdel` are found by both schedulers. We added more binaries to this list ones that are unique to Cobalt and PBS to avoid this issue. 

