### PR TITLE
delay LocalExecutor shell check at time of running

### DIFF
--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -49,6 +49,9 @@ class CobaltExecutor(BaseExecutor):
         we check returncode and exit with failure. After we submit job, we
         start timer and record when job was submitted and poll job once to get
         job details and store them in builder object.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
         """
 
         os.chdir(builder.stage_dir)
@@ -133,6 +136,9 @@ class CobaltExecutor(BaseExecutor):
         is in 'pending' stage we check if job exceeds 'max_pend_time' time limit
         by checking with builder timer attribute using ``start`` and ``stop`` method.
         If job exceeds the time limit job is cancelled.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
         """
 
         self.logger.debug(f"Query Job: {builder.metadata['jobid']}")
@@ -190,13 +196,16 @@ class CobaltExecutor(BaseExecutor):
         output of exit code. Cobalt doesn't provide any method to retrieve
         exit code using account command (``qstat``) so we need to perform
         regular expression.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
         """
 
         builder.metadata["output"] = read_file(builder.metadata["outfile"])
-        builder.metadata["error"] = read_file(self.builder.metadata["errfile"])
+        builder.metadata["error"] = read_file(builder.metadata["errfile"])
 
         cobaltlog = os.path.join(
-            self.builder.stage_dir, str(self.builder.metadata["jobid"]) + ".cobaltlog"
+            builder.stage_dir, str(builder.metadata["jobid"]) + ".cobaltlog"
         )
 
         self.end_time(builder)
@@ -208,8 +217,7 @@ class CobaltExecutor(BaseExecutor):
             # pattern to check in cobalt log file is 'exit code of <CODE>;'
             m = re.search(pattern, content)
             if m:
-                self.builder.metadata["result"]["returncode"] = int(m.group(2))
-                print(self.builder.metadata["result"]["returncode"])
+                builder.metadata["result"]["returncode"] = int(m.group(2))
             else:
                 self.logger.debug(
                     f"Error in regular expression: {pattern}. Unable to find returncode please check your cobalt log file"
@@ -218,7 +226,11 @@ class CobaltExecutor(BaseExecutor):
         self.check_test_state()
 
     def cancel(self, builder):
-        """Cancel Cobalt job using qdel, this operation is performed if job exceeds its max_pend_time"""
+        """Cancel Cobalt job using qdel, this operation is performed if job exceeds its max_pend_time
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
+        """
 
         query = f"qdel {builder.metadata['jobid']}"
 

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -223,7 +223,7 @@ class CobaltExecutor(BaseExecutor):
                     f"Error in regular expression: {pattern}. Unable to find returncode please check your cobalt log file"
                 )
 
-        self.check_test_state()
+        self.check_test_state(builder)
 
     def cancel(self, builder):
         """Cancel Cobalt job using qdel, this operation is performed if job exceeds its max_pend_time

--- a/buildtest/executors/lsf.py
+++ b/buildtest/executors/lsf.py
@@ -226,7 +226,7 @@ class LSFExecutor(BaseExecutor):
         self.logger.debug(
             f"[{builder.name}] returncode: {builder.metadata['result']['returncode']}"
         )
-        self.check_test_state()
+        self.check_test_state(builder)
 
     def cancel(self, builder):
         """Cancel LSF job, this is required if job exceeds max pending time in queue.

--- a/buildtest/executors/lsf.py
+++ b/buildtest/executors/lsf.py
@@ -70,7 +70,11 @@ class LSFExecutor(BaseExecutor):
         self.queue = self._settings.get("queue")
 
     def dispatch(self, builder):
-        """This method is responsible for dispatching job to scheduler."""
+        """This method is responsible for dispatching job to scheduler.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
+        """
 
         # The job_id variable is used to store the JobID retrieved by bjobs
         self.job_id = 0
@@ -131,6 +135,9 @@ class LSFExecutor(BaseExecutor):
         """This method will poll for job by using bjobs and return state of job.
         The command to be run is ``bjobs -noheader -o 'stat' <JOBID>`` which
         returns job state.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
         """
 
         self.logger.debug(f"Query Job: {builder.metadata['jobid']}")
@@ -171,6 +178,9 @@ class LSFExecutor(BaseExecutor):
         """Gather Job detail after completion of job. This method will retrieve output
         fields defined for ``self.format_fields``. buildtest will run
         ``bjobs -o '<field1> ... <fieldN>' <JOBID> -json``.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
         """
 
         # bjobs gather command to extract format fields and convert output to JSON
@@ -214,12 +224,16 @@ class LSFExecutor(BaseExecutor):
         builder.metadata["error"] = read_file(builder.metadata["errfile"])
 
         self.logger.debug(
-            f"[{self.builder.name}] returncode: {builder.metadata['result']['returncode']}"
+            f"[{builder.name}] returncode: {builder.metadata['result']['returncode']}"
         )
         self.check_test_state()
 
     def cancel(self, builder):
-        """Cancel LSF job, this is required if job exceeds max pending time in queue"""
+        """Cancel LSF job, this is required if job exceeds max pending time in queue.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
+        """
 
         query = f"bkill {builder.metadata['jobid']}"
 

--- a/buildtest/executors/pbs.py
+++ b/buildtest/executors/pbs.py
@@ -50,6 +50,9 @@ class PBSExecutor(BaseExecutor):
         we check returncode and exit with failure. After we submit job, we
         start timer and record when job was submitted and poll job once to get
         job details and store them in builder object.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
         """
 
         self.load()
@@ -68,7 +71,7 @@ class PBSExecutor(BaseExecutor):
             batch_cmd += [" ".join(self.launcher_opts)]
 
         batch_cmd += [builder.metadata["testpath"]]
-        self.builder.metadata["command"] = " ".join(batch_cmd)
+        builder.metadata["command"] = " ".join(batch_cmd)
         self.logger.debug(f"Running Test via command: {builder.metadata['command']}")
         command = BuildTestCommand(builder.metadata["command"])
         command.execute()
@@ -115,6 +118,9 @@ class PBSExecutor(BaseExecutor):
         is in 'pending' stage we check if job exceeds 'max_pend_time' time limit
         by checking with builder timer attribute using ``start`` and ``stop`` method.
         If job exceeds the time limit job is cancelled.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
         """
 
         self.logger.debug(f"Query Job: {builder.metadata['jobid']}")
@@ -152,7 +158,7 @@ class PBSExecutor(BaseExecutor):
             # if timer time is more than requested pend time then cancel job
             if int(builder.duration) > self.max_pend_time:
                 self.cancel(builder)
-                self.builder.job_state = "CANCELLED"
+                builder.job_state = "CANCELLED"
                 print(
                     "Cancelling Job because duration time: {:f} sec exceeds max pend time: {} sec".format(
                         builder.duration, self.max_pend_time
@@ -166,6 +172,9 @@ class PBSExecutor(BaseExecutor):
         and storing the result in builder object. We retrieve specific fields such as exit status,
         start time, end time, runtime and store them in builder object. We read output and error file
         and store the content in builder object.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
         """
 
         qstat_cmd = f"{self.poll_cmd} -x -f -F json {builder.metadata['jobid']}"
@@ -178,7 +187,7 @@ class PBSExecutor(BaseExecutor):
 
         job_data = json.loads(output)
 
-        self.builder.metadata["result"]["returncode"] = job_data["Jobs"][
+        builder.metadata["result"]["returncode"] = job_data["Jobs"][
             builder.metadata["jobid"]
         ]["Exit_status"]
 
@@ -193,7 +202,11 @@ class PBSExecutor(BaseExecutor):
         self.check_test_state()
 
     def cancel(self, builder):
-        """Cancel Cobalt job using qdel, this operation is performed if job exceeds its max_pend_time"""
+        """Cancel Cobalt job using qdel, this operation is performed if job exceeds its max_pend_time.
+
+        :param builder: builder object
+        :type builder: BuilderBase, required
+        """
 
         query = f"qdel {builder.metadata['jobid']}"
 

--- a/buildtest/executors/pbs.py
+++ b/buildtest/executors/pbs.py
@@ -199,7 +199,7 @@ class PBSExecutor(BaseExecutor):
         builder.metadata["output"] = read_file(builder.metadata["outfile"])
         builder.metadata["error"] = read_file(builder.metadata["errfile"])
 
-        self.check_test_state()
+        self.check_test_state(builder)
 
     def cancel(self, builder):
         """Cancel Cobalt job using qdel, this operation is performed if job exceeds its max_pend_time.

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -165,7 +165,7 @@ class BuildTest:
         self.bp_removed = None
         # this variable contains the detected buildspecs that will be processed by buildtest.
         self.detected_buildspecs = None
-        self.buildexecutor = None
+
         self.builders = None
         self.buildexecutor = BuildExecutor(self.configuration)
 
@@ -472,8 +472,7 @@ class BuildTest:
 
         # print any skipped buildspecs if they failed to validate during build stage
         if len(invalid_buildspecs) > 0:
-            print("\n\n")
-            print("Error Messages from Stage: Parse")
+            print("\n\nError Messages from Stage: Parse")
             print("{:_<80}".format(""))
             for test in invalid_buildspecs:
                 print(test)
@@ -534,10 +533,10 @@ class BuildTest:
         """
         invalid_builders = []
         msg = """
-+-------------------------------+
-| Stage: Building Test          |
-+-------------------------------+ 
-        """
++----------------------+
+| Stage: Building Test |
++----------------------+ 
+"""
         if os.getenv("BUILDTEST_COLOR") == "True":
             msg = colored(msg, "red", attrs=["bold"])
 
@@ -572,8 +571,7 @@ class BuildTest:
         if printTable:
             # print any skipped buildspecs if they failed to validate during build stage
             if invalid_builders:
-                print("\n\n")
-                print("Error Messages from Stage: Build")
+                print("\n\nError Messages from Stage: Build")
                 print("{:_<80}".format(""))
                 for test in invalid_builders:
                     print(test)
@@ -642,9 +640,9 @@ class BuildTest:
 
         if printTable:
             msg = """
-+-------------------------------+
-| Stage: Running Test           |
-+-------------------------------+ 
++---------------------+
+| Stage: Running Test |
++---------------------+ 
 """
             if os.getenv("BUILDTEST_COLOR") == "True":
                 msg = colored(msg, "red", attrs=["bold"])


### PR DESCRIPTION
@samcom12 

With this fix we can run a test even if we have a `csh` executor defined in our configuration file

```
[pbsuser@pbs buildtest]$ which csh
/usr/bin/which: no csh in (/tmp/Documents/github/buildtest/bin:/tmp/Documents/buildtest/bin:/tmp/Documents/github/buildtest/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/opt/pbs/bin:/home/pbsuser/.local/bin:/home/pbsuser/bin)
[pbsuser@pbs buildtest]$ buildtest build -b tutorials/vars.yml 


+-------------------------------+
| Stage: Discovering Buildspecs |
+-------------------------------+ 

Discovered Buildspecs:
/tmp/Documents/github/buildtest/tutorials/vars.yml

+---------------------------+
| Stage: Parsing Buildspecs |
+---------------------------+ 

 schemafile              | validstate   | buildspec
-------------------------+--------------+----------------------------------------------------
 script-v1.0.schema.json | True         | /tmp/Documents/github/buildtest/tutorials/vars.yml

+----------------------+
| Stage: Building Test |
+----------------------+ 

 name           | id       | type   | executor           | tags          | testpath
----------------+----------+--------+--------------------+---------------+------------------------------------------------------------------------------------------------------
 variables_bash | bef756b9 | script | generic.local.bash | ['tutorials'] | /tmp/Documents/github/buildtest/var/tests/generic.local.bash/vars/variables_bash/3/stage/generate.sh



+---------------------+
| Stage: Running Test |
+---------------------+ 

 name           | id       | executor           | status   |   returncode | testpath
----------------+----------+--------------------+----------+--------------+------------------------------------------------------------------------------------------------------
 variables_bash | bef756b9 | generic.local.bash | PASS     |            0 | /tmp/Documents/github/buildtest/var/tests/generic.local.bash/vars/variables_bash/3/stage/generate.sh

+----------------------+
| Stage: Test Summary  |
+----------------------+ 

Passed Tests: 1/1 Percentage: 100.000%
Failed Tests: 0/1 Percentage: 0.000%



Writing Logfile to: /tmp/buildtest_gy86vkkv.log
```

Now if we run a test that depends on csh executor we get an error at runtime 
```
[pbsuser@pbs buildtest]$ buildtest build -b tutorials/csh_shell_examples.yml 


+-------------------------------+
| Stage: Discovering Buildspecs |
+-------------------------------+ 

Discovered Buildspecs:
/tmp/Documents/github/buildtest/tutorials/csh_shell_examples.yml
Traceback (most recent call last):
  File "/tmp/Documents/github/buildtest/bin/buildtest", line 17, in <module>
    buildtest.main.main()
  File "/tmp/Documents/github/buildtest/buildtest/main.py", line 65, in main
    cmd.build()
  File "/tmp/Documents/github/buildtest/buildtest/menu/build.py", line 509, in build
    self.parse_buildspecs(printTable=True)
  File "/tmp/Documents/github/buildtest/buildtest/menu/build.py", line 469, in parse_buildspecs
    rebuild=self.rebuild,
  File "/tmp/Documents/github/buildtest/buildtest/buildsystem/builders.py", line 72, in __init__
    testdir=self.testdir,
  File "/tmp/Documents/github/buildtest/buildtest/buildsystem/base.py", line 95, in __init__
    self.shell = Shell(self.recipe.get("shell", "bash"))
  File "/tmp/Documents/github/buildtest/buildtest/utils/shell.py", line 45, in __init__
    self.path = self.name
  File "/tmp/Documents/github/buildtest/buildtest/utils/shell.py", line 95, in path
    raise BuildTestError(f"Can't find program: {name}")
buildtest.exceptions.BuildTestError: "Can't find program: csh"
```


The current executors are the following

```
[pbsuser@pbs buildtest]$ buildtest config executors

executors:
  local:
    bash:
      description: submit jobs on local machine using bash shell
      shell: bash
    csh:
      description: submit jobs on local machine using csh shell
      shell: csh
    python:
      description: submit jobs on local machine using python shell
      shell: python
    sh:
      description: submit jobs on local machine using sh shell
      shell: sh
    zsh:
      description: submit jobs on local machine using zsh shell
      shell: zsh

```
This will apply to all other shells, we still need to leave the `csh`, `tcsh`, `zsh` executor in the default configuration file to ensure we can run all the tutorials and regression test.