### PR TITLE
remove buildtest config compilers --list and make output default

### DIFF
--- a/buildtest/menu/__init__.py
+++ b/buildtest/menu/__init__.py
@@ -331,11 +331,12 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         )
 
         subparsers_compiler_find = compiler_config.add_subparsers(
-            description="Find new compilers and add them to detected compiler section"
+            description="Find new compilers and add them to detected compiler section",
         )
 
         compiler_find = subparsers_compiler_find.add_parser(
-            "find", help="Find compilers"
+            "find",
+            help="Find compilers",
         )
         compiler_find.add_argument(
             "-d",
@@ -355,9 +356,6 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
             "--yaml",
             action="store_true",
             help="List compiler details in YAML format",
-        )
-        compiler_config.add_argument(
-            "-l", "--list", action="store_true", help="List all compilers "
         )
         # parser_config_executor.set_defaults(fun)
         parser_executors.set_defaults(func=func_config_executors)

--- a/buildtest/menu/build.py
+++ b/buildtest/menu/build.py
@@ -489,12 +489,16 @@ class BuildTest:
 | Stage: Parsing Buildspecs |
 +---------------------------+ 
 """
+            headers = table.keys()
+
             if os.getenv("BUILDTEST_COLOR") == "True":
                 msg = colored(msg, "red", attrs=["bold"])
+                headers = list(
+                    map(lambda x: colored(x, "blue", attrs=["bold"]), headers)
+                )
 
             print(msg)
-
-            print(tabulate(table, headers=table.keys(), tablefmt="presto"))
+            print(tabulate(table, headers=headers, tablefmt="presto"))
 
         return self.builders
 
@@ -543,7 +547,8 @@ class BuildTest:
         print(msg)
 
         table = Hasher()
-        for field in ["name", "id", "type", "executor", "tags", "compiler", "testpath"]:
+        headers = ["name", "id", "type", "executor", "tags", "compiler", "testpath"]
+        for field in headers:
             table["script"][field] = []
             table["compiler"][field] = []
 
@@ -577,20 +582,34 @@ class BuildTest:
                     print(test)
 
             if len(table["script"]["name"]) > 0:
+
+                if os.getenv("BUILDTEST_COLOR") == "True":
+                    headers = list(
+                        map(lambda x: colored(x, "blue", attrs=["bold"]), headers)
+                    )
+
                 print(
                     tabulate(
                         table["script"],
-                        headers=table["script"].keys(),
+                        headers=headers,
                         tablefmt="presto",
                     )
                 )
 
             print("\n")
+
             if len(table["compiler"]["name"]) > 0:
+
+                headers = table["compiler"].keys()
+                if os.getenv("BUILDTEST_COLOR") == "True":
+                    headers = list(
+                        map(lambda x: colored(x, "blue", attrs=["bold"]), headers)
+                    )
+
                 print(
                     tabulate(
                         table["compiler"],
-                        headers=table["compiler"].keys(),
+                        headers=headers,
                         tablefmt="presto",
                     )
                 )
@@ -690,7 +709,13 @@ class BuildTest:
             total_tests += 1
 
         if printTable:
-            print(tabulate(table, headers=table.keys(), tablefmt="presto"))
+            headers = table.keys()
+            if os.getenv("BUILDTEST_COLOR") == "True":
+                headers = list(
+                    map(lambda x: colored(x, "blue", attrs=["bold"]), headers)
+                )
+
+            print(tabulate(table, headers=headers, tablefmt="presto"))
 
         if errmsg:
             print("\n\n")
@@ -746,7 +771,13 @@ class BuildTest:
                 total_tests += 1
 
             if printTable:
-                print(tabulate(table, headers=table.keys(), tablefmt="presto"))
+                headers = table.keys()
+                if os.getenv("BUILDTEST_COLOR") == "True":
+                    headers = list(
+                        map(lambda x: colored(x, "blue", attrs=["bold"]), headers)
+                    )
+
+                print(tabulate(table, headers=headers, tablefmt="presto"))
 
         ########## TEST SUMMARY ####################
         if total_tests == 0:
@@ -775,7 +806,7 @@ class BuildTest:
 
             print(msg1)
             print(msg2)
-            print("\n\n")
+            print("\n")
 
         return valid_builders
 

--- a/buildtest/menu/compilers.py
+++ b/buildtest/menu/compilers.py
@@ -54,7 +54,7 @@ def func_config_compiler(args=None):
     """
     bc = BuildtestCompilers()
 
-    if args.json == False and args.yaml == False:
+    if args.json is False and args.yaml is False:
         bc.print_compilers()
 
     if args.json:

--- a/buildtest/menu/compilers.py
+++ b/buildtest/menu/compilers.py
@@ -52,14 +52,16 @@ def func_config_compiler(args=None):
     """This method implements ``buildtest config compilers`` which shows compiler
     section from buildtest configuration.
     """
-
     bc = BuildtestCompilers()
+
+    if args.json == False and args.yaml == False:
+        bc.print_compilers()
+
     if args.json:
         bc.print_json()
+
     if args.yaml:
         bc.print_yaml()
-    if args.list:
-        bc.print_compilers()
 
 
 class BuildtestCompilers:


### PR DESCRIPTION
when running "buildtest config compilers"
Colorize table headers for build, run, poll stage