### PR TITLE
force buildtest to write files in $HOME/.buildtest instead of $BUILDTEST_ROOT

### DIFF
--- a/buildtest/buildsystem/compilerbuilder.py
+++ b/buildtest/buildsystem/compilerbuilder.py
@@ -4,7 +4,7 @@ import shutil
 
 from buildtest.buildsystem.base import BuilderBase
 from buildtest.config import buildtest_configuration
-from buildtest.defaults import executor_root
+from buildtest.defaults import BUILDTEST_EXECUTOR_DIR
 from buildtest.exceptions import BuildTestError
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.utils.file import resolve_path
@@ -200,7 +200,7 @@ class CompilerBuilder(BuilderBase):
             lines += data_warp_lines
 
         lines += [
-            f"source {os.path.join(executor_root, self.executor, 'before_script.sh')}"
+            f"source {os.path.join(BUILDTEST_EXECUTOR_DIR, self.executor, 'before_script.sh')}"
         ]
 
         lines += [self.exec_variable]
@@ -231,7 +231,7 @@ class CompilerBuilder(BuilderBase):
             lines.append(self.post_run)
 
         lines += [
-            f"source {os.path.join(executor_root, self.executor, 'after_script.sh')}"
+            f"source {os.path.join(BUILDTEST_EXECUTOR_DIR, self.executor, 'after_script.sh')}"
         ]
         return lines
 

--- a/buildtest/buildsystem/scriptbuilder.py
+++ b/buildtest/buildsystem/scriptbuilder.py
@@ -2,7 +2,7 @@ import os
 import shutil
 
 from buildtest.buildsystem.base import BuilderBase
-from buildtest.defaults import executor_root
+from buildtest.defaults import BUILDTEST_EXECUTOR_DIR
 from buildtest.utils.file import write_file
 
 
@@ -70,7 +70,7 @@ class ScriptBuilder(BuilderBase):
             lines += data_warp_lines
 
         lines += [
-            f"source {os.path.join(executor_root, self.executor, 'before_script.sh')}"
+            f"source {os.path.join(BUILDTEST_EXECUTOR_DIR, self.executor, 'before_script.sh')}"
         ]
 
         # for python scripts we generate python script and return lines
@@ -78,7 +78,7 @@ class ScriptBuilder(BuilderBase):
             self.logger.debug(f"[{self.name}]: Detected python shell")
             lines += self.write_python_script()
             lines += [
-                f"source {os.path.join(executor_root, self.executor, 'after_script.sh')}"
+                f"source {os.path.join(BUILDTEST_EXECUTOR_DIR, self.executor, 'after_script.sh')}"
             ]
 
             return lines
@@ -95,7 +95,7 @@ class ScriptBuilder(BuilderBase):
         lines += [self.recipe.get("run")]
 
         lines += [
-            f"source {os.path.join(executor_root, self.executor, 'after_script.sh')}"
+            f"source {os.path.join(BUILDTEST_EXECUTOR_DIR, self.executor, 'after_script.sh')}"
         ]
 
         return lines

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -4,11 +4,10 @@ interact with a global configuration for buildtest.
 """
 import argparse
 import os
-from termcolor import colored
 
+from termcolor import colored
 from buildtest import BUILDTEST_VERSION, BUILDTEST_COPYRIGHT
 from buildtest.docs import buildtestdocs, schemadocs
-from buildtest.cli.schema import schema_cmd
 from buildtest.schemas.defaults import schema_table
 
 

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -13,10 +13,7 @@ from jsonschema.exceptions import ValidationError
 from tabulate import tabulate
 from termcolor import colored
 from buildtest.config import check_settings
-from buildtest.defaults import (
-    BUILDTEST_ROOT,
-    BUILDSPEC_CACHE_FILE,
-)
+from buildtest.defaults import BUILDSPEC_CACHE_FILE, BUILDTEST_USER_HOME
 from buildtest.buildsystem.builders import Builder
 from buildtest.buildsystem.parser import BuildspecParser
 from buildtest.exceptions import BuildTestError
@@ -62,7 +59,9 @@ def resolve_testdirectory(buildtest_configuration, cli_testdir=None):
     # 2. Configuration option specified by 'testdir'
     # 3. Defaults to $BUILDTEST_ROOT/var/tests
     test_directory = (
-        cli_testdir or prefix_testdir or os.path.join(BUILDTEST_ROOT, "var", "tests")
+        cli_testdir
+        or prefix_testdir
+        or os.path.join(BUILDTEST_USER_HOME, "var", "tests")
     )
     if not test_directory:
         raise BuildTestError(

--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -29,12 +29,14 @@ BUILDTEST_USER_HOME = os.path.join(userhome, ".buildtest")
 # dictionary used for storing status of builds
 USER_SETTINGS_FILE = os.path.join(BUILDTEST_USER_HOME, "config.yml")
 
-var_root = os.path.join(BUILDTEST_ROOT, "var")
-executor_root = os.path.join(var_root, "executors")
+BUILDTEST_VAR_DIR = os.path.join(BUILDTEST_USER_HOME, "var")
+BUILDTEST_EXECUTOR_DIR = os.path.join(BUILDTEST_USER_HOME, "executor")
+BUILDTEST_BUILDSPEC_DIR = os.path.join(BUILDTEST_USER_HOME, "buildspecs")
 
-BUILDSPEC_CACHE_FILE = os.path.join(var_root, "buildspec-cache.json")
+BUILDSPEC_CACHE_FILE = os.path.join(BUILDTEST_BUILDSPEC_DIR, "cache.json")
+BUILDSPEC_ERROR_FILE = os.path.join(BUILDTEST_BUILDSPEC_DIR, "error.txt")
 
-BUILD_REPORT = os.path.join(var_root, "report.json")
+BUILD_REPORT = os.path.join(BUILDTEST_USER_HOME, "report.json")
 
 BUILDSPEC_DEFAULT_PATH = [
     os.path.join(BUILDTEST_ROOT, "tutorials"),

--- a/buildtest/executors/setup.py
+++ b/buildtest/executors/setup.py
@@ -9,7 +9,7 @@ import logging
 import os
 import sys
 
-from buildtest.defaults import USER_SETTINGS_FILE, executor_root
+from buildtest.defaults import USER_SETTINGS_FILE, BUILDTEST_EXECUTOR_DIR
 from buildtest.executors.cobalt import CobaltExecutor
 from buildtest.executors.local import LocalExecutor
 from buildtest.executors.lsf import LSFExecutor
@@ -140,16 +140,20 @@ class BuildExecutor:
         """
 
         for executor_name in self.executors.keys():
-            create_dir(os.path.join(executor_root, executor_name))
+            create_dir(os.path.join(BUILDTEST_EXECUTOR_DIR, executor_name))
             executor_settings = self.executors[executor_name]._settings
 
             # if before_script field defined in executor section write content to var/executors/<executor>/before_script.sh
-            file = os.path.join(executor_root, executor_name, "before_script.sh")
+            file = os.path.join(
+                BUILDTEST_EXECUTOR_DIR, executor_name, "before_script.sh"
+            )
             content = executor_settings.get("before_script") or ""
             write_file(file, content)
 
             # after_script field defined in executor section write content to var/executors/<executor>/after_script.sh
-            file = os.path.join(executor_root, executor_name, "after_script.sh")
+            file = os.path.join(
+                BUILDTEST_EXECUTOR_DIR, executor_name, "after_script.sh"
+            )
             content = executor_settings.get("after_script") or ""
             write_file(file, content)
 

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -9,7 +9,12 @@ from buildtest.config import (
     resolve_settings_file,
     buildtest_configuration,
 )
-from buildtest.defaults import var_root, BUILDTEST_USER_HOME
+from buildtest.defaults import (
+    BUILDTEST_VAR_DIR,
+    BUILDTEST_USER_HOME,
+    BUILDTEST_EXECUTOR_DIR,
+    BUILDTEST_BUILDSPEC_DIR,
+)
 from buildtest.cli import get_parser
 from buildtest.cli.build import BuildTest
 from buildtest.system import system
@@ -35,14 +40,13 @@ def main():
     logger.info("Starting buildtest log")
 
     create_dir(BUILDTEST_USER_HOME)
-    create_dir(var_root)
+    create_dir(BUILDTEST_VAR_DIR)
+    create_dir(BUILDTEST_EXECUTOR_DIR)
+    create_dir(BUILDTEST_BUILDSPEC_DIR)
 
     # Create a build test system, and check requirements
     # BuildTestSystem()
     system.check()
-
-    # parser = BuildTestParser()
-    # args = parser.parse_options()
 
     parser = get_parser()
     args, extras = parser.parse_known_args()

--- a/scripts/regtest.py
+++ b/scripts/regtest.py
@@ -4,15 +4,13 @@ import os
 import shutil
 import sys
 
-from buildtest.defaults import BUILDTEST_USER_HOME, var_root
+from buildtest.defaults import BUILDTEST_USER_HOME
 from buildtest.utils.file import is_dir
 
 if not os.getenv("BUILDTEST_ROOT"):
     sys.exit("Please check your buildtest installation by running 'source setup.sh'")
 
 html_dir = os.path.join(os.getenv("BUILDTEST_ROOT"), "htmlcov")
-if is_dir(var_root):
-    shutil.rmtree(var_root)
 
 if is_dir(BUILDTEST_USER_HOME):
     shutil.rmtree(BUILDTEST_USER_HOME)


### PR DESCRIPTION
This PR helps address an issue if buildtest was deployed system wide (root) user and enable users to use buildtest. Previously buildtest will write some files under $BUILDTEST_ROOT which is problematic because users won't have access to $BUILDTEST_ROOT if its deployed system wide. By default files were written in $BUILDTEST_ROOT/var that impacts commands like `buildtest build`, `buildtest buildspec find`. 