### PR TITLE
add test coverage for buildtest cdash command.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 CHANGELOG
 =========
 
+v0.9.6 or v0.10.0 (TBD)
+------------------------
+
+- Add support for buildtest cdash integration for uploading test results using `buildtest cdash` command. The `buildtest cdash upload` command
+  can be used to upload test results to CDASH server. See `#721 <https://github.com/buildtesters/buildtest/pull/721>`_, `#733 <https://github.com/buildtesters/buildtest/pull/733>`_,  `#734 <https://github.com/buildtesters/buildtest/pull/734>`_
+- Change behavior of buildtest to write files to `$HOME/.buildtest` instead of `$BUILDTEST_ROOT`. See `#719 <https://github.com/buildtesters/buildtest/pull/719>`_.
+- Add command `buildtest report clear` to clear report file. In addition we add option to specify report file on command line. This can be specified using
+  `buildtest report --report_file`, `buildtest build --report_file`, and `buildtest inspect --report_file` see `#727 <https://github.com/buildtesters/buildtest/pull/727>`_, `#730 <https://github.com/buildtesters/buildtest/pull/730>`_.
+- Change behavior of `buildtest config executors` to print a list of executors, previously it was showing content of YAML. Now we have option `buildtest config executors --yaml` for YAML format.
+
+
 v0.9.5 (Mar 31, 2021)
 ----------------------
 

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -436,6 +436,8 @@ def cdash_menu(subparsers):
     """This method builds arguments for `buildtest cdash` command."""
 
     parser_cdash = subparsers.add_parser("cdash")
+    parser_cdash.add_argument("-c", "--config", help="Path to buildtest configuration")
+
     subparser = parser_cdash.add_subparsers(
         help="subcommands", description="CDASH operations", dest="cdash"
     )

--- a/buildtest/cli/cdash.py
+++ b/buildtest/cli/cdash.py
@@ -20,7 +20,7 @@ from buildtest.utils.tools import deep_get
 
 
 def cdash_cmd(args, default_configuration=None, open_browser=True):
-    """ This method is entry point for ``buildtest cdash`` command which implements uploading
+    """This method is entry point for ``buildtest cdash`` command which implements uploading
     results to CDASH server and command line interface to open CDASH project.
 
     :param args: Instance of ArgumentParser that contains arguments for ``buildtest cdash`` command
@@ -31,7 +31,6 @@ def cdash_cmd(args, default_configuration=None, open_browser=True):
     :type open_browser: optional
 
     """
-
 
     # Shown below is an example cdash setting in configuration file
     #     cdash:
@@ -44,18 +43,17 @@ def cdash_cmd(args, default_configuration=None, open_browser=True):
     if args.config:
         configuration = check_settings(args.config)
 
-
     if not configuration:
         sys.exit("Unable to load a configuration file")
-
 
     print("Reading configuration file: ", configuration.file)
 
     cdash_config = deep_get(configuration.target_config, "cdash")
 
-
     if not cdash_config:
-        sys.exit(f"We found no 'cdash' setting set in configuration file: {configuration.file}. Please specify 'cdash' setting in order to use 'buildtest cdash' command")
+        sys.exit(
+            f"We found no 'cdash' setting set in configuration file: {configuration.file}. Please specify 'cdash' setting in order to use 'buildtest cdash' command"
+        )
 
     if args.cdash == "view":
         # if url is specified on command line (buildtest cdash view --url) then open link as is
@@ -63,20 +61,22 @@ def cdash_cmd(args, default_configuration=None, open_browser=True):
             webbrowser.open(args.url)
             return
 
-
         url = cdash_config["url"]
         project = cdash_config["project"]
         target_url = urljoin(url, f"index.php?project={project}")
 
-        print("URL:",  target_url)
+        print("URL:", target_url)
         # check for url via requests, it can raise an exception if its invalid URL in that case we print a message
         try:
             r = requests.get(target_url)
         except requests.ConnectionError as err:
             print(err)
 
-            print("\nShown below is the CDASH settings from configuration file:", configuration.file)
-            print(yaml.dump(cdash_config,indent=2))
+            print(
+                "\nShown below is the CDASH settings from configuration file:",
+                configuration.file,
+            )
+            print(yaml.dump(cdash_config, indent=2))
             sys.exit(f"Invalid URL: {target_url}")
 
         # A 200 status code is valid URL, if its not found we exit before opening page in browser
@@ -88,7 +88,12 @@ def cdash_cmd(args, default_configuration=None, open_browser=True):
 
     if args.cdash == "upload":
 
-        upload_test_cdash(build_name=args.buildname,configuration=configuration, site=args.site, report_file=args.report_file)
+        upload_test_cdash(
+            build_name=args.buildname,
+            configuration=configuration,
+            site=args.site,
+            report_file=args.report_file,
+        )
 
 
 def upload_test_cdash(build_name, configuration, site=None, report_file=None):
@@ -107,7 +112,6 @@ def upload_test_cdash(build_name, configuration, site=None, report_file=None):
     :return:
     """
 
-
     cdash_url = configuration.target_config["cdash"]["url"]
     site_name = site or configuration.target_config["cdash"]["site"]
     project_name = configuration.target_config["cdash"]["project"]
@@ -118,7 +122,10 @@ def upload_test_cdash(build_name, configuration, site=None, report_file=None):
     try:
         r = requests.get(cdash_url)
     except requests.ConnectionError as err:
-        print("\nShown below is the CDASH settings from configuration file:", configuration.file)
+        print(
+            "\nShown below is the CDASH settings from configuration file:",
+            configuration.file,
+        )
         print(yaml.dump(configuration.target_config["cdash"], indent=2))
         sys.exit(err)
 
@@ -132,7 +139,6 @@ def upload_test_cdash(build_name, configuration, site=None, report_file=None):
     # '<cdash version="3.0.3">\n  <status>OK</status>\n  <message></message>\n  <md5>d41d8cd98f00b204e9800998ecf8427e</md5>\n</cdash>\n'
     if not re.search("<status>OK</status>", r.text):
         sys.exit(f"Invalid URL: {upload_url}")
-
 
     # For best CDash results, builds names should be consistent (ie not change every time).
 
@@ -385,4 +391,6 @@ def upload_test_cdash(build_name, configuration, site=None, report_file=None):
             print("PUT STATUS:", response.status)
             if match:
                 buildid = match.group(1)
-                print(f"You can view the results at: {cdash_url}/viewTest.php?buildid={buildid}")
+                print(
+                    f"You can view the results at: {cdash_url}/viewTest.php?buildid={buildid}"
+                )

--- a/buildtest/cli/cdash.py
+++ b/buildtest/cli/cdash.py
@@ -13,26 +13,53 @@ import zlib
 from datetime import datetime
 from urllib.request import urlopen, Request
 from urllib.parse import urlencode, urljoin
+from buildtest.config import check_settings
 from buildtest.defaults import BUILD_REPORT
 from buildtest.utils.file import resolve_path
 from buildtest.utils.tools import deep_get
 
 
-def cdash_cmd(args, configuration):
+def cdash_cmd(args, default_configuration=None, open_browser=True):
+    """ This method is entry point for ``buildtest cdash`` command which implements uploading
+    results to CDASH server and command line interface to open CDASH project.
+
+    :param args: Instance of ArgumentParser that contains arguments for ``buildtest cdash`` command
+    :type args: ArgumentParser
+    :param default_configuration: The loaded default configuration which is an instance of BuildTestConfiguration
+    :type default_configuration: BuildTestConfiguration, optional
+    :param open_browser: boolean to control if we open page in web browser using webbrowser.open. This is enabled by default, but can be turned off especially when running regression test where we don't want to see the page
+    :type open_browser: optional
+
+    """
+
 
     # Shown below is an example cdash setting in configuration file
     #     cdash:
     #       url: https://my.cdash.org
     #       project: buildtest
     #       site: laptop
+    configuration = default_configuration
+
+    # if buildtest cdash --config option is specified check the configuration file
+    if args.config:
+        configuration = check_settings(args.config)
+
+
+    if not configuration:
+        sys.exit("Unable to load a configuration file")
+
+
+    print("Reading configuration file: ", configuration.file)
+
     cdash_config = deep_get(configuration.target_config, "cdash")
+
 
     if not cdash_config:
         sys.exit(f"We found no 'cdash' setting set in configuration file: {configuration.file}. Please specify 'cdash' setting in order to use 'buildtest cdash' command")
 
     if args.cdash == "view":
         # if url is specified on command line (buildtest cdash view --url) then open link as is
-        if args.url:
+        if args.url and open_browser:
             webbrowser.open(args.url)
             return
 
@@ -56,57 +83,43 @@ def cdash_cmd(args, configuration):
         if not r.status_code == 200:
             sys.exit("Invalid URL")
 
-        webbrowser.open(target_url)
+        if open_browser:
+            webbrowser.open(target_url)
 
     if args.cdash == "upload":
 
-        upload_test_cdash(cdash_config,
-            args.site, args.buildname, args.report_file, configuration
-        )
+        upload_test_cdash(build_name=args.buildname,configuration=configuration, site=args.site, report_file=args.report_file)
 
 
-def upload_test_cdash(cdash_setting, site, buildname, report_file, configuration):
+def upload_test_cdash(build_name, configuration, site=None, report_file=None):
     """This method is responsible for reading report file and pushing results to CDASH
     server. User can specify cdash settings in configuration file or pass them in command line.
     The command ``buildtest cdash upload`` will upload results to CDASH.
 
-    :param cdash_setting: cdash settings loaded from configuration file
-    :type cdash_setting: dict
-    :param site: site name that shows up in CDASH
+    :param build_name: build name that shows up in CDASH
     :type site: str
-    :param buildname: build name that shows up in CDASH
-    :type site: str
-    :param report_file: Path to report file when uploading results. This is specified via ``buildtest cdash upload -r`` command
-    :type report_file: str
     :param configuration: Instance of BuildTestConfiguration class that contains the configuration file
     :type configuration: BuildTestConfiguration
+    :param site: site name that shows up in CDASH
+    :type site: str, optional
+    :param report_file: Path to report file when uploading results. This is specified via ``buildtest cdash upload -r`` command
+    :type report_file: str, optional
     :return:
     """
 
 
-    cdash_url = cdash_setting["url"]
-    project_name = cdash_setting["project"]
-    site_name = site or cdash_setting["site"]
-    build_name = buildname or cdash_setting["buildname"]
-
-
-    if not site_name:
-        sys.exit("Please specify site name")
+    cdash_url = configuration.target_config["cdash"]["url"]
+    site_name = site or configuration.target_config["cdash"]["site"]
+    project_name = configuration.target_config["cdash"]["project"]
 
     if not build_name:
         sys.exit("Please specify a buildname")
-
-    if not project_name:
-        sys.exit("Please specify a project name in cdash section")
-
-    if not cdash_url:
-        sys.exit("Please specify a CDASH url in configuration file or via 'buildtest cdash upload --url'")
 
     try:
         r = requests.get(cdash_url)
     except requests.ConnectionError as err:
         print("\nShown below is the CDASH settings from configuration file:", configuration.file)
-        print(yaml.dump(cdash_config, indent=2))
+        print(yaml.dump(configuration.target_config["cdash"], indent=2))
         sys.exit(err)
 
     if not requests.get(cdash_url).status_code == 200:

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -156,7 +156,7 @@ def main():
     elif args.subcommands == "cdash":
         from buildtest.cli.cdash import cdash_cmd
 
-        cdash_cmd(args, configuration)
+        cdash_cmd(args, default_configuration=configuration)
 
 
 if __name__ == "__main__":

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -12,7 +12,7 @@ Talks
 
     "`ECP Annual Meeting 2021 <https://whova.com/portal/webapp/ecpan_202104/Agenda/1511107>`_", "Apr 15, 2021", "`PDF <https://drive.google.com/file/d/134bZIWyp0AL60I1bW4oWywCYW0oV8ckB/view?usp=sharing>`_"
     "`High Performance Computing & Simulation 2020 <http://hpcs2020.cisedu.info/>`_ at `HPBench <http://hpcs2020.cisedu.info/2-conference/special-sessions/session02-hpbench>`_", "Mar 26, 2021", "`PDF <https://drive.google.com/file/d/13Otx6w1hBxdW4WwrK4v1QCp2d0dTNiV0/view?usp=sharing>`_"
-    "`SEA Improving Scientific Software 2021 <https://sea.ucar.edu/conference/2021>`_ ", "Mar 23, 2021", "`PDF <https://drive.google.com/file/d/1zs-l7a1GF7ws26Oq1zvFp3VaQ8xdHOhG/view?usp=sharing>`_"
+    "`SEA Improving Scientific Software 2021 <https://sea.ucar.edu/conference/2021>`_ ", "Mar 23, 2021", "`PDF <https://drive.google.com/file/d/1zs-l7a1GF7ws26Oq1zvFp3VaQ8xdHOhG/view?usp=sharing>`_, `VIDEO <https://www.youtube.com/watch?v=QBQCEnlgX3I>`_"
     "FOSDEM21_", "Feb 7, 2021", "`PDF <https://fosdem.org/2021/schedule/event/buildtest/attachments/slides/4399/export/events/attachments/buildtest/slides/4399/buildtest_fosdem21.pdf>`_"
     "`6th Easybuild User Meeting <https://easybuild.io/eum/>`_", "Jan 29, 2021", "`PDF <https://easybuild.io/eum/022_eum21_buildtest.pdf>`_, `VIDEO <https://youtu.be/FI3ES9B89Ig>`_"
     "FOSDEM20_", "Feb 2, 2020", "`PDF <https://archive.fosdem.org/2020/schedule/event/buildtest/attachments/slides/3602/export/events/attachments/buildtest/slides/3602/buildtest_fosdem20.pdf>`_, `VIDEO <https://ftp.heanet.ie/mirrors/fosdem-video/2020/UB5.132/buildtest.webm>`_"

--- a/tests/cli/cdash_examples/invalid_project.yml
+++ b/tests/cli/cdash_examples/invalid_project.yml
@@ -1,0 +1,37 @@
+system:
+  generic:
+    hostnames:
+    - .*
+    description: Generic System
+    moduletool: lmod
+    load_default_buildspecs: true
+    cdash:
+      url: "https://my.cdash.org"
+      project:  INVALID-PROJECT
+      site: laptop
+    executors:
+      local:
+        bash:
+          description: submit jobs on local machine using bash shell
+          shell: bash
+        sh:
+          description: submit jobs on local machine using sh shell
+          shell: sh
+        csh:
+          description: submit jobs on local machine using csh shell
+          shell: csh
+        zsh:
+          description: submit jobs on local machine using zsh shell
+          shell: zsh
+        python:
+          description: submit jobs on local machine using python shell
+          shell: python
+    compilers:
+      find:
+        gcc: "^(gcc)"
+      compiler:
+        gcc:
+          builtin_gcc:
+            cc: /usr/bin/gcc
+            fc: /usr/bin/gfortran
+            cxx: /usr/bin/g++

--- a/tests/cli/cdash_examples/invalid_url.yml
+++ b/tests/cli/cdash_examples/invalid_url.yml
@@ -1,0 +1,37 @@
+system:
+  generic:
+    hostnames:
+    - .*
+    description: Generic System
+    moduletool: lmod
+    load_default_buildspecs: true
+    cdash:
+      url: "https://my.cdash.XYZ.org"
+      project:  buildtest
+      site: laptop
+    executors:
+      local:
+        bash:
+          description: submit jobs on local machine using bash shell
+          shell: bash
+        sh:
+          description: submit jobs on local machine using sh shell
+          shell: sh
+        csh:
+          description: submit jobs on local machine using csh shell
+          shell: csh
+        zsh:
+          description: submit jobs on local machine using zsh shell
+          shell: zsh
+        python:
+          description: submit jobs on local machine using python shell
+          shell: python
+    compilers:
+      find:
+        gcc: "^(gcc)"
+      compiler:
+        gcc:
+          builtin_gcc:
+            cc: /usr/bin/gcc
+            fc: /usr/bin/gfortran
+            cxx: /usr/bin/g++

--- a/tests/cli/test_cdash.py
+++ b/tests/cli/test_cdash.py
@@ -4,28 +4,27 @@ from buildtest.cli.cdash import cdash_cmd
 from buildtest.config import check_settings
 from buildtest.defaults import DEFAULT_SETTINGS_FILE
 
+
 def test_cdash_view():
 
     configuration = check_settings()
+
     class args:
-        cdash =  "view"
+        cdash = "view"
         url = None
         config = None
 
-
     cdash_cmd(args=args, default_configuration=configuration, open_browser=False)
 
-
     class args:
-        cdash =  "view"
+        cdash = "view"
         config = DEFAULT_SETTINGS_FILE
         url = None
 
     cdash_cmd(args, open_browser=False)
 
+
 def test_cdash_upload():
-
-
     class args:
         cdash = "upload"
         config = DEFAULT_SETTINGS_FILE
@@ -33,12 +32,10 @@ def test_cdash_upload():
         site = None
         report_file = None
 
-
     cdash_cmd(args)
 
 
 def test_cdash_upload_exceptions():
-
     class args:
         cdash = "upload"
         config = DEFAULT_SETTINGS_FILE
@@ -50,15 +47,16 @@ def test_cdash_upload_exceptions():
     with pytest.raises(SystemExit):
         cdash_cmd(args)
 
-
     here = os.path.dirname(__file__)
+
     class args:
         cdash = "upload"
-        config = os.path.abspath(os.path.join(here, "cdash_examples", "invalid_url.yml"))
+        config = os.path.abspath(
+            os.path.join(here, "cdash_examples", "invalid_url.yml")
+        )
         buildname = "DEMO"
         site = None
         report_file = None
-
 
     # in configuration file we have invalid url to CDASH server
     with pytest.raises(SystemExit):
@@ -66,7 +64,9 @@ def test_cdash_upload_exceptions():
 
     class args:
         cdash = "upload"
-        config = os.path.abspath(os.path.join(here, "cdash_examples", "invalid_project.yml"))
+        config = os.path.abspath(
+            os.path.join(here, "cdash_examples", "invalid_project.yml")
+        )
         buildname = "DEMO"
         site = None
         report_file = None
@@ -74,4 +74,3 @@ def test_cdash_upload_exceptions():
     # in configuration file we have invalid project name in CDASH
     with pytest.raises(SystemExit):
         cdash_cmd(args)
-

--- a/tests/cli/test_cdash.py
+++ b/tests/cli/test_cdash.py
@@ -1,0 +1,77 @@
+import os
+import pytest
+from buildtest.cli.cdash import cdash_cmd
+from buildtest.config import check_settings
+from buildtest.defaults import DEFAULT_SETTINGS_FILE
+
+def test_cdash_view():
+
+    configuration = check_settings()
+    class args:
+        cdash =  "view"
+        url = None
+        config = None
+
+
+    cdash_cmd(args=args, default_configuration=configuration, open_browser=False)
+
+
+    class args:
+        cdash =  "view"
+        config = DEFAULT_SETTINGS_FILE
+        url = None
+
+    cdash_cmd(args, open_browser=False)
+
+def test_cdash_upload():
+
+
+    class args:
+        cdash = "upload"
+        config = DEFAULT_SETTINGS_FILE
+        buildname = "TESTING"
+        site = None
+        report_file = None
+
+
+    cdash_cmd(args)
+
+
+def test_cdash_upload_exceptions():
+
+    class args:
+        cdash = "upload"
+        config = DEFAULT_SETTINGS_FILE
+        buildname = None
+        site = None
+        report_file = None
+
+    # a buildname must be specified, a None will result in error
+    with pytest.raises(SystemExit):
+        cdash_cmd(args)
+
+
+    here = os.path.dirname(__file__)
+    class args:
+        cdash = "upload"
+        config = os.path.abspath(os.path.join(here, "cdash_examples", "invalid_url.yml"))
+        buildname = "DEMO"
+        site = None
+        report_file = None
+
+
+    # in configuration file we have invalid url to CDASH server
+    with pytest.raises(SystemExit):
+        cdash_cmd(args)
+
+    class args:
+        cdash = "upload"
+        config = os.path.abspath(os.path.join(here, "cdash_examples", "invalid_project.yml"))
+        buildname = "DEMO"
+        site = None
+        report_file = None
+
+    # in configuration file we have invalid project name in CDASH
+    with pytest.raises(SystemExit):
+        cdash_cmd(args)
+


### PR DESCRIPTION
Add command 'buildtest cdash -c' to specify alternate configuration
file when pushing data. This can be useful in regression test but could also
be used in CI pipeline where configuration file is stored in alternate
location not $HOME/.buildtest/config.yml