### PR TITLE
Add --max-pend-time command line option 

### DIFF
--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -50,7 +50,7 @@ def positive_number(value):
     """
 
     value = int(value)
-    if value <= 0 or value > 50:
+    if value <= 0:
         raise argparse.ArgumentTypeError(
             f"{value} must be a positive number between [1-50]"
         )
@@ -200,8 +200,8 @@ def build_menu(subparsers):
     )
     parser_build.add_argument(
         "--max-pend-time",
-        type=float,
-        help="Specify Maximum Pending Time for job before cancelling job. This only applies for batch job submission.",
+        type=positive_number,
+        help="Specify Maximum Pending Time (sec) for job before cancelling job. This only applies for batch job submission.",
     )
 
 

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -198,6 +198,11 @@ def build_menu(subparsers):
         "--report_file",
         help="Specify a report file where tests will be written.",
     )
+    parser_build.add_argument(
+        "--max-pend-time",
+        type=float,
+        help="Specify Maximum Pending Time for job before cancelling job. This only applies for batch job submission.",
+    )
 
 
 def buildspec_menu(subparsers):

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -49,6 +49,7 @@ class BuildTest:
         rebuild=None,
         buildtest_system=None,
         report_file=None,
+        max_pend_time=None,
     ):
         """The initializer method is responsible for checking input arguments for type
         check, if any argument fails type check we raise an error. If all arguments pass
@@ -76,6 +77,8 @@ class BuildTest:
         :type  buildtest_system: BuildTestSystem
         :param report_file: Specify location where report file is written
         :type report_file: str, optional
+        :param max_pend_time: Maximum Pend Time for batch job submission
+        :type report_file: float, optional
         """
 
         if buildspecs and not isinstance(buildspecs, list):
@@ -107,6 +110,7 @@ class BuildTest:
         self.exclude_buildspecs = exclude_buildspecs
         self.tags = tags
         self.executors = executors
+        self.max_pend_time = max_pend_time
 
         # get real path to log directory which accounts for variable expansion, user expansion, and symlinks
         self.logdir = resolve_path(
@@ -139,7 +143,7 @@ class BuildTest:
         self.detected_buildspecs = None
 
         self.builders = None
-        self.buildexecutor = BuildExecutor(self.configuration)
+        self.buildexecutor = BuildExecutor(self.configuration, self.max_pend_time)
         self.system = buildtest_system or system
         self.report_file = resolve_path(report_file, exist=False) or BUILD_REPORT
 

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -102,8 +102,14 @@ class BuildTest:
         if stage and not isinstance(stage, str):
             raise BuildTestError(f"{stage} is not of type str")
 
-        if rebuild and not isinstance(rebuild, int):
-            raise BuildTestError(f"{rebuild} is not of type int")
+        if rebuild:
+            if not isinstance(rebuild, int):
+                raise BuildTestError(f"{rebuild} is not of type int")
+
+            if rebuild > 50:
+                raise BuildTestError(
+                    f"--rebuild {rebuild} exceeds maximum rebuild limit of 50"
+                )
 
         self.configuration = configuration
         self.buildspecs = buildspecs

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -14,7 +14,7 @@ class BaseExecutor:
 
     type = "base"
 
-    def __init__(self, name, settings, site_configs, max_pend_time=None):
+    def __init__(self, name, settings, site_configs):
         """Initiate a base executor, meaning we provide a name (also held
         by the BuildExecutor base that holds it) and the loaded dictionary
         of config opts to parse.
@@ -33,7 +33,6 @@ class BaseExecutor:
         self._buildtestsettings = site_configs
         self.load()
         self.result = {}
-        self.max_pend_time = max_pend_time
 
     def load(self):
         """Load a particular configuration based on the name. This method

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -14,7 +14,7 @@ class BaseExecutor:
 
     type = "base"
 
-    def __init__(self, name, settings, site_configs):
+    def __init__(self, name, settings, site_configs, max_pend_time=None):
         """Initiate a base executor, meaning we provide a name (also held
         by the BuildExecutor base that holds it) and the loaded dictionary
         of config opts to parse.
@@ -33,6 +33,7 @@ class BaseExecutor:
         self._buildtestsettings = site_configs
         self.load()
         self.result = {}
+        self.max_pend_time = max_pend_time
 
     def load(self):
         """Load a particular configuration based on the name. This method

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -27,6 +27,11 @@ class CobaltExecutor(BaseExecutor):
     type = "cobalt"
     poll_cmd = "qstat"
 
+    def __init__(self, name, settings, site_configs, max_pend_time=None):
+
+        self.maxpendtime = max_pend_time
+        super().__init__(name, settings, site_configs)
+
     def load(self):
         """Load the a Cobalt executor configuration from buildtest settings."""
 
@@ -39,8 +44,15 @@ class CobaltExecutor(BaseExecutor):
         self.account = self._settings.get("account") or deep_get(
             self._buildtestsettings.target_config, "executors", "defaults", "account"
         )
-        self.max_pend_time = self._settings.get("max_pend_time") or deep_get(
-            self._buildtestsettings, "executors", "defaults", "max_pend_time"
+        self.max_pend_time = (
+            self.maxpendtime
+            or self._settings.get("max_pend_time")
+            or deep_get(
+                self._buildtestsettings.target_config,
+                "executors",
+                "defaults",
+                "max_pend_time",
+            )
         )
 
     def dispatch(self, builder):

--- a/buildtest/executors/lsf.py
+++ b/buildtest/executors/lsf.py
@@ -163,7 +163,7 @@ class LSFExecutor(BaseExecutor):
         )
 
         # if job state in PEND check if we need to cancel job by checking internal timer
-        if builder.job_state == "PEND":
+        if builder.job_state in ["PEND","PSUSP","USUSP", "SSUSP"]:
             builder.stop()
             self.logger.debug(f"Time Duration: {builder.duration}")
             self.logger.debug(f"Max Pend Time: {self.max_pend_time}")

--- a/buildtest/executors/lsf.py
+++ b/buildtest/executors/lsf.py
@@ -51,6 +51,11 @@ class LSFExecutor(BaseExecutor):
         "error_file",
     ]
 
+    def __init__(self, name, settings, site_configs, max_pend_time=None):
+
+        self.maxpendtime = max_pend_time
+        super().__init__(name, settings, site_configs)
+
     def load(self):
         """Load the a LSF executor configuration from buildtest settings."""
 
@@ -61,11 +66,15 @@ class LSFExecutor(BaseExecutor):
         self.account = self._settings.get("account") or deep_get(
             self._buildtestsettings.target_config, "executors", "defaults", "account"
         )
-        self.max_pend_time = self._settings.get("max_pend_time") or deep_get(
-            self._buildtestsettings.target_config,
-            "executors",
-            "defaults",
-            "max_pend_time",
+        self.max_pend_time = (
+            self.maxpendtime
+            or self._settings.get("max_pend_time")
+            or deep_get(
+                self._buildtestsettings.target_config,
+                "executors",
+                "defaults",
+                "max_pend_time",
+            )
         )
         self.queue = self._settings.get("queue")
 

--- a/buildtest/executors/pbs.py
+++ b/buildtest/executors/pbs.py
@@ -25,6 +25,11 @@ class PBSExecutor(BaseExecutor):
     type = "pbs"
     poll_cmd = "qstat"
 
+    def __init__(self, name, settings, site_configs, max_pend_time=None):
+
+        self.maxpendtime = max_pend_time
+        super().__init__(name, settings, site_configs)
+
     def load(self):
         """Load the a Cobalt executor configuration from buildtest settings."""
 
@@ -38,11 +43,15 @@ class PBSExecutor(BaseExecutor):
             self._buildtestsettings.target_config, "executors", "defaults", "account"
         )
 
-        self.max_pend_time = self._settings.get("max_pend_time") or deep_get(
-            self._buildtestsettings.target_config,
-            "executors",
-            "defaults",
-            "max_pend_time",
+        self.max_pend_time = (
+            self.maxpendtime
+            or self._settings.get("max_pend_time")
+            or deep_get(
+                self._buildtestsettings.target_config,
+                "executors",
+                "defaults",
+                "max_pend_time",
+            )
         )
 
     def dispatch(self, builder):

--- a/buildtest/executors/setup.py
+++ b/buildtest/executors/setup.py
@@ -228,7 +228,10 @@ class BuildExecutor:
         # poll LSF job
         elif executor.type == "lsf":
             # only poll job if its in PENDING or RUNNING state
-            if builder.job_state in ["PEND", "RUN"] or not builder.job_state:
+            if (
+                builder.job_state in ["PEND", "RUN", "PSUSP", "USUSP", "SSUSP"]
+                or not builder.job_state
+            ):
                 executor.poll(builder)
             # only gather result when job state in DONE. This implies job is complete
             elif builder.job_state == "DONE":
@@ -265,11 +268,6 @@ class BuildExecutor:
             elif builder.job_state in ["F"]:
                 executor.gather(builder)
                 poll_info["job_complete"] = True
-            # if job is on hold we cancel it asap
-            elif builder.job_state in ["H"]:
-                executor.cancel(builder)
-                poll_info["job_complete"] = True
-                poll_info["ignore_job"] = True
             else:
                 poll_info["job_complete"] = True
                 poll_info["ignore_job"] = True

--- a/buildtest/executors/setup.py
+++ b/buildtest/executors/setup.py
@@ -29,7 +29,7 @@ class BuildExecutor:
     **poll**: This is responsible for invoking ``poll`` method for corresponding executor from the builder object by checking job state
     """
 
-    def __init__(self, site_config):
+    def __init__(self, site_config, max_pend_time=None):
         """Initialize executors, meaning that we provide the buildtest
         configuration that are validated, and can instantiate
         each executor to be available.
@@ -56,6 +56,7 @@ class BuildExecutor:
                     f"{site_config.name}.slurm.{name}",
                     site_config.target_config["executors"]["slurm"][name],
                     site_config,
+                    max_pend_time,
                 )
 
         if site_config.lsfexecutors:
@@ -64,6 +65,7 @@ class BuildExecutor:
                     f"{site_config.name}.lsf.{name}",
                     site_config.target_config["executors"]["lsf"][name],
                     site_config,
+                    max_pend_time,
                 )
 
         if site_config.cobaltexecutors:
@@ -72,6 +74,7 @@ class BuildExecutor:
                     f"{site_config.name}.cobalt.{name}",
                     site_config.target_config["executors"]["cobalt"][name],
                     site_config,
+                    max_pend_time,
                 )
 
         if site_config.pbsexecutors:
@@ -80,6 +83,7 @@ class BuildExecutor:
                     f"{site_config.name}.pbs.{name}",
                     site_config.target_config["executors"]["pbs"][name],
                     site_config,
+                    max_pend_time,
                 )
         self.setup()
 

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -54,6 +54,11 @@ class SlurmExecutor(BaseExecutor):
         "WorkDir",
     ]
 
+    def __init__(self, name, settings, site_configs, max_pend_time=None):
+
+        self.maxpendtime = max_pend_time
+        super().__init__(name, settings, site_configs)
+
     def load(self):
         """Load the a slurm executor configuration from buildtest settings."""
 
@@ -69,7 +74,7 @@ class SlurmExecutor(BaseExecutor):
             self._buildtestsettings.target_config, "executors", "defaults", "account"
         )
         self.max_pend_time = (
-            self.max_pend_time
+            self.maxpendtime
             or self._settings.get("max_pend_time")
             or deep_get(
                 self._buildtestsettings.target_config,

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -68,11 +68,15 @@ class SlurmExecutor(BaseExecutor):
         self.account = self._settings.get("account") or deep_get(
             self._buildtestsettings.target_config, "executors", "defaults", "account"
         )
-        self.max_pend_time = self._settings.get("max_pend_time") or deep_get(
-            self._buildtestsettings.target_config,
-            "executors",
-            "defaults",
-            "max_pend_time",
+        self.max_pend_time = (
+            self.max_pend_time
+            or self._settings.get("max_pend_time")
+            or deep_get(
+                self._buildtestsettings.target_config,
+                "executors",
+                "defaults",
+                "max_pend_time",
+            )
         )
 
     def dispatch(self, builder):

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -69,6 +69,7 @@ def main():
             testdir=args.testdir,
             buildtest_system=system,
             report_file=args.report_file,
+            max_pend_time=args.max_pend_time,
         )
         cmd.build()
 

--- a/tests/cli/test_argparse.py
+++ b/tests/cli/test_argparse.py
@@ -6,13 +6,8 @@ from buildtest.cli import positive_number, handle_kv_string, get_parser
 
 def test_positive_number():
     assert 1 == positive_number(1)
-    assert 50 == positive_number("50")
     with pytest.raises(argparse.ArgumentTypeError) as err:
         positive_number(0)
-        print(err)
-
-    with pytest.raises(argparse.ArgumentTypeError) as err:
-        positive_number(51)
         print(err)
 
 

--- a/tests/test_ascent.py
+++ b/tests/test_ascent.py
@@ -31,6 +31,17 @@ def test_ascent():
     )
     cmd.build()
 
+    # This job will be held indefinitely but job will be cancelled by scheduler after 15sec once job pending time has reached max_pend_time
+    buildspec_files = os.path.join(here, "examples", "ascent", "hold_job.yml")
+    cmd = BuildTest(
+        configuration=bc,
+        buildspecs=[buildspec_files],
+        buildtest_system=system,
+        max_pend_time=15,
+    )
+    with pytest.raises(SystemExit):
+        cmd.build()
+
 
 def test_compilers_find_ascent():
 


### PR DESCRIPTION
This option can override executor setting for `max_pend_time` which can be useful when one wants to update how long jobs can stay pending in queue before they are cancelled without updating the configuration file.