### PR TITLE
Fix bug when copying files to stage directory 

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -235,7 +235,10 @@ class BuilderBase(ABC):
 
         # copy all files relative to buildspec file into stage directory
         for fname in Path(os.path.dirname(self.buildspec)).glob("*.*"):
-            shutil.copy2(fname, self.stage_dir)
+            if os.path.isdir(fname):
+                shutil.copytree(fname, os.path.join(self.stage_dir, fname))
+            else:
+                shutil.copy2(fname, self.stage_dir)
 
     def _get_scheduler_directives(self, bsub, sbatch, cobalt, pbs, batch):
         """Get Scheduler Directives for LSF, Slurm or Cobalt if we are processing


### PR DESCRIPTION
This addresses a bug picked up in CI job when we were unable to copy files during build process

```
+----------------------+
| Stage: Building Test |
+----------------------+ 
Traceback (most recent call last):
  File "/global/cscratch1/ecp-gitlab/siddiq90/buildtest-cori/builds/users/siddiq90/yreSDskr/0/siddiq90/buildtest-cori/buildtest/bin/buildtest", line 17, in <module>
    buildtest.main.main()
  File "/global/cscratch1/ecp-gitlab/siddiq90/buildtest-cori/builds/users/siddiq90/yreSDskr/0/siddiq90/buildtest-cori/buildtest/buildtest/main.py", line 74, in main
    cmd.build()
  File "/global/cscratch1/ecp-gitlab/siddiq90/buildtest-cori/builds/users/siddiq90/yreSDskr/0/siddiq90/buildtest-cori/buildtest/buildtest/cli/build.py", line 182, in build
    self.build_phase(printTable=True)
  File "/global/cscratch1/ecp-gitlab/siddiq90/buildtest-cori/builds/users/siddiq90/yreSDskr/0/siddiq90/buildtest-cori/buildtest/buildtest/cli/build.py", line 659, in build_phase
    builder.build()
  File "/global/cscratch1/ecp-gitlab/siddiq90/buildtest-cori/builds/users/siddiq90/yreSDskr/0/siddiq90/buildtest-cori/buildtest/buildtest/buildsystem/base.py", line 197, in build
    self._build_setup()
  File "/global/cscratch1/ecp-gitlab/siddiq90/buildtest-cori/builds/users/siddiq90/yreSDskr/0/siddiq90/buildtest-cori/buildtest/buildtest/buildsystem/base.py", line 238, in _build_setup
    shutil.copy2(fname, self.stage_dir)
  File "/global/homes/s/siddiq90/.conda/envs/buildtest/lib/python3.8/shutil.py", line 435, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/global/homes/s/siddiq90/.conda/envs/buildtest/lib/python3.8/shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
IsADirectoryError: [Errno 21] Is a directory: '/global/cscratch1/ecp-gitlab/siddiq90/buildtest-cori/builds/users/siddiq90/yreSDskr/0/siddiq90/buildtest-cori/buildspecs/system/etc_profile.d'
Running after_script
00:01
Running after script...
$ conda env remove -p $CI_PROJECT_DIR/.conda  -y
bash: line 102: conda: command not found
ERROR: Job failed: slurm job 1868899 failed, final state FAILED
```