### PR TITLE
add option --keep-stage-dir for preserving stage directory. 

### DIFF
--- a/buildtest/buildsystem/scriptbuilder.py
+++ b/buildtest/buildsystem/scriptbuilder.py
@@ -20,10 +20,10 @@ class ScriptBuilder(BuilderBase):
         write_file(script_path, python_content)
         self.logger.debug(f"[{self.name}]: Writing python script to: {script_path}")
         shutil.copy2(
-            script_path, os.path.join(self.run_dir, os.path.basename(script_path))
+            script_path, os.path.join(self.test_root, os.path.basename(script_path))
         )
         self.logger.debug(
-            f"[{self.name}]: Copying file: {script_path} to: {os.path.join(self.run_dir, os.path.basename(script_path))}"
+            f"[{self.name}]: Copying file: {script_path} to: {os.path.join(self.test_root, os.path.basename(script_path))}"
         )
 
         lines = [f"python {script_path}"]

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -203,6 +203,12 @@ def build_menu(subparsers):
         type=positive_number,
         help="Specify Poll Interval (sec) for polling batch jobs",
     )
+    parser_build.add_argument(
+        "-k",
+        "--keep-stage-dir",
+        action="store_true",
+        help="Keep stage directory after job completion.",
+    )
 
 
 def buildspec_menu(subparsers):

--- a/buildtest/cli/cdash.py
+++ b/buildtest/cli/cdash.py
@@ -202,7 +202,6 @@ def upload_test_cdash(build_name, configuration, site=None, report_file=None):
 
                 # testroot = test_data['testroot']
                 test["stagedir"] = test_data["stagedir"]
-                test["rundir"] = test_data["rundir"]
                 test["outfile"] = test_data["outfile"]
                 test["errfile"] = test_data["errfile"]
 
@@ -274,7 +273,6 @@ def upload_test_cdash(build_name, configuration, site=None, report_file=None):
             "build_script",
             "testpath",
             "stagedir",
-            "rundir",
             "outfile",
             "errfile",
             "starttime",

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -452,7 +452,6 @@ def update_report(valid_builders, report_file=BUILD_REPORT):
             "testroot",
             "testpath",
             "stagedir",
-            "rundir",
             "command",
             "outfile",
             "errfile",

--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -26,7 +26,7 @@ BUILDTEST_USER_HOME = os.path.join(userhome, ".buildtest")
 # dictionary used for storing status of builds
 USER_SETTINGS_FILE = os.path.join(BUILDTEST_USER_HOME, "config.yml")
 
-BUILDTEST_VAR_DIR = os.path.join(BUILDTEST_USER_HOME, "var")
+BUILDTEST_DEFAULT_TESTDIR = os.path.join(BUILDTEST_USER_HOME, "tests")
 BUILDTEST_EXECUTOR_DIR = os.path.join(BUILDTEST_USER_HOME, "executor")
 BUILDTEST_BUILDSPEC_DIR = os.path.join(BUILDTEST_USER_HOME, "buildspecs")
 

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -184,6 +184,8 @@ class CobaltExecutor(BaseExecutor):
         )
         builder.metadata["output"] = read_file(builder.metadata["outfile"])
         builder.metadata["error"] = read_file(builder.metadata["errfile"])
+        builder.copy_stage_files()
+
         cobaltlog = os.path.join(builder.stage_dir, builder.job.cobalt_log())
 
         self.logger.debug(f"Cobalt Log File written to {cobaltlog}")

--- a/buildtest/executors/local.py
+++ b/buildtest/executors/local.py
@@ -81,24 +81,19 @@ class LocalExecutor(BaseExecutor):
 
         builder.metadata["output"] = "".join(out)
         builder.metadata["error"] = "".join(err)
+
         self.write_testresults(builder)
         self.check_test_state(builder)
 
     def write_testresults(self, builder):
-        """This method writes test results into output and error file.
+        """Upon execution of tests we write stdout and stderr to output and error file.
 
         :param builder: builder object
         :type builder: BuilderBase, required
         """
 
-        # Keep an output file
-        run_output_file = os.path.join(
-            builder.metadata.get("testroot"),
-            "run",
-            builder.metadata.get("name"),
-        )
-        outfile = run_output_file + ".out"
-        errfile = run_output_file + ".err"
+        outfile = os.path.join(builder.stage_dir, builder.name) + ".out"
+        errfile = os.path.join(builder.stage_dir, builder.name) + ".err"
 
         self.logger.debug(f"Writing test output to file: {outfile}")
         write_file(outfile, builder.metadata["output"])
@@ -109,3 +104,5 @@ class LocalExecutor(BaseExecutor):
 
         builder.metadata["outfile"] = outfile
         builder.metadata["errfile"] = errfile
+
+        builder.copy_stage_files()

--- a/buildtest/executors/lsf.py
+++ b/buildtest/executors/lsf.py
@@ -165,6 +165,8 @@ class LSFExecutor(BaseExecutor):
         self.logger.debug(
             f"[{builder.name}] returncode: {builder.metadata['result']['returncode']}"
         )
+        builder.copy_stage_files()
+
         self.check_test_state(builder)
 
 

--- a/buildtest/executors/pbs.py
+++ b/buildtest/executors/pbs.py
@@ -151,6 +151,8 @@ class PBSExecutor(BaseExecutor):
         builder.metadata["output"] = read_file(builder.metadata["outfile"])
         builder.metadata["error"] = read_file(builder.metadata["errfile"])
 
+        builder.copy_stage_files()
+
         self.check_test_state(builder)
 
 

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -6,7 +6,6 @@ when initializing the executors.
 import logging
 import os
 import re
-import shutil
 
 from buildtest.executors.base import BaseExecutor
 from buildtest.executors.job import Job
@@ -155,24 +154,14 @@ class SlurmExecutor(BaseExecutor):
         builder.metadata["result"]["returncode"] = builder.job.exitcode()
 
         builder.metadata["outfile"] = os.path.join(
-            builder.job.workdir(), builder.metadata["name"] + ".out"
+            builder.job.workdir(), builder.name + ".out"
         )
         builder.metadata["errfile"] = os.path.join(
-            builder.job.workdir(), builder.metadata["name"] + ".err"
+            builder.job.workdir(), builder.name + ".err"
         )
 
-        shutil.copy2(
-            builder.metadata["outfile"],
-            os.path.join(
-                builder.run_dir, os.path.basename(builder.metadata["outfile"])
-            ),
-        )
-        shutil.copy2(
-            builder.metadata["errfile"],
-            os.path.join(
-                builder.run_dir, os.path.basename(builder.metadata["errfile"])
-            ),
-        )
+        builder.copy_stage_files()
+
         self.logger.debug(
             f"[{builder.name}] returncode: {builder.metadata['result']['returncode']}"
         )

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -4,7 +4,6 @@ import os
 import webbrowser
 from buildtest.config import SiteConfiguration
 from buildtest.defaults import (
-    BUILDTEST_VAR_DIR,
     BUILDTEST_USER_HOME,
     BUILDTEST_EXECUTOR_DIR,
     BUILDTEST_BUILDSPEC_DIR,
@@ -39,7 +38,6 @@ def main():
     logger = init_logfile()
 
     create_dir(BUILDTEST_USER_HOME)
-    create_dir(BUILDTEST_VAR_DIR)
     create_dir(BUILDTEST_EXECUTOR_DIR)
     create_dir(BUILDTEST_BUILDSPEC_DIR)
 
@@ -70,6 +68,7 @@ def main():
             report_file=args.report_file,
             max_pend_time=args.max_pend_time,
             poll_interval=args.poll_interval,
+            keep_stage_dir=args.keep_stage_dir,
         )
         cmd.build()
         return

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -121,6 +121,7 @@ def test_build_multi_executors():
     cmd.build()
 
 
+@pytest.mark.cli
 def test_run_only():
 
     system = BuildTestSystem()
@@ -139,6 +140,7 @@ def test_run_only():
     cmd.build()
 
 
+@pytest.mark.cli
 def test_skip_field():
 
     system = BuildTestSystem()
@@ -196,6 +198,7 @@ def test_build_rebuild():
     cmd.build()
 
 
+@pytest.mark.cli
 def test_invalid_buildspes():
 
     system = BuildTestSystem()
@@ -216,19 +219,45 @@ def test_invalid_buildspes():
     cmd.build()
 
 
-def test_build_disable_BUILDTEST_COLOR():
+@pytest.mark.cli
+def test_build_with_without_color():
 
     system = BuildTestSystem()
     system.check()
 
     buildspec_file = [os.path.join(BUILDTEST_ROOT, "tutorials", "python-shell.yml")]
-    os.environ["BUILDTEST_COLOR"] = "True"
+    os.environ["BUILDTEST_COLOR"] = "False"
 
     # BUILDTEST_COLOR=False buildtest build -b tutorials/python-shell.yml
     cmd = BuildTest(
         configuration=configuration,
         buildspecs=buildspec_file,
         buildtest_system=system,
+    )
+    cmd.build()
+
+    os.environ["BUILDTEST_COLOR"] = "True"
+
+    # BUILDTEST_COLOR=True buildtest build -b tutorials/python-shell.yml
+    cmd = BuildTest(
+        configuration=configuration,
+        buildspecs=buildspec_file,
+        buildtest_system=system,
+    )
+    cmd.build()
+
+
+@pytest.mark.cli
+def test_keep_stage():
+
+    system = BuildTestSystem()
+    system.check()
+    buildspec_file = [os.path.join(BUILDTEST_ROOT, "tutorials", "python-shell.yml")]
+    cmd = BuildTest(
+        configuration=configuration,
+        buildspecs=buildspec_file,
+        buildtest_system=system,
+        keep_stage_dir=True,
     )
     cmd.build()
 


### PR DESCRIPTION
This PR will allow buildtest to preserve stage directory which was its original behavior however the default is buildtest will remove the `stage` directory unless user specifies `--keep-stage-dir` option. This is available as part of `buildtest build` command.