### PR TITLE
Add support for spack buildsystem

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -77,6 +77,9 @@ class BuilderBase(ABC):
         # applicable for builders using batch executor.
         self.job_state = None
 
+        # this value holds the 'status' property from the schema which is assigned in the subclass
+        self.status = None
+
         self.buildspec = buildspec
         # strip .yml extension from file name
         file_name = re.sub("[.](yml)", "", os.path.basename(buildspec))
@@ -87,7 +90,7 @@ class BuilderBase(ABC):
         self.logger.debug(f"Processing Buildspec: {self.buildspec}")
         self.logger.debug(f"Processing Buildspec section: {self.name}")
 
-        # get type attribute from Executor class (local, slurm, cobalt, lsf)
+        # get type attribute from Executor class (local, slurm, cobalt, pbs, lsf)
         self.executor_type = buildexecutor.executors[self.executor].type
         self.buildexecutor = buildexecutor
         self._set_metadata_values()

--- a/buildtest/buildsystem/batch.py
+++ b/buildtest/buildsystem/batch.py
@@ -214,3 +214,82 @@ class PBSBatchScript(BatchScript):
                     ]
                 else:
                     continue
+
+
+def get_sbatch_lines(name, sbatch, batch):
+    """This method will return a list of lines with #SBATCH directive given an input ``sbatch`` and ``batch`` key.
+    :param name: The name of the Slurm job, output and error file.
+    :type name: str
+    :param sbatch: ``bsub`` key from buildspec that defines #BSUB directives
+    :type sbatch: list
+    :param batch: ``batch`` key from buildspec that defines a key/value pair of scheduler configuration
+    :type: dict
+    """
+
+    lines = []
+    script = SlurmBatchScript(batch=batch, sbatch=sbatch)
+    lines += script.get_headers()
+    lines += [f"#SBATCH --job-name={name}"]
+    lines += [f"#SBATCH --output={name}.out"]
+    lines += [f"#SBATCH --error={name}.err"]
+
+    return lines
+
+
+def get_bsub_lines(name, bsub, batch):
+    """This method will return a list of lines with #BSUB directive given an input ``bsub`` and ``batch`` key.
+    :param name: The name of the LSF job, output and error file.
+    :type name: str
+    :param bsub: ``bsub`` key from buildspec that defines #BSUB directives
+    :type bsub: list
+    :param batch: ``batch`` key from buildspec that defines a key/value pair of scheduler configuration
+    :type: dict
+    """
+
+    lines = []
+    script = LSFBatchScript(batch=batch, bsub=bsub)
+
+    lines += script.get_headers()
+    lines += [f"#BSUB -J {name}"]
+    lines += [f"#BSUB -o {name}.out"]
+    lines += [f"#BSUB -e {name}.err"]
+
+    return lines
+
+
+def get_pbs_lines(name, pbs, batch):
+    """This method will return a list of lines with #PBS directive given an input ``pbs`` and ``batch`` key.
+    :param name: The name of the PBS job, output and error file.
+    :type name: str
+    :param bsub: ``bsub`` key from buildspec that defines #BSUB directives
+    :type bsub: list
+    :param batch: ``batch`` key from buildspec that defines a key/value pair of scheduler configuration
+    :type: dict
+    """
+
+    lines = []
+    script = PBSBatchScript(batch=batch, pbs=pbs)
+
+    lines += script.get_headers()
+    lines += [f"#PBS -N {name}"]
+
+    return lines
+
+
+def get_cobalt_lines(name, cobalt, batch):
+    """This method will return a list of lines with #COBALT directive given an input ``cobalt`` and ``batch`` key.
+    :param name: The name of the Cobalt job, output and error file.
+    :type name: str
+    :param cobalt: ``bsub`` key from buildspec that defines #BSUB directives
+    :type cobalt: list
+    :param batch: ``batch`` key from buildspec that defines a key/value pair of scheduler configuration
+    :type: dict
+    """
+
+    lines = []
+    script = CobaltBatchScript(batch=batch, cobalt=cobalt)
+
+    lines += script.get_headers()
+    lines += [f"#COBALT --jobname {name}"]
+
+    return lines

--- a/buildtest/buildsystem/builders.py
+++ b/buildtest/buildsystem/builders.py
@@ -9,6 +9,7 @@ import re
 
 from buildtest.buildsystem.scriptbuilder import ScriptBuilder
 from buildtest.buildsystem.compilerbuilder import CompilerBuilder
+from buildtest.buildsystem.spack import SpackBuilder
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.system import system
 
@@ -95,7 +96,8 @@ class Builder:
                 elif recipe["type"] == "compiler":
 
                     self._build_compilers(name, recipe)
-
+                elif recipe["type"] == "spack":
+                    self.builders += self._generate_builders(recipe, name)
                 else:
                     print(
                         "%s is not recognized by buildtest, skipping." % recipe["type"]
@@ -156,6 +158,19 @@ class Builder:
                     compiler=compiler_name,
                     buildspec=self.bp.buildspec,
                     configuration=self.configuration,
+                    buildexecutor=self.buildexecutor,
+                    testdir=self.testdir,
+                )
+
+            elif (
+                re.fullmatch(recipe.get("executor"), executor)
+                and recipe["type"] == "spack"
+            ):
+                builder = SpackBuilder(
+                    name=name,
+                    recipe=recipe,
+                    executor=executor,
+                    buildspec=self.bp.buildspec,
                     buildexecutor=self.buildexecutor,
                     testdir=self.testdir,
                 )

--- a/buildtest/buildsystem/parser.py
+++ b/buildtest/buildsystem/parser.py
@@ -165,7 +165,7 @@ class BuildspecParser:
             recipe=self.recipe, schema=schema_table["global.schema.json"]["recipe"]
         )
 
-        self.schema_version = self.recipe.get("version", "latest")
+        self.schema_version = self.recipe.get("version")
 
         assert isinstance(self.recipe.get("buildspecs"), dict)
 

--- a/buildtest/buildsystem/spack.py
+++ b/buildtest/buildsystem/spack.py
@@ -41,7 +41,8 @@ class SpackBuilder(BuilderBase):
 
     def generate_script(self):
         """Method responsible for generating the content of test script for spack buildsystem"""
-        lines = []
+
+        lines = ["#!/bin/bash"]
 
         if self.recipe.get("sbatch"):
             lines += get_sbatch_lines(
@@ -72,7 +73,11 @@ class SpackBuilder(BuilderBase):
             )
 
         if self.recipe.get("pre_cmds"):
+            lines.append("\n")
+            lines.append("######## START OF PRE COMMANDS ######## ")
             lines += [self.recipe["pre_cmds"]]
+            lines.append("######## END OF PRE COMMANDS   ######## ")
+            lines.append("\n")
 
         spack_configuration = self.recipe["spack"]
         if spack_configuration.get("root"):
@@ -99,7 +104,11 @@ class SpackBuilder(BuilderBase):
                 lines.append(f"spack install {opts}")
 
         if self.recipe.get("post_cmds"):
+            lines.append("\n")
+            lines.append("######## START OF POST COMMANDS ######## ")
             lines += [self.recipe["post_cmds"]]
+            lines.append("######## END OF POST COMMANDS   ######## ")
+            lines.append("\n")
 
         return lines
 
@@ -144,12 +153,13 @@ class SpackBuilder(BuilderBase):
                 cmd += ["-d", env_dir]
 
             if spack_env["create"].get("manifest"):
-                manifest = resolve_path(spack_env["create"]["manifest"])
+                manifest = resolve_path(spack_env["create"]["manifest"], exist=False)
+                """
                 if not manifest:
                     raise BuildTestError(
                         f"Unable to find manifest file based on input: {spack_env['create']['manifest']}"
                     )
-
+                """
                 cmd.append(manifest)
 
             spack_env_create_line = " ".join(cmd)

--- a/buildtest/buildsystem/spack.py
+++ b/buildtest/buildsystem/spack.py
@@ -1,0 +1,154 @@
+"""This method defines the Spack buildsystem for the spack package manager (https://spack.readthedocs.io/en/latest/)
+by generating scripts that will do various spack operation. The SpackBuilder class will generate a test script using the
+schema definition 'spack-v1.0.schema.json' that defines how buildspecs are written.
+"""
+
+import os
+
+from buildtest.buildsystem.base import BuilderBase
+from buildtest.utils.file import resolve_path
+from buildtest.exceptions import BuildTestError
+
+
+class SpackBuilder(BuilderBase):
+
+    type = "spack"
+
+    def __init__(
+        self,
+        name,
+        recipe,
+        buildspec,
+        buildexecutor,
+        executor,
+        testdir=None,
+    ):
+        super().__init__(
+            name=name,
+            recipe=recipe,
+            buildspec=buildspec,
+            executor=executor,
+            buildexecutor=buildexecutor,
+            testdir=testdir,
+        )
+        self.generate_script()
+
+    def generate_script(self):
+        """Method responsible for generating the content of test script for spack buildsystem"""
+        lines = []
+        """
+        lines += self._get_scheduler_directives(
+            bsub=self.recipe.get("bsub"),
+            sbatch=self.recipe.get("sbatch"),
+            cobalt=self.recipe.get("cobalt"),
+            pbs=self.recipe.get("pbs"),
+            batch=self.recipe.get("batch"),
+        )
+        """
+        if self.recipe.get("pre_cmds"):
+            lines += [self.recipe["pre_cmds"]]
+
+        spack_configuration = self.recipe["spack"]
+        if spack_configuration.get("root"):
+            lines += [
+                "source "
+                + self._resolve_spack_root(
+                    spack_configuration["root"], spack_configuration.get("verify_spack")
+                )
+            ]
+
+        if spack_configuration.get("compiler_find"):
+            lines.append("spack compiler find")
+
+        if spack_configuration.get("env"):
+            lines += self._spack_environment(spack_configuration["env"])
+
+        if spack_configuration.get("install"):
+            opts = spack_configuration["install"].get("option") or ""
+            if spack_configuration["install"].get("specs"):
+                for spec in spack_configuration["install"]["specs"]:
+                    lines.append(f"spack install {opts} {spec}")
+            else:
+                lines.append(f"spack install {opts}")
+
+        if self.recipe.get("post_cmds"):
+            lines += [self.recipe["post_cmds"]]
+
+        return lines
+
+    def _resolve_spack_root(self, path, verify_spack=True):
+        """Given a path find the startup spack setup script to source."""
+
+        spack_root = resolve_path(path, exist=verify_spack)
+
+        if not spack_root:
+            raise BuildTestError(
+                f"Unable to find root of spack based on directory: {path}"
+            )
+
+        setup_script = os.path.join(spack_root, "share", "spack", "setup-env.sh")
+
+        sourced_script = resolve_path(setup_script, exist=verify_spack)
+
+        if not sourced_script:
+            raise BuildTestError(
+                f"Unable to find spack setup-env.sh script: {setup_script}"
+            )
+        return sourced_script
+
+    def _spack_environment(self, spack_env):
+        # create spack environment ('spack env create')
+        lines = []
+        if spack_env.get("create"):
+            opts = spack_env["create"].get("options") or ""
+            cmd = ["spack env create", opts]
+
+            # create spack environment from name
+            if spack_env["create"].get("name"):
+                cmd.append(spack_env["create"]["name"])
+
+            # create spack envrionment from directory. Note we don't need to check if directory exist because spack will create the directory via `spack env create -d <dir>`
+            elif spack_env["create"].get("dir"):
+                env_dir = resolve_path(spack_env["create"]["dir"], exist=False)
+                cmd += ["-d", env_dir]
+
+            if spack_env["create"].get("manifest"):
+                manifest = resolve_path(spack_env["create"]["manifest"])
+                if not manifest:
+                    raise BuildTestError(
+                        f"Unable to find manifest file based on input: {spack_env['create']['manifest']}"
+                    )
+
+                cmd.append(manifest)
+
+            spack_env_create_line = " ".join(cmd)
+            lines += [spack_env_create_line]
+
+        # activate environment ('spack env activate')
+        if spack_env.get("activate"):
+            opts = spack_env["activate"].get("options") or ""
+            cmd = ["spack env activate", opts]
+            # activate spack environment via name 'spack env activate <name>'
+            if spack_env["activate"].get("name"):
+                cmd.append(spack_env["activate"]["name"])
+
+            # activate spack environment via directory 'spack env activate -d <dir>'
+            elif spack_env["activate"].get("dir"):
+
+                env_dir = resolve_path(spack_env["activate"]["dir"], exist=False)
+                if not env_dir:
+                    raise BuildTestError(
+                        f"Unable to resolve directory: {spack_env['activate']['dir']} for activating spack environment via directory. Please specify a valid directory"
+                    )
+                cmd += ["-d", env_dir]
+
+            spack_env_activate_line = " ".join(cmd)
+            lines.append(spack_env_activate_line)
+
+        if spack_env.get("specs"):
+            for spec in spack_env["specs"]:
+                lines.append(f"spack add {spec}")
+
+        if spack_env.get("concretize"):
+            lines.append("spack concretize -f")
+        return lines

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -700,6 +700,8 @@ class BuildTest:
 
         for field in ["name", "id", "type", "executor", "tags", "testpath"]:
             table["script"][field] = []
+            table["spack"][field] = []
+
         for field in ["name", "id", "type", "executor", "tags", "compiler", "testpath"]:
             table["compiler"][field] = []
 
@@ -872,6 +874,27 @@ class BuildTest:
 
         print("\n")
 
+        # if we have any tests using 'script' schema we print all tests together since table columns are different
+        if len(table["spack"]["name"]) > 0:
+
+            headers = table["spack"].keys()
+            if os.getenv("BUILDTEST_COLOR") == "True":
+                headers = list(
+                    map(
+                        lambda x: colored(x, "blue", attrs=["bold"]),
+                        table["spack"].keys(),
+                    )
+                )
+
+            print(
+                tabulate(
+                    table["spack"],
+                    headers=headers,
+                    tablefmt="presto",
+                )
+            )
+
+        print("\n")
         # if we have any tests using 'compiler' schema we print all tests together since table columns are different
         if len(table["compiler"]["name"]) > 0:
 

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -7,7 +7,6 @@ from buildtest.defaults import (
     BUILDTEST_USER_HOME,
     BUILDTEST_EXECUTOR_DIR,
     BUILDTEST_BUILDSPEC_DIR,
-    BUILD_HISTORY_DIR,
 )
 from buildtest.cli import get_parser
 from buildtest.cli.build import BuildTest

--- a/buildtest/schemas/defaults.py
+++ b/buildtest/schemas/defaults.py
@@ -37,6 +37,16 @@ schema_table["compiler-v1.0.schema.json"]["recipe"] = load_schema(
     schema_table["compiler-v1.0.schema.json"]["path"]
 )
 
+
+schema_table["spack-v1.0.schema.json"] = {}
+schema_table["spack-v1.0.schema.json"]["path"] = os.path.join(
+    here, "spack-v1.0.schema.json"
+)
+schema_table["spack-v1.0.schema.json"]["recipe"] = load_schema(
+    schema_table["spack-v1.0.schema.json"]["path"]
+)
+
+
 schema_table["definitions.schema.json"] = {}
 schema_table["definitions.schema.json"]["path"] = os.path.join(
     here, "definitions.schema.json"
@@ -64,6 +74,9 @@ schema_store = {
     ]["recipe"],
     schema_table["script-v1.0.schema.json"]["recipe"]["$id"]: schema_table[
         "script-v1.0.schema.json"
+    ]["recipe"],
+    schema_table["spack-v1.0.schema.json"]["recipe"]["$id"]: schema_table[
+        "spack-v1.0.schema.json"
     ]["recipe"],
     schema_table["definitions.schema.json"]["recipe"]["$id"]: schema_table[
         "definitions.schema.json"

--- a/buildtest/schemas/defaults.py
+++ b/buildtest/schemas/defaults.py
@@ -5,17 +5,19 @@ from buildtest.schemas.utils import load_schema
 here = os.path.dirname(os.path.abspath(__file__))
 
 schema_table = {}
-schema_table["types"] = ["script", "compiler"]
+schema_table["types"] = ["script", "compiler", "spack"]
 schema_table["names"] = [
     "global.schema.json",
     "definitions.schema.json",
     "settings.schema.json",
     "compiler-v1.0.schema.json",
+    "spack-v1.0.schema.json",
     "script-v1.0.schema.json",
 ]
 schema_table["versions"] = {}
 schema_table["versions"]["script"] = ["1.0"]
 schema_table["versions"]["compiler"] = ["1.0"]
+schema_table["versions"]["spack"] = ["1.0"]
 
 schema_table["global.schema.json"] = {}
 schema_table["global.schema.json"]["path"] = os.path.join(here, "global.schema.json")

--- a/buildtest/schemas/examples/spack-v1.0.schema.json/invalid/examples.yml
+++ b/buildtest/schemas/examples/spack-v1.0.schema.json/invalid/examples.yml
@@ -1,0 +1,30 @@
+version: "1.0"
+buildspecs:
+  missing_root_to_spack:
+    type: spack
+    executor: generic.local.sh
+    description: 'root property required to run source $SPACK_ROOT/share/spack/setup-env.sh'
+    spack:
+      env:
+        create:
+          name: myproject
+        specs:
+          - m4
+          - zlib
+      install:
+        options: ''
+
+  specs_must_be_list_of_strings:
+    type: spack
+    executor: generic.local.sh
+    description: 'specs must be a list of strings '
+    spack:
+      root: $HOME/spack
+      env:
+        create:
+          name: myproject
+        specs:
+          - 1
+          - zlib
+      install:
+        options: ''

--- a/buildtest/schemas/examples/spack-v1.0.schema.json/valid/examples.yml
+++ b/buildtest/schemas/examples/spack-v1.0.schema.json/valid/examples.yml
@@ -13,6 +13,19 @@ buildspecs:
           - zlib
       install:
         options: ''
+  env_activate:
+    type: spack
+    executor: generic.local.sh
+    spack:
+      root: $HOME/spack/
+      env:
+        activate:
+          name: myproject
+        specs:
+          - m4
+          - zlib
+      install:
+        options: ''
 
   env_create_directory:
     type: spack
@@ -42,6 +55,7 @@ buildspecs:
 
   env_concretized_install:
     type: spack
+    description: run 'spack concretize -f' in an environment and install specs
     executor: generic.local.sh
     spack:
       root: $HOME/spack/
@@ -53,9 +67,25 @@ buildspecs:
       install:
         options: '--cache-only'
 
+  env_mirror:
+    type: spack
+    executor: generic.local.sh
+    description: declare spack mirror 'spack mirror add h5 /path/to/mirror' in environment
+    spack:
+      root: $HOME/spack/
+      env:
+        mirror:
+          h5: /path/to/mirror
+        create:
+          name: myproject
+          manifest: $HOME/spack.yaml
+      install:
+        options: '--cache-only'
+
   install_without_env:
     type: spack
     executor: generic.local.sh
+    description: install specs without environment
     spack:
       root: $HOME/spack/
       install:
@@ -66,6 +96,7 @@ buildspecs:
   pre_post_cmd_spack_install:
     type: spack
     executor: generic.local.sh
+    description: run commands before and after spack using pre_cmds and post_cmds
     pre_cmds: |
       cd $HOME
       git clone https://github.com/spack/spack
@@ -74,6 +105,5 @@ buildspecs:
       install:
         options: '--cache-only'
         specs: ['m4', 'bzip2']
-
     post_cmds: |
       spack find

--- a/buildtest/schemas/examples/spack-v1.0.schema.json/valid/examples.yml
+++ b/buildtest/schemas/examples/spack-v1.0.schema.json/valid/examples.yml
@@ -1,0 +1,79 @@
+version: "1.0"
+buildspecs:
+  env_create_name:
+    type: spack
+    executor: generic.local.sh
+    spack:
+      root: $HOME/spack/
+      env:
+        create:
+          name: myproject
+        specs:
+          - m4
+          - zlib
+      install:
+        options: ''
+
+  env_create_directory:
+    type: spack
+    executor: generic.local.sh
+    spack:
+      root: $HOME/spack/
+      env:
+        create:
+          directory: $HOME/spack-env/myproject
+        specs:
+          - 'm4'
+          - 'zlib@1.2.11'
+      install:
+        options: '--cache-only'
+
+  env_create_from_manifest:
+    type: spack
+    executor: generic.local.sh
+    spack:
+      root: $HOME/spack/
+      env:
+        create:
+          name: myproject
+          manifest: $HOME/spack.yaml
+      install:
+        options: '--cache-only'
+
+  env_concretized_install:
+    type: spack
+    executor: generic.local.sh
+    spack:
+      root: $HOME/spack/
+      env:
+        create:
+          name: myproject
+          manifest: $HOME/spack.yaml
+        concretize: true
+      install:
+        options: '--cache-only'
+
+  install_without_env:
+    type: spack
+    executor: generic.local.sh
+    spack:
+      root: $HOME/spack/
+      install:
+        options: '--cache-only'
+        specs: ['m4', 'bzip2']
+
+
+  pre_post_cmd_spack_install:
+    type: spack
+    executor: generic.local.sh
+    pre_cmds: |
+      cd $HOME
+      git clone https://github.com/spack/spack
+    spack:
+      root: $HOME/spack/
+      install:
+        options: '--cache-only'
+        specs: ['m4', 'bzip2']
+
+    post_cmds: |
+      spack find

--- a/buildtest/schemas/spack-v1.0.schema.json
+++ b/buildtest/schemas/spack-v1.0.schema.json
@@ -55,6 +55,9 @@
       "type": "string",
       "description": "Shell commands run after spack"
     },
+    "status": {
+      "$ref": "definitions.schema.json#/definitions/status"
+    },
     "spack":
     {
       "type": "object",
@@ -62,8 +65,17 @@
       "additionalProperties": false,
       "properties": {
         "root": {"type": "string"},
+        "compiler_find": {
+          "type":  "boolean",
+          "description": "Run ``spack compiler find`` if set to ``True``. This is run right after sourcing spack startup script."
+        },
         "env": {"$ref":  "#definitions/env"},
-        "install": {"$ref":  "#definitions/install"}
+        "install": {"$ref":  "#definitions/install"},
+        "verify_spack": {
+          "type": "boolean",
+          "description": "This boolean will determine if we need to check for file existence where spack is cloned via ``root`` property and file **$SPACK_ROOT/share/spack/setup-env.sh** exists. These checks can be disabled by setting this to ``False`` which can be useful if you dont want buildtest to raise exception during test generation process and test is skipped.",
+          "default": true
+        }
       }
     }
   },
@@ -72,14 +84,25 @@
       "type": "object",
       "properties": {
         "create": {
+          "description": "Create a spack environment via ``spack env create``",
           "type": "object",
           "properties": {
             "name": {"type": "string"},
             "manifest": {"type": "string"},
-            "options": {"type": "string"},
-            "dir": {"type": "string"}
+            "options": {"type": "string", "description": "Options passed to ``spack env create``"},
+            "dir": {"type": "string", "description": "Create a spack environment in a specific directory"}
           }
         },
+        "activate": {
+          "type": "object",
+          "description": "Activate a spack environment via ``spack env activate``",
+          "properties": {
+            "name": {"type": "string", "description": "Name of spack environment to activate."},
+            "options": {"type": "string", "description": "Options passed to ``spack env activate``"},
+            "dir": {"type": "string", "description": "Activate spack environment from directory."}
+          }
+        },
+        "mirror": {"$ref": "definitions.schema.json#/definitions/env"},
         "specs": {"$ref": "definitions.schema.json#/definitions/list_of_strings"},
         "concretize": {"type": "boolean"}
       }
@@ -87,8 +110,14 @@
     "install": {
       "type": "object",
       "properties": {
-        "options": {"type": "string"},
-        "specs": {"$ref": "definitions.schema.json#/definitions/list_of_strings"}
+        "options": {
+          "type": "string",
+          "description": "Pass options to ``spack install`` command"
+        },
+        "specs": {
+          "$ref": "definitions.schema.json#/definitions/list_of_strings",
+          "description":  "List of specs to install using ``spack install`` command"
+        }
       }
     }
   }

--- a/buildtest/schemas/spack-v1.0.schema.json
+++ b/buildtest/schemas/spack-v1.0.schema.json
@@ -1,0 +1,95 @@
+{
+  "$id": "spack-v1.0.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "spack schema version 1.0",
+  "description": "The spack schema is referenced using ``type: spack`` which is used for generating tests using spack package manager",
+  "type": "object",
+  "required": [
+    "type",
+    "executor",
+    "spack"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "type": "string",
+      "pattern": "^spack$",
+      "description": "Select schema type to use when validating buildspec. This must be set to 'spack'"
+    },
+    "description": {
+      "$ref": "definitions.schema.json#/definitions/description"
+    },
+    "executor": {
+      "$ref": "definitions.schema.json#/definitions/executor"
+    },
+    "sbatch": {
+      "$ref": "definitions.schema.json#/definitions/list_of_strings",
+      "description": "This field is used for specifying #SBATCH options in test script."
+    },
+    "bsub": {
+      "$ref": "definitions.schema.json#/definitions/list_of_strings",
+      "description": "This field is used for specifying #BSUB options in test script."
+    },
+    "cobalt": {
+      "$ref": "definitions.schema.json#/definitions/list_of_strings",
+      "description": "This field is used for specifying #COBALT options in test script."
+    },
+     "pbs": {
+      "$ref": "definitions.schema.json#/definitions/list_of_strings",
+      "description": "This field is used for specifying #PBS directives in test script."
+    },
+    "batch": {
+      "$ref": "definitions.schema.json#/definitions/batch"
+    },
+    "skip": {
+      "$ref": "definitions.schema.json#/definitions/skip"
+    },
+    "tags": {
+      "$ref": "definitions.schema.json#/definitions/tags"
+    },
+    "pre_cmds": {
+      "type": "string",
+      "description": "Shell commands run before spack"
+    },
+    "post_cmds": {
+      "type": "string",
+      "description": "Shell commands run after spack"
+    },
+    "spack":
+    {
+      "type": "object",
+      "required": ["root"],
+      "additionalProperties": false,
+      "properties": {
+        "root": {"type": "string"},
+        "env": {"$ref":  "#definitions/env"},
+        "install": {"$ref":  "#definitions/install"}
+      }
+    }
+  },
+  "definitions": {
+    "env": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "object",
+          "properties": {
+            "name": {"type": "string"},
+            "manifest": {"type": "string"},
+            "options": {"type": "string"},
+            "dir": {"type": "string"}
+          }
+        },
+        "specs": {"$ref": "definitions.schema.json#/definitions/list_of_strings"},
+        "concretize": {"type": "boolean"}
+      }
+    },
+    "install": {
+      "type": "object",
+      "properties": {
+        "options": {"type": "string"},
+        "specs": {"$ref": "definitions.schema.json#/definitions/list_of_strings"}
+      }
+    }
+  }
+}

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -115,12 +115,24 @@ def create_dir(dirname):
 
 def resolve_path(path, exist=True):
     """This method will resolve a file path to account for shell expansion and resolve paths in
-    when a symlink is provided in the file. This method assumes file already exists.
+     when a symlink is provided in the file. This method assumes file already exists.
 
-    :param path: file path to resolve
-    :type path: str, required
-    :return: return realpath to file if found otherwise return None
-    :rtype: str or None
+     :param path: file path to resolve
+     :type path: str, required
+     :param exist: expects a boolean to determine if filepath should be returned or None. By default, `exist` is `True`
+     and file is checked using `os.path.exist` to return full path.
+
+    >>> a = resolve_path("$HOME/.bashrc")
+    >>> assert a
+    >>> b = resolve_path("$HOME/.bashrc1", exist=False)
+    >>> assert b
+    >>> c = resolve_path("$HOME/.bashrc1", exist=True)
+    >>> assert not c
+
+
+     file is checked``os.path.exists`` after getting realpath using ``os.path.realpath()``.   resolve
+     :return: return realpath to file if found otherwise return None
+     :rtype: str or None
     """
 
     # if path not set return None
@@ -138,10 +150,7 @@ def resolve_path(path, exist=True):
     path = os.path.expanduser(path)
 
     real_path = os.path.realpath(path)
-    if os.path.exists(real_path):
-        return real_path
-
-    if not exist:
+    if os.path.exists(real_path) or not exist:
         return real_path
 
 

--- a/docs/buildspecs/spack.rst
+++ b/docs/buildspecs/spack.rst
@@ -1,0 +1,186 @@
+.. _spack_schema:
+
+Spack Schema
+=============
+
+.. Note:: This feature is in active development.
+
+
+buildtest can generate tests for the `spack <https://spack.readthedocs.io/en/latest/>`_ package manager which can be
+used if you want to install or test packages as part of a repeatable process. You must set ``type: spack`` property
+in buildspec to use the spack schema for validating the buildspec test. Currently, we have
+`spack-v1.0.schema.json <https://github.com/buildtesters/buildtest/blob/devel/buildtest/schemas/spack-v1.0.schema.json>`_
+JSON schema that defines the structure of how tests are to be written in buildspec. Shown below is the schema header. The
+**required** properties are ``type``, ``executor`` and ``spack``.
+
+.. code-block:: json
+
+      "$id": "spack-v1.0.schema.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "spack schema version 1.0",
+      "description": "The spack schema is referenced using ``type: spack`` which is used for generating tests using spack package manager",
+      "type": "object",
+      "required": [
+        "type",
+        "executor",
+        "spack"
+      ],
+
+Install Specs
+---------------
+
+Let's start off with a simple example where we create a test that can ``spack install zlib``. Shown below
+is a test named **install_zlib**. The **spack** keyword is a JSON object, in this test we define the root
+of spack using the ``root`` keyword which informs buildtest where spack is located. buildtest will automatically
+check the path and source the startup script. Next we see the keyword ``install`` which is a JSON object which
+contains a field ``specs`` which is a list of spack specs to install. The ``specs`` is property is a list of string types
+and each item will added as a separate command as follows: ``spack install <spec>``
+
+The schema is designed to mimic spack commands which will be clear with more examples.
+
+.. program-output:: cat ../tutorials/spack/install_zlib.yml
+
+If you build this test and inspect the generated script, buildtest will source spack
+startup script - **source $SPACK_ROOT/share/spack/setup-env.sh** based on the ``root`` property. In this example,
+we have spack cloned in **$HOME/spack** which is **/Users/siddiq90/spack** and buildtest will find the
+startup script which is in ``share/spack/setup-env.sh``.
+
+.. code-block:: shell
+
+    source /Users/siddiq90/spack/share/spack/setup-env.sh
+    spack install  zlib
+
+
+Spack Environment
+-----------------
+
+buildtest can generate scripts to make use of `spack environments <https://spack.readthedocs.io/en/latest/environments.html>`_ which
+can be useful if you want to install or test specs in an isolated environment.
+
+Currently, we can create spack environment (``spack env create``) via name, directory and manifest file (``spack.yaml``, ``spack.lock``) and pass any
+options to **spack env create** command. Furthermore, we can activate existing spack environment via name or directory using
+``spack env activate`` and pass options to the command.
+
+
+Activate Spack Environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In this next example, we will activate an existing environment ``m4`` and add spec for **m4** and concretize the spack environment.
+The ``env`` is an object that mimics the ``spack env`` command. The ``activate`` field maps to ``spack env activate`` command.
+The **name** property is of ``type: string`` which is name of spack environment you want to activate. The ``specs`` property in **env** section
+maps to ``spack add <specs`` instead of ``spack install``.
+
+The property ``concretize: true`` will run ``spack concretize`` command that is only available as part of the ``env`` object since this command
+is only applicable in spack environments.
+
+.. program-output:: cat ../tutorials/spack/concretize_m4.yml
+
+If we build this test and inspect the generated test we see that spack will activate a spack environment **m4**, add specs in spack
+environment via ``spack add m4`` and concretize the environment. The ``concretize`` is a boolean type, if its ``true`` we will run ``spack concretize -f``,
+if its ``false`` this command will not be in script.
+
+.. code-block:: shell
+
+    source /Users/siddiq90/spack/share/spack/setup-env.sh
+    spack env activate  m4
+    spack add m4
+    spack concretize -f
+
+If we inspect the output file we see that m4 was concretized in the spack environment.
+
+.. code-block:: shell
+
+    ==> Package m4 was already added to m4
+    ==> Concretized m4
+    [+]  volmsbn  m4@1.4.19%apple-clang@11.0.3+sigsegv arch=darwin-bigsur-skylake
+    [+]  bc6kuc4      ^libsigsegv@2.13%apple-clang@11.0.3 arch=darwin-bigsur-skylake
+
+Create a Spack Environment by name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In this next example, we will create a spack environment named ``m4_zlib`` that will install
+`m4` and `zlib` spec. The **create** field is a JSON object that maps to ``spack env create``
+command which can pass some arguments in the form of key/value pairs. The ``name`` property
+in **create** section is used to create a spack environment by name.
+
+The ``compiler_find: true`` is a boolean that determines if we need to find compilers in spack via
+``spack compiler find``. This can be useful if you need to find compilers so spack can install specs
+with a preferred compiler otherwise spack may have issues concretizing or install specs.
+buildtest will run **spack compiler find** after sourcing spack.
+
+!!! Note:: The ``compiler_find`` option may not be useful if your compilers are already defined in one of your
+  configuration scopes or ``spack.yaml`` that is part of your spack environment.
+
+The ``option`` field can pass any command line arguments to ``spack install`` command
+and this field is available for other properties.
+
+.. program-output:: cat ../tutorials/spack/env_install.yml
+
+
+If we build this test and see generated test we see that buildtest will create a
+spack environment `m4_zlib` and activate the environment, add **m4** and **zlib**,
+concretize the environment and install the specs.
+
+.. code-block:: shell
+
+    source /Users/siddiq90/spack/share/spack/setup-env.sh
+    spack compiler find
+    spack env create  m4_zlib
+    spack env activate  m4_zlib
+    spack add m4
+    spack add zlib
+    spack concretize -f
+    spack install --keep-prefix
+
+
+Now let's examine the output of this test, shown below is the summary of this test, as you can
+see we have successfully installed **m4** and **zlib** in a spack environment ``m4_zlib``.
+
+.. code-block:: shell
+
+    ==> Found no new compilers
+    ==> Compilers are defined in the following files:
+        /Users/siddiq90/.spack/darwin/compilers.yaml
+    ==> Updating view at /Users/siddiq90/spack/var/spack/environments/m4_zlib/.spack-env/view
+    ==> Created environment 'm4_zlib' in /Users/siddiq90/spack/var/spack/environments/m4_zlib
+    ==> You can activate this environment with:
+    ==>   spack env activate m4_zlib
+    ==> Adding m4 to environment m4_zlib
+    ==> Adding zlib to environment m4_zlib
+    ==> Concretized m4
+    [+]  volmsbn  m4@1.4.19%apple-clang@11.0.3+sigsegv arch=darwin-bigsur-skylake
+    [+]  bc6kuc4      ^libsigsegv@2.13%apple-clang@11.0.3 arch=darwin-bigsur-skylake
+    ==> Concretized zlib
+     -   2hw3hzd  zlib@1.2.11%apple-clang@11.0.3+optimize+pic+shared arch=darwin-bigsur-skylake
+    ==> Updating view at /Users/siddiq90/spack/var/spack/environments/m4_zlib/.spack-env/view
+    ==> Installing environment m4_zlib
+    ==> Installing zlib-1.2.11-2hw3hzdfy7e2ndzojgqoq472m5flsloj
+    ==> No binary for zlib-1.2.11-2hw3hzdfy7e2ndzojgqoq472m5flsloj found: installing from source
+    ==> Fetching https://mirror.spack.io/_source-cache/archive/c3/c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1.tar.gz
+    ==> No patches needed for zlib
+    ==> zlib: Executing phase: 'install'
+    ==> zlib: Successfully installed zlib-1.2.11-2hw3hzdfy7e2ndzojgqoq472m5flsloj
+      Fetch: 0.84s.  Build: 6.98s.  Total: 7.82s.
+    [+] /Users/siddiq90/spack/opt/spack/darwin-bigsur-skylake/apple-clang-11.0.3/zlib-1.2.11-2hw3hzdfy7e2ndzojgqoq472m5flsloj
+    ==> Updating view at /Users/siddiq90/spack/var/spack/environments/m4_zlib/.spack-env/view
+
+We can create spack environment from a directory using the ``dir`` property that
+is available as part of ``create`` and ``activate`` field. In this next example we
+create a spack environment in our $HOME directory and concretize **m4** in the spack
+environment
+
+.. program-output:: cat ../tutorials/spack/env_create_directory.yml
+
+When creating spack environment using directory, buildtest will automatically add the
+``-d`` option which is required when creating spack environments. However, one can also pass
+this using the ``option`` field. Shown below is the generated script for the above test.
+
+
+.. code-block:: shell
+
+    source /Users/siddiq90/spack/share/spack/setup-env.sh
+    spack env create  -d /Users/siddiq90/spack-envs/m4
+    spack env activate  -d /Users/siddiq90/spack-envs/m4
+    spack add m4
+    spack concretize -f
+

--- a/docs/buildspecs/spack.rst
+++ b/docs/buildspecs/spack.rst
@@ -47,9 +47,9 @@ startup script which is in ``share/spack/setup-env.sh``.
 
 .. code-block:: shell
 
+    #!/bin/bash
     source /Users/siddiq90/spack/share/spack/setup-env.sh
     spack install  zlib
-
 
 Spack Environment
 -----------------
@@ -60,7 +60,6 @@ can be useful if you want to install or test specs in an isolated environment.
 Currently, we can create spack environment (``spack env create``) via name, directory and manifest file (``spack.yaml``, ``spack.lock``) and pass any
 options to **spack env create** command. Furthermore, we can activate existing spack environment via name or directory using
 ``spack env activate`` and pass options to the command.
-
 
 Activate Spack Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -81,6 +80,7 @@ if its ``false`` this command will not be in script.
 
 .. code-block:: shell
 
+    #!/bin/bash
     source /Users/siddiq90/spack/share/spack/setup-env.sh
     spack env activate  m4
     spack add m4
@@ -108,14 +108,14 @@ The ``compiler_find: true`` is a boolean that determines if we need to find comp
 with a preferred compiler otherwise spack may have issues concretizing or install specs.
 buildtest will run **spack compiler find** after sourcing spack.
 
-!!! Note:: The ``compiler_find`` option may not be useful if your compilers are already defined in one of your
-  configuration scopes or ``spack.yaml`` that is part of your spack environment.
+.. note::
+    The ``compiler_find`` option may not be useful if your compilers are already defined in
+    one of your configuration scopes or ``spack.yaml`` that is part of your spack environment.
 
 The ``option`` field can pass any command line arguments to ``spack install`` command
 and this field is available for other properties.
 
 .. program-output:: cat ../tutorials/spack/env_install.yml
-
 
 If we build this test and see generated test we see that buildtest will create a
 spack environment `m4_zlib` and activate the environment, add **m4** and **zlib**,
@@ -123,6 +123,7 @@ concretize the environment and install the specs.
 
 .. code-block:: shell
 
+    #!/bin/bash
     source /Users/siddiq90/spack/share/spack/setup-env.sh
     spack compiler find
     spack env create  m4_zlib
@@ -137,6 +138,7 @@ Now let's examine the output of this test, shown below is the summary of this te
 see we have successfully installed **m4** and **zlib** in a spack environment ``m4_zlib``.
 
 .. code-block:: shell
+    :emphasize-lines: 16-24
 
     ==> Found no new compilers
     ==> Compilers are defined in the following files:
@@ -164,6 +166,9 @@ see we have successfully installed **m4** and **zlib** in a spack environment ``
     [+] /Users/siddiq90/spack/opt/spack/darwin-bigsur-skylake/apple-clang-11.0.3/zlib-1.2.11-2hw3hzdfy7e2ndzojgqoq472m5flsloj
     ==> Updating view at /Users/siddiq90/spack/var/spack/environments/m4_zlib/.spack-env/view
 
+Creating Spack Environment from Directory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 We can create spack environment from a directory using the ``dir`` property that
 is available as part of ``create`` and ``activate`` field. In this next example we
 create a spack environment in our $HOME directory and concretize **m4** in the spack
@@ -175,12 +180,99 @@ When creating spack environment using directory, buildtest will automatically ad
 ``-d`` option which is required when creating spack environments. However, one can also pass
 this using the ``option`` field. Shown below is the generated script for the above test.
 
-
 .. code-block:: shell
+    :emphasize-lines: 3-4
 
+    #!/bin/bash
     source /Users/siddiq90/spack/share/spack/setup-env.sh
     spack env create  -d /Users/siddiq90/spack-envs/m4
     spack env activate  -d /Users/siddiq90/spack-envs/m4
     spack add m4
     spack concretize -f
 
+buildtest will create environment first followed by activating the spack environment.
+
+Create Spack Environment from Manifest File (spack.yaml, spack.lock)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Spack can create environments from `spack.yaml` or `spack.lock` which can be useful if you
+already have a spack configuration that works for your system. When you are creating a spack
+environment, you can use the ``manifest`` property to specify path to your ``spack.yaml`` or ``spack.lock``.
+buildtest will not enforce that manifest names be **spack.yaml** or **spack.lock** since spack allows
+one to create spack environment from arbitrary name so long as it is a valid spack configuration.
+
+Shown below is an example buildspec that generates a test from a manifest file. The ``manifest`` property
+is of ``type: string`` and this is only available as part of ``create`` property.
+
+.. program-output:: cat ../tutorials/spack/env_create_manifest.yml
+
+If we build this test and inspect the generated script we see ``spack env create`` command
+will create an environment **manifest_example** using the manifest file that we provided.
+
+.. code-block:: shell
+    :emphasize-lines: 3
+
+    #!/bin/bash
+    source /Users/siddiq90/spack/share/spack/setup-env.sh
+    spack env create  manifest_example /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/spack/example/spack.yaml
+    spack env activate  manifest_example
+    spack concretize -f
+
+Pre and Post Commands
+----------------------
+
+The spack schema supports ability to write arbitrary shell script content using the ``pre_cmds`` and ``post_cmds``
+field that are of ``type: string`` and buildtest will insert the content into the test exactly as it is defined by
+these two fields.
+
+In this next example, we will test an installation of `zlib` by cloning spack from upstream and use ``pre_cmds`` field
+to specify where we will clone spack. In this example, we will clone spack under **/tmp**. Since we don't have a valid
+root of spack since test hasn't been run, we can ignore check for spack paths by specifying ``verify_spack: false`` which
+informs buildtest to skip spack path check. Generally, buildtest will raise an exception if path specified by ``root`` is
+invalid and if ``$SPACK_ROOT/share/spack/setup-env.sh`` doesn't exist since this is the file that must be sourced.
+
+The ``pre_cmds`` are shell commands that are run before sourcing spack, whereas the ``post_cmds`` are run at the very
+end of the script. In the `post_cmds`, we will ``spack find`` that will be run after ``spack install``.
+We remove spack root (``$SPACK_ROOT``) so that this test can be rerun again.
+
+.. program-output:: cat ../tutorials/spack/pre_post_cmds.yml
+
+If we build this test and inspect the generated script we see the following
+
+.. code-block:: shell
+    :emphasize-lines: 4-8,15-18
+
+    #!/bin/bash
+
+
+    ######## START OF PRE COMMANDS ########
+    cd /tmp
+    git clone https://github.com/spack/spack
+
+    ######## END OF PRE COMMANDS   ########
+
+
+    source /private/tmp/spack/share/spack/setup-env.sh
+    spack install  zlib
+
+
+    ######## START OF POST COMMANDS ########
+    spack find
+    rm -rf $SPACK_ROOT
+    ######## END OF POST COMMANDS   ########
+
+If we inspect the output, we see that `zlib` is installed as shown in output from ``spack find``
+
+.. code-block:: shell
+    :emphasize-lines: 9-10
+
+    ==> Installing zlib-1.2.11-2hw3hzdfy7e2ndzojgqoq472m5flsloj
+    ==> No binary for zlib-1.2.11-2hw3hzdfy7e2ndzojgqoq472m5flsloj found: installing from source
+    ==> Fetching https://mirror.spack.io/_source-cache/archive/c3/c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1.tar.gz
+    ==> No patches needed for zlib
+    ==> zlib: Executing phase: 'install'
+    ==> zlib: Successfully installed zlib-1.2.11-2hw3hzdfy7e2ndzojgqoq472m5flsloj
+      Fetch: 0.50s.  Build: 5.90s.  Total: 6.40s.
+    [+] /private/tmp/spack/opt/spack/darwin-bigsur-skylake/apple-clang-11.0.3/zlib-1.2.11-2hw3hzdfy7e2ndzojgqoq472m5flsloj
+    -- darwin-bigsur-skylake / apple-clang@11.0.3 -------------------
+    zlib@1.2.11

--- a/docs/writing_buildspecs.rst
+++ b/docs/writing_buildspecs.rst
@@ -9,5 +9,6 @@ Writing buildspecs
    buildspecs/buildspec_overview
    buildspecs/global
    buildspecs/compiler
+   buildspecs/spack
    buildspecs/batch_support
    buildspecs/schema_examples

--- a/tests/schema_tests/test_spack.py
+++ b/tests/schema_tests/test_spack.py
@@ -1,0 +1,88 @@
+import os
+import pytest
+import re
+
+from jsonschema.exceptions import ValidationError
+from buildtest.defaults import SCHEMA_ROOT
+from buildtest.schemas.defaults import custom_validator
+from buildtest.schemas.utils import load_recipe, load_schema
+
+here = os.path.dirname(os.path.abspath(__file__))
+schemaroot = os.path.join(os.path.dirname(here), "schemas")
+
+schema_name = "spack"
+schema_file = f"{schema_name}-v1.0.schema.json"
+schema_path = os.path.join(SCHEMA_ROOT, schema_file)
+
+spack_schema_examples = os.path.join(SCHEMA_ROOT, "examples", schema_file)
+
+
+def check_invalid_recipes(recipes, invalids, loaded, version):
+    for recipe in recipes:
+        assert recipe
+        assert re.search("(yml|yaml)$", recipe)
+        recipe_path = os.path.join(invalids, recipe)
+        content = load_recipe(recipe_path)
+
+        # Ensure version is correct in header
+        assert content["version"] == version
+        del content["version"]
+
+        # For each section, assume folder type and validate
+        for name in content["buildspecs"].keys():
+            with pytest.raises(ValidationError) as excinfo:
+                custom_validator(recipe=content["buildspecs"][name], schema=loaded)
+            print(excinfo.type, excinfo.value)
+            print("Testing %s from recipe %s should be invalid" % (name, recipe))
+
+
+def check_valid_recipes(recipes, valids, loaded, version):
+    for recipe in recipes:
+        assert recipe
+        assert re.search("(yml|yaml)$", recipe)
+        recipe_path = os.path.join(valids, recipe)
+        content = load_recipe(recipe_path)
+
+        # Ensure version is correct in header
+        assert content["version"] == version
+        del content["version"]
+
+        # For each section, assume folder type and validate
+        for name in content["buildspecs"].keys():
+            print("Testing %s from recipe %s should be valid" % (name, recipe))
+            custom_validator(recipe=content["buildspecs"][name], schema=loaded)
+
+
+@pytest.mark.schema
+def test_spack_examples():
+
+    loaded = load_schema(schema_path)
+    assert isinstance(loaded, dict)
+
+    # Assert is named correctly
+    print("Getting version of %s" % schema_file)
+    match = re.search(
+        "%s-v(?P<version>[0-9]{1}[.][0-9]{1})[.]schema[.]json" % schema_name,
+        schema_file,
+    )
+    print(match)
+    assert match
+
+    # Ensure we found a version
+    assert match.groups()
+    version = match["version"]
+
+    invalids = os.path.join(spack_schema_examples, "invalid")
+    valids = os.path.join(spack_schema_examples, "valid")
+    # print(invalids, valids)
+    assert invalids
+    assert valids
+
+    invalid_recipes = os.listdir(invalids)
+    valid_recipes = os.listdir(valids)
+
+    assert invalid_recipes
+    assert valid_recipes
+
+    check_valid_recipes(valid_recipes, valids, loaded, version)
+    check_invalid_recipes(invalid_recipes, invalids, loaded, version)

--- a/tutorials/spack/concretize_m4.yml
+++ b/tutorials/spack/concretize_m4.yml
@@ -1,0 +1,15 @@
+version: "1.0"
+buildspecs:
+  concretize_m4_in_spack_env:
+    type: spack
+    executor: generic.local.sh
+    description: "Concretize m4 in a spack environment named m4"
+    tags: [spack]
+    spack:
+      root: $HOME/spack
+      env:
+        specs:
+          - 'm4'
+        activate:
+          name: m4
+        concretize: true

--- a/tutorials/spack/env_create_directory.yml
+++ b/tutorials/spack/env_create_directory.yml
@@ -1,0 +1,17 @@
+version: "1.0"
+buildspecs:
+  spack_env_directory:
+    type: spack
+    executor: generic.local.sh
+    description: "Concretize m4 in a spack environment named m4"
+    tags: [spack]
+    spack:
+      root: $HOME/spack
+      env:
+        create:
+          dir: $HOME/spack-envs/m4
+        activate:
+          dir: $HOME/spack-envs/m4
+        specs:
+          - 'm4'
+        concretize: true

--- a/tutorials/spack/env_create_manifest.yml
+++ b/tutorials/spack/env_create_manifest.yml
@@ -1,0 +1,16 @@
+version: "1.0"
+buildspecs:
+  spack_env_create_from_manifest:
+    type: spack
+    executor: generic.local.sh
+    description: "Create spack environment from spack.yaml"
+    tags: [spack]
+    spack:
+      root: $HOME/spack
+      env:
+        create:
+          name: 'manifest_example'
+          manifest: "$BUILDTEST_ROOT/tutorials/spack/example/spack.yaml"
+        activate:
+          name: 'manifest_example'
+        concretize: true

--- a/tutorials/spack/env_install.yml
+++ b/tutorials/spack/env_install.yml
@@ -1,0 +1,20 @@
+version: "1.0"
+buildspecs:
+  install_m4_in_spack_env:
+    type: spack
+    executor: generic.local.sh
+    description: "Install m4 in a spack environment named m4"
+    tags: [spack]
+    spack:
+      root: $HOME/spack
+      compiler_find: true
+      env:
+        create:
+          name: 'm4'
+        specs:
+          - 'm4'
+        activate:
+          name: m4
+        concretize: true
+      install:
+        options: ''

--- a/tutorials/spack/env_install.yml
+++ b/tutorials/spack/env_install.yml
@@ -1,20 +1,21 @@
 version: "1.0"
 buildspecs:
-  install_m4_in_spack_env:
+  install_m4_zlib_in_spack_env:
     type: spack
     executor: generic.local.sh
-    description: "Install m4 in a spack environment named m4"
+    description: "Install m4 and zlib in a spack environment named m4_zlib"
     tags: [spack]
     spack:
       root: $HOME/spack
       compiler_find: true
       env:
         create:
-          name: 'm4'
+          name: 'm4_zlib'
         specs:
           - 'm4'
+          - 'zlib'
         activate:
-          name: m4
+          name: m4_zlib
         concretize: true
       install:
-        options: ''
+        option: '--keep-prefix'

--- a/tutorials/spack/example/spack.yaml
+++ b/tutorials/spack/example/spack.yaml
@@ -1,0 +1,9 @@
+spack:
+  view: false
+  concretization: separately
+  config:
+    install_tree:
+      root: $spack
+  specs:
+    - m4
+    - zlib

--- a/tutorials/spack/install_zlib.yml
+++ b/tutorials/spack/install_zlib.yml
@@ -9,4 +9,3 @@ buildspecs:
       root: $HOME/spack
       install:
         specs: ['zlib']
-        option: '-v'

--- a/tutorials/spack/install_zlib.yml
+++ b/tutorials/spack/install_zlib.yml
@@ -1,0 +1,12 @@
+version: "1.0"
+buildspecs:
+  install_zlib:
+    type: spack
+    executor: generic.local.sh
+    description: "Install zlib"
+    tags: [spack]
+    spack:
+      root: $HOME/spack
+      install:
+        specs: ['zlib']
+        option: '-v'

--- a/tutorials/spack/pre_post_cmds.yml
+++ b/tutorials/spack/pre_post_cmds.yml
@@ -1,0 +1,18 @@
+version: "1.0"
+buildspecs:
+  run_pre_post_commands:
+    type: spack
+    executor: generic.local.sh
+    description: "Install zlib"
+    tags: [spack]
+    pre_cmds: |
+      cd /tmp
+      git clone https://github.com/spack/spack
+    spack:
+      root: /tmp/spack
+      verify_spack: false
+      install:
+        specs: ['zlib']
+    post_cmds: |
+      spack find
+      rm -rf $SPACK_ROOT


### PR DESCRIPTION
This PR will add `spack-v1.0.schema.json` which will support `type: spack` so one can write test using this schema. In addition, we have provided a few examples using the spack schema along with user documentation