### PR TITLE
add command buildtest buildspec validate

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -119,11 +119,16 @@ _buildtest ()
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) );;
 
     buildspec)
-      local cmds="-h --help find"
+      local cmds="-h --help find validate"
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )
+
       if [[ "${prev}" == "find" ]]; then
         local opts="-h --help --root -r --rebuild -t --tags -b --buildspec -e --executors -p --paths --group-by-tags --group-by-executor -m --maintainers -mb --maintainers-by-buildspecs --filter --format --helpfilter --helpformat"
         COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
+
+      elif [[ "${prev}" == "validate" ]]; then
+          local opts="-b --buildspec -t --tag -x --exclude -e --executor"
+          COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       fi
       ;;
 

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -222,9 +222,45 @@ def buildspec_menu(subparsers):
 
     subparsers_buildspec = parser_buildspec.add_subparsers(
         description="Find buildspec from cache file",
+        dest="buildspecs_subcommand",
         metavar="",
     )
     buildspec_find = subparsers_buildspec.add_parser("find", help="find all buildspecs")
+    buildspec_validate = subparsers_buildspec.add_parser(
+        "validate", help="Validate buildspecs"
+    )
+
+    buildspec_validate.add_argument(
+        "-b",
+        "--buildspec",
+        type=str,
+        help="Specify path to buildspec (file, or directory) to validate",
+        action="append",
+    )
+
+    buildspec_validate.add_argument(
+        "-x",
+        "--exclude",
+        type=str,
+        help="Specify path to buildspec to exclude (file or directory) during validation",
+        action="append",
+    )
+    buildspec_validate.add_argument(
+        "-t",
+        "--tag",
+        type=str,
+        action="append",
+        help="Specify buildspecs by tag name to validate",
+    )
+
+    buildspec_validate.add_argument(
+        "-e",
+        "--executor",
+        type=str,
+        action="append",
+        help="Specify buildspecs by executor name to validate",
+    )
+
     buildspec_find.add_argument(
         "--root",
         help="Specify root buildspecs (directory) path to load buildspecs into buildspec cache.",

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -413,7 +413,7 @@ def report_menu(subparsers):
     subparsers = parser_report.add_subparsers(
         description="Fetch test results from report file and print them in table format",
         metavar="",
-        dest="report",
+        dest="report_subcommand",
     )
     subparsers.add_parser("clear", help="delete report file")
     parser_report.add_argument(

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -142,8 +142,6 @@ def discover_buildspecs(
         msg = "There are no Buildspec files to process."
         sys.exit(msg)
 
-    print_discovered_buildspecs(buildspec_dict=buildspec_dict)
-
     return buildspec_dict
 
 
@@ -529,6 +527,8 @@ class BuildTest:
             tags=self.tags,
             executors=self.executors,
         )
+
+        print_discovered_buildspecs(buildspec_dict=self.discovered_bp)
 
         self.detected_buildspecs = self.discovered_bp["detected"]
 

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -757,7 +757,7 @@ def buildspec_validate(
     exception_counter = 0
     for buildspec in detected_buildspecs:
         try:
-            parse = BuildspecParser(buildspec=buildspec, buildexecutor=buildexecutor)
+            BuildspecParser(buildspec=buildspec, buildexecutor=buildexecutor)
         except (BuildTestError, BuildspecError, ValidationError) as err:
             exception_counter += 1
             print("\nfile: ", buildspec)

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -723,7 +723,9 @@ class BuildspecCache:
             print(path)
 
 
-def buildspec_validate(args, configuration):
+def buildspec_validate(
+    configuration, buildspecs=None, excluded_buildspecs=None, tags=None, executors=None
+):
     """Entry point for ``buildtest buildspec validate``. This method is responsible for discovering buildspec
     with same options used for building buildspecs that includes ``--buildspec``, ``--exclude``, ``--tag``, and
     ``--executor``. Upon discovery we pass each buildspec to ``BuildspecParser`` class to validate buildspec and
@@ -731,10 +733,10 @@ def buildspec_validate(args, configuration):
     """
 
     buildspecs_dict = discover_buildspecs(
-        buildspecs=args.buildspec,
-        exclude_buildspecs=args.exclude,
-        tags=args.tag,
-        executors=args.executor,
+        buildspecs=buildspecs,
+        exclude_buildspecs=excluded_buildspecs,
+        tags=tags,
+        executors=executors,
     )
     detected_buildspecs = buildspecs_dict["detected"]
 

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -464,7 +464,7 @@ class BuildspecCache:
                     self.table["tags"].append(tags)
                     self.table["description"].append(description)
 
-    def get_buildspecfiles(self, terse):
+    def get_buildspecfiles(self, terse=None):
         """This method implements ``buildtest buildspec find --buildspec``
         which reports all buildspec files in cache.
 
@@ -494,7 +494,7 @@ class BuildspecCache:
 
         print(tabulate(table, headers=table.keys(), tablefmt="grid"))
 
-    def get_tags(self, terse):
+    def get_tags(self, terse=None):
         """This method implements ``buildtest buildspec find --tags`` which
         reports a list of unique tags from all buildspecs in cache file.
 
@@ -517,7 +517,7 @@ class BuildspecCache:
 
         print(tabulate(table, headers=headers, tablefmt="grid"))
 
-    def get_executors(self, terse):
+    def get_executors(self, terse=None):
         """This method implements ``buildtest buildspec find --executors``
         which reports all executors from cache.
 
@@ -595,7 +595,7 @@ class BuildspecCache:
             )
         )
 
-    def print_maintainer(self, terse):
+    def print_maintainer(self, terse=None):
         """This method prints maintainers from buildspec cache file which implements
         ``buildtest buildspec find --maintainers`` command.
 

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -730,6 +730,17 @@ def buildspec_validate(
     with same options used for building buildspecs that includes ``--buildspec``, ``--exclude``, ``--tag``, and
     ``--executor``. Upon discovery we pass each buildspec to ``BuildspecParser`` class to validate buildspec and
     report any errors during validation which is raised as exceptions.
+
+    :param configuration: An instance of SiteConfiguration class which is the loaded buildtest configuration used for validating the buildspecs.
+    :type configuration: instance of SiteConfiguration
+    :param buildspecs: List of paths to buildspec file which can be a file or directory
+    :type buildspecs: List, optional
+    :param excluded_buildspecs:
+    :type excluded_buildspecs: List, optional
+    :param tags: List of tag names to search for buildspec
+    :type excluded_buildspecs: List, optional
+    :param executors: List of executor names to search for buildspecs
+    :type executors: List, optional
     """
 
     buildspecs_dict = discover_buildspecs(

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -756,7 +756,7 @@ def buildspec_validate(args, configuration):
             print(f"Processing buildspec: {buildspec}")
 
     if exception_counter > 0:
-        print(f"There were {exception_counter} exceptions raised during validation")
+        print(f"There were {exception_counter} buildspecs that failed validation")
     else:
         print("All buildspecs passed validation!!!")
 

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -387,10 +387,10 @@ class Report:
 
 def report_cmd(args):
 
-    if args.report == "clear":
-        if not is_file(args.report_file):
-            sys.exit(f"There is no report file: {args.report_file} to delete")
-        print(f"Removing report file: {args.report_file}")
+    if args.report_subcommand == "clear":
+        if not is_file(args.report):
+            sys.exit(f"There is no report file: {args.report} to delete")
+        print(f"Removing report file: {args.report}")
         os.remove(BUILD_REPORT)
         return
 

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -80,9 +80,12 @@ def main():
 
     # implementation for 'buildtest buildspec find'
     elif args.subcommands == "buildspec":
-        from buildtest.cli.buildspec import buildspec_find
+        from buildtest.cli.buildspec import buildspec_find, buildspec_validate
 
-        buildspec_find(args=args, configuration=configuration)
+        if args.buildspecs_subcommand == "find":
+            buildspec_find(args=args, configuration=configuration)
+        elif args.buildspecs_subcommand == "validate":
+            buildspec_validate(args, configuration=configuration)
 
     # running buildtest inspect
     elif args.subcommands == "inspect":

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -85,7 +85,13 @@ def main():
         if args.buildspecs_subcommand == "find":
             buildspec_find(args=args, configuration=configuration)
         elif args.buildspecs_subcommand == "validate":
-            buildspec_validate(args, configuration=configuration)
+            buildspec_validate(
+                buildspecs=args.buildspec,
+                excluded_buildspecs=args.exclude,
+                tags=args.tag,
+                executors=args.executor,
+                configuration=configuration,
+            )
 
     # running buildtest inspect
     elif args.subcommands == "inspect":

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -96,11 +96,11 @@ def test_buildspec_tag_executor():
     system = BuildTestSystem()
     system.check()
 
-    # testing buildtest build --tags fail --executor generic.local.sh
+    # testing buildtest build --tags fail --executor generic.local.csh
     cmd = BuildTest(
         configuration=configuration,
         tags=["fail"],
-        executors=["generic.local.sh"],
+        executors=["generic.local.csh"],
         buildtest_system=system,
     )
     cmd.build()
@@ -112,10 +112,10 @@ def test_build_multi_executors():
     system = BuildTestSystem()
     system.check()
 
-    # testing buildtest build --executor generic.local.sh --executor generic.local.python
+    # testing buildtest build --executor generic.local.csh --executor generic.local.python
     cmd = BuildTest(
         configuration=configuration,
-        executors=["generic.local.sh", "generic.local.python"],
+        executors=["generic.local.csh", "generic.local.python"],
         buildtest_system=system,
     )
     cmd.build()

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -3,11 +3,37 @@ import pytest
 from buildtest.config import SiteConfiguration
 from buildtest.defaults import BUILDTEST_ROOT
 from buildtest.exceptions import BuildTestError
-from buildtest.cli.buildspec import BuildspecCache
+from buildtest.cli.buildspec import BuildspecCache, buildspec_validate
 
 configuration = SiteConfiguration()
 configuration.detect_system()
 configuration.validate()
+
+
+@pytest.mark.cli
+def test_buildspec_validate():
+
+    buildspecs = [
+        os.path.join(BUILDTEST_ROOT, "tutorials", "vars.yml"),
+        os.path.join(BUILDTEST_ROOT, "tutorials", "compilers"),
+    ]
+    exclude_buildspecs = [
+        os.path.join(BUILDTEST_ROOT, "tutorials", "compilers", "gnu_hello_c.yml")
+    ]
+    tags = ["pass", "python"]
+    executors = ["generic.local.sh"]
+
+    buildspec_validate(
+        buildspecs=buildspecs,
+        excluded_buildspecs=exclude_buildspecs,
+        tags=tags,
+        executors=executors,
+        configuration=configuration,
+    )
+
+    buildspec = [os.path.join(BUILDTEST_ROOT, "tutorials", "invalid_executor.yml")]
+
+    buildspec_validate(buildspecs=buildspec, configuration=configuration)
 
 
 @pytest.mark.cli

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -22,26 +22,38 @@ def test_func_buildspec_find():
     cache = BuildspecCache(configuration=configuration)
     cache.print_buildspecs()
 
-    # implements buildtest buildspec find --tags
+    # buildtest buildspec find --tags
     cache.get_tags()
 
-    # implements buildtest buildspec find --buildspec
+    #  buildtest buildspec find --tags --terse
+    cache.get_tags(terse=True)
+
+    # buildtest buildspec find --buildspec
     cache.get_buildspecfiles()
 
-    # implements buildtest buildspec find --paths
+    #  buildtest buildspec find --buildspec
+    cache.get_buildspecfiles(terse=True)
+
+    # buildtest buildspec find --paths
     cache.print_paths()
 
-    # implements buildtest buildspec find --executors
+    # buildtest buildspec find --executors
     cache.get_executors()
 
-    # implements buildtest buildspec find --group-by-executors
+    # buildtest buildspec find --executors --terse
+    cache.get_executors(terse=True)
+
+    # buildtest buildspec find --group-by-executors
     cache.print_by_executors()
 
-    # implements buildtest buildspec find --group-by-tags
+    # buildtest buildspec find --group-by-tags
     cache.print_by_tags()
 
-    # implements buildtest buildspec find --maintainers
+    # buildtest buildspec find --maintainers
     cache.print_maintainer()
+
+    # buildtest buildspec find --maintainers --terse
+    cache.print_maintainer(terse=True)
 
     # implements buildtest buildspec find --maintainers-by-buildspecs
     cache.print_maintainers_by_buildspecs()

--- a/tests/cli/test_cdash.py
+++ b/tests/cli/test_cdash.py
@@ -21,7 +21,7 @@ def test_cdash_upload():
         cdash = "upload"
         buildname = "TESTING"
         site = None
-        report_file = None
+        report = None
 
     cdash_cmd(args, default_configuration=configuration)
 
@@ -31,7 +31,7 @@ def test_cdash_upload_exceptions():
         cdash = "upload"
         buildname = None
         site = None
-        report_file = None
+        report = None
 
     # a buildname must be specified, a None will result in error
     with pytest.raises(SystemExit):
@@ -48,7 +48,7 @@ def test_cdash_upload_exceptions():
         cdash = "upload"
         buildname = "DEMO"
         site = None
-        report_file = None
+        report = None
 
     # in configuration file we have invalid url to CDASH server
     with pytest.raises(SystemExit):
@@ -63,7 +63,7 @@ def test_cdash_upload_exceptions():
         cdash = "upload"
         buildname = "DEMO"
         site = None
-        report_file = None
+        report = None
 
     # in configuration file we have invalid project name in CDASH
     with pytest.raises(SystemExit):

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -11,7 +11,7 @@ def test_buildtest_inspect_list():
     class args:
         subcommands = "config"
         inspect = "list"
-        report_file = False
+        report = False
 
     inspect_cmd(args)
 
@@ -29,7 +29,7 @@ def test_buildtest_inspect_name():
         subcommands = "config"
         inspect = "name"
         name = [test_name]
-        report_file = None
+        report = None
 
     print(f"Querying test names: {args.name}")
     print(args)
@@ -39,7 +39,7 @@ def test_buildtest_inspect_name():
         subcommands = "config"
         inspect = "name"
         name = ["".join(random.choice(string.ascii_letters) for i in range(10))]
-        report_file = None
+        report = None
 
     print(f"Querying test names: {args.name}")
     with pytest.raises(SystemExit):
@@ -56,7 +56,7 @@ def test_buildtest_inspect_id():
         subcommands = "config"
         inspect = "id"
         id = [identifier]
-        report_file = None
+        report = None
 
     print(f"Querying test identifier: {args.id}")
     inspect_cmd(args)
@@ -65,7 +65,7 @@ def test_buildtest_inspect_id():
         subcommands = "config"
         inspect = "id"
         id = [str(uuid.uuid4())]
-        report_file = None
+        report = None
 
     print(f"Querying test identifier: {args.id}")
     # generate a random unique id which is not a valid test id when searching for tests by id.

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -21,8 +21,8 @@ def test_report_format():
         filter = None
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report'
     report_cmd(args)
@@ -34,8 +34,8 @@ def test_report_format():
         filter = None
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --format name,state,returncode,buildspec'
     report_cmd(args)
@@ -50,8 +50,8 @@ def test_invalid_format():
         format = "XYZ"
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # buildtest report --format XYZ is invalid format field
     with pytest.raises(BuildTestError):
@@ -67,8 +67,8 @@ def test_report_helpformat():
         filter = None
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     report_cmd(args)
 
@@ -82,8 +82,8 @@ def test_report_filter():
         filter = None
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --helpfilter'
     report_cmd(args)
@@ -95,8 +95,8 @@ def test_report_filter():
         format = None
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --filter state=PASS'
     report_cmd(args)
@@ -108,8 +108,8 @@ def test_report_filter():
         format = "name,state"
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --filter state=PASS --format name,state'
     report_cmd(args)
@@ -121,8 +121,8 @@ def test_report_filter():
         format = "name,state"
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --filter state=UNKNOWN --format name,state',
     # this raises error because UNKNOWN is not valid value for state field
@@ -136,8 +136,8 @@ def test_report_filter():
         format = "name,returncode,executor"
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --filter returncode=0,executor=local.bash --format name,returncode,executor
     report_cmd(args)
@@ -153,8 +153,8 @@ def test_report_filter():
         format = "name,returncode,buildspec"
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --filter buildspec=tutorials/pass_returncode.yml --format name,returncode,buildspec
     report_cmd(args)
@@ -166,8 +166,8 @@ def test_report_filter():
         format = "name,returncode,state"
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --filter name=exit1_pass --format name,returncode,state
     report_cmd(args)
@@ -179,8 +179,8 @@ def test_report_filter():
         format = None
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --filter returncode=-999 to ensure _filter_test_by_returncode returns True
     report_cmd(args)
@@ -194,8 +194,8 @@ def test_report_oldest_and_latest():
         format = None
         oldest = False
         latest = True
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # buildtest report --filter tags=tutorials --latest
     report_cmd(args)
@@ -207,8 +207,8 @@ def test_report_oldest_and_latest():
         format = None
         oldest = True
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # buildtest report --filter tags=tutorials --oldest
     report_cmd(args)
@@ -220,8 +220,8 @@ def test_report_oldest_and_latest():
         format = None
         oldest = True
         latest = True
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # buildtest report --filter tags=tutorials --oldest --latest
     report_cmd(args)
@@ -237,8 +237,8 @@ def test_invalid_filters():
         format = "name,returncode,state"
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # the filter argument buildspec is a random string which will be invalid file
     # and we expect an exception to be raised
@@ -252,8 +252,8 @@ def test_invalid_filters():
         format = "name,returncode,state"
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --filter buildspec=$HOME/.bashrc --format name,returncode,state
     # this will raise error even though file is valid it won't be found in cache
@@ -272,8 +272,8 @@ def test_invalid_filters():
         format = "name,returncode,state,executor,tags"
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # run 'buildtest report --filter tags=tutorials,executor=local.bash,state=PASS,returncode=0 --format name,returncode,state,executor,tags
     report_cmd(args)
@@ -287,8 +287,8 @@ def test_invalid_filters():
         format = None
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # buildtest report --filter returncode=1.5 is invalid returncode (must be INT)
     with pytest.raises(BuildTestError):
@@ -304,8 +304,8 @@ def test_invalid_filters():
         format = None
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = None
+        report = BUILD_REPORT
+        report_subcommand = None
 
     # buildtest report --filter XYZ=tutorials is invalid filter field
     with pytest.raises(BuildTestError):
@@ -323,8 +323,8 @@ def test_invalid_report_format():
         format = None
         oldest = False
         latest = False
-        report_file = tf.name
-        report = None
+        report = tf.name
+        report_subcommand = None
 
     # reading a report file not in JSON format will result in exception BuildTestError
     with pytest.raises(BuildTestError):
@@ -339,8 +339,8 @@ def test_report_clear():
         format = None
         oldest = False
         latest = False
-        report_file = BUILD_REPORT
-        report = "clear"
+        report = BUILD_REPORT
+        report_subcommand = None
 
     backupfile = BUILD_REPORT + ".bak"
     shutil.copy2(BUILD_REPORT, backupfile)
@@ -355,8 +355,8 @@ def test_report_clear():
         format = None
         oldest = False
         latest = False
-        report_file = "".join(random.choice(string.ascii_letters) for i in range(10))
-        report = "clear"
+        report = "".join(random.choice(string.ascii_letters) for i in range(10))
+        report_subcommand = "clear"
 
     # buildtest report clear -f <file> will raise an error since file doesn't exist
     with pytest.raises(SystemExit):
@@ -371,8 +371,8 @@ def test_report_missing_file():
         format = None
         oldest = False
         latest = False
-        report_file = "".join(random.choice(string.ascii_letters) for i in range(10))
-        report = None
+        report = "".join(random.choice(string.ascii_letters) for i in range(10))
+        report_subcommand = None
 
     with pytest.raises(SystemExit):
         report_cmd(args)


### PR DESCRIPTION
This command has the following options which has same command names used for `buildtest build` command.

```
(buildtest) bash-3.2$ buildtest buildspec validate -h
usage: buildtest [options] [COMMANDS] buildspec validate [-h] [-b BUILDSPEC] [-x EXCLUDE] [-t TAG] [-e EXECUTOR]

optional arguments:
  -h, --help            show this help message and exit
  -b BUILDSPEC, --buildspec BUILDSPEC
                        Specify path to buildspec (file, or directory) to validate
  -x EXCLUDE, --exclude EXCLUDE
                        Specify path to buildspec to exclude (file or directory) during validation
  -t TAG, --tag TAG     Specify buildspecs by tag name to validate
  -e EXECUTOR, --executor EXECUTOR
                        Specify buildspecs by executor name to validate
```

Now we can validate the buildspecs and `-b` and `-x` work similar to `buildtest build -b` or `buildtest build -x` where we can have multiple arguments appended to find buildspecs

```
(buildtest) bash-3.2$ buildtest buildspec validate -b tutorials/vars.yml -b tutorials/compilers/ -x tutorials/compilers/compiler_exclude.yml 
Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/compilers/gnu_hello_fortran.yml
Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/compilers/envvar_override.yml
Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/compilers/custom_run.yml
Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/vars.yml
Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/compilers/compiler_status_regex.yml
Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/compilers/openmp_hello.yml
Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/compilers/pre_post_build_run.yml
Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/compilers/gnu_hello_c.yml
Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/compilers/vecadd.yml
All buildspecs passed validation!!!
```

If there is an error in buildspec we print to terminal

```
(buildtest) bash-3.2$ buildtest buildspec validate -b tutorials/invalid_executor.yml -b tutorials/invalid_tags.yml 

file:  /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/invalid_tags.yml
________________________________________________________________________________
['network', 'network'] is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['tags']:
    {'oneOf': [{'type': 'string'},
               {'$ref': '#/definitions/list_of_strings'}]}

On instance['tags']:
    ['network', 'network']


Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/invalid_tags.yml

file:  /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/invalid_executor.yml
________________________________________________________________________________
"[/Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/invalid_executor.yml]: Unable to find executor: badexecutor in ['generic.local.bash', 'generic.local.sh', 'generic.local.csh', 'generic.local.zsh', 'generic.local.python']"


Processing buildspec: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/invalid_executor.yml
There were 2 buildspecs that failed validation
```