### PR TITLE
using isort to sort python imports. Add github action and pre-commit 

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -14,7 +14,7 @@ jobs:
   blackformat:
     runs-on: ubuntu-latest
     steps:
-      
+
       # use isort github action see https://pycqa.github.io/isort/docs/configuration/github_action.html
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -14,11 +14,21 @@ jobs:
   blackformat:
     runs-on: ubuntu-latest
     steps:
+      
+      # use isort github action see https://pycqa.github.io/isort/docs/configuration/github_action.html
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: jamescurtin/isort-action@master
+        with:
+          requirementsFiles: "requirements.txt docs/requirements.txt"
+
+      # use black github action see https://black.readthedocs.io/en/stable/integrations/github_actions.html
       - uses: psf/black@stable
         with:
-          args: "buildtest tests scripts --check"
+          options: "--check"
+          src: "buildtest tests scripts"
 
       - name: Check imports with pyflakes
         run: |

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: jamescurtin/isort-action@master
         with:
           requirementsFiles: "requirements.txt docs/requirements.txt"
-
+          sortPaths: "buildtest tests docs"
       # use black github action see https://black.readthedocs.io/en/stable/integrations/github_actions.html
       - uses: psf/black@stable
         with:

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
-[setting]
-profile = "black"
+[settings]
+profile=black
 src_paths = ["buildtest", "tests", "docs"]
 multi_line_output = 3
 include_trailing_comma = True

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
-[tool.isort]
+[setting]
 profile = "black"
-src_paths = ["buildtest", "tests"]
+src_paths = ["buildtest", "tests", "docs"]
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.6.4
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files", "buildtest", "tests", "docs"]
+
   - repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:
@@ -6,8 +12,4 @@ repos:
         language_version: python3.7
 
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.6.4
-    hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,10 @@ repos:
     hooks:
       - id: black
         language_version: python3.7
+
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.6.4
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -17,19 +17,20 @@ import stat
 import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
+
+from buildtest.buildsystem.batch import (
+    CobaltBatchScript,
+    LSFBatchScript,
+    PBSBatchScript,
+    SlurmBatchScript,
+)
 from buildtest.defaults import BUILDTEST_EXECUTOR_DIR
 from buildtest.exceptions import ExecutorError
-from buildtest.buildsystem.batch import (
-    SlurmBatchScript,
-    LSFBatchScript,
-    CobaltBatchScript,
-    PBSBatchScript,
-)
 from buildtest.schemas.defaults import schema_table
 from buildtest.utils.command import BuildTestCommand
-from buildtest.utils.file import create_dir, write_file, read_file
-from buildtest.utils.timer import Timer
+from buildtest.utils.file import create_dir, read_file, write_file
 from buildtest.utils.shell import Shell
+from buildtest.utils.timer import Timer
 
 
 class BuilderBase(ABC):

--- a/buildtest/buildsystem/builders.py
+++ b/buildtest/buildsystem/builders.py
@@ -6,9 +6,8 @@ import logging
 import os
 import re
 
-
-from buildtest.buildsystem.scriptbuilder import ScriptBuilder
 from buildtest.buildsystem.compilerbuilder import CompilerBuilder
+from buildtest.buildsystem.scriptbuilder import ScriptBuilder
 from buildtest.buildsystem.spack import SpackBuilder
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.system import system

--- a/buildtest/buildsystem/compilerbuilder.py
+++ b/buildtest/buildsystem/compilerbuilder.py
@@ -3,8 +3,8 @@ import os
 import shutil
 
 from buildtest.buildsystem.base import BuilderBase
-from buildtest.exceptions import BuildTestError
 from buildtest.cli.compilers import BuildtestCompilers
+from buildtest.exceptions import BuildTestError
 from buildtest.utils.file import resolve_path
 from buildtest.utils.tools import deep_get
 

--- a/buildtest/buildsystem/parser.py
+++ b/buildtest/buildsystem/parser.py
@@ -9,11 +9,11 @@ import logging
 import os
 import re
 
-from buildtest.exceptions import BuildTestError, BuildspecError
+from buildtest.exceptions import BuildspecError, BuildTestError
 from buildtest.executors.setup import BuildExecutor
+from buildtest.schemas.defaults import custom_validator, schema_table
 from buildtest.schemas.utils import load_recipe
-from buildtest.schemas.defaults import schema_table, custom_validator
-from buildtest.utils.file import resolve_path, is_dir
+from buildtest.utils.file import is_dir, resolve_path
 
 
 class BuildspecParser:

--- a/buildtest/buildsystem/spack.py
+++ b/buildtest/buildsystem/spack.py
@@ -6,8 +6,8 @@ schema definition 'spack-v1.0.schema.json' that defines how buildspecs are writt
 import os
 
 from buildtest.buildsystem.base import BuilderBase
-from buildtest.utils.file import resolve_path
 from buildtest.exceptions import BuildTestError
+from buildtest.utils.file import resolve_path
 
 
 class SpackBuilder(BuilderBase):

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -5,11 +5,10 @@ interact with a global configuration for buildtest.
 import argparse
 import os
 
-from termcolor import colored
-
 from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import BUILD_REPORT
 from buildtest.schemas.defaults import schema_table
+from termcolor import colored
 
 
 def handle_kv_string(val):

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -6,7 +6,8 @@ import argparse
 import os
 
 from termcolor import colored
-from buildtest import BUILDTEST_VERSION, BUILDTEST_COPYRIGHT
+
+from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import BUILD_REPORT
 from buildtest.schemas.defaults import schema_table
 

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import time
 from datetime import datetime
+
 from jsonschema.exceptions import ValidationError
 from tabulate import tabulate
 from termcolor import colored
@@ -19,19 +20,15 @@ from buildtest import BUILDTEST_VERSION
 from buildtest.buildsystem.builders import Builder
 from buildtest.buildsystem.parser import BuildspecParser
 from buildtest.defaults import (
-    BUILDSPEC_CACHE_FILE,
-    BUILD_REPORT,
-    BUILDTEST_DEFAULT_TESTDIR,
     BUILD_HISTORY_DIR,
+    BUILD_REPORT,
+    BUILDSPEC_CACHE_FILE,
+    BUILDTEST_DEFAULT_TESTDIR,
 )
-from buildtest.exceptions import (
-    BuildTestError,
-    BuildspecError,
-    ExecutorError,
-)
+from buildtest.exceptions import BuildspecError, BuildTestError, ExecutorError
 from buildtest.executors.setup import BuildExecutor
 from buildtest.system import system
-from buildtest.utils.file import walk_tree, resolve_path, is_file, create_dir, load_json
+from buildtest.utils.file import create_dir, is_file, load_json, resolve_path, walk_tree
 from buildtest.utils.tools import Hasher, deep_get
 
 logger = logging.getLogger(__name__)

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -19,13 +19,21 @@ from buildtest.defaults import (
     BUILD_HISTORY_DIR,
     BUILD_REPORT,
     BUILDSPEC_CACHE_FILE,
-    BUILDTEST_REPORT_SUMMARY,
     BUILDTEST_DEFAULT_TESTDIR,
+    BUILDTEST_REPORT_SUMMARY,
 )
 from buildtest.exceptions import BuildspecError, BuildTestError, ExecutorError
 from buildtest.executors.setup import BuildExecutor
 from buildtest.system import system
-from buildtest.utils.file import walk_tree, resolve_path, is_file, create_dir, load_json, read_file, write_file
+from buildtest.utils.file import (
+    create_dir,
+    is_file,
+    load_json,
+    read_file,
+    resolve_path,
+    walk_tree,
+    write_file,
+)
 from buildtest.utils.tools import Hasher, deep_get
 from jsonschema.exceptions import ValidationError
 from tabulate import tabulate
@@ -1262,6 +1270,5 @@ def update_report(valid_builders, report_file=BUILD_REPORT):
     if report_file not in content:
         content.append(report_file)
 
-    with open(BUILDTEST_REPORT_SUMMARY, 'w') as fd:
+    with open(BUILDTEST_REPORT_SUMMARY, "w") as fd:
         fd.write("\n".join(content))
-

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -32,7 +32,6 @@ from buildtest.utils.file import (
     read_file,
     resolve_path,
     walk_tree,
-    write_file,
 )
 from buildtest.utils.tools import Hasher, deep_get
 from jsonschema.exceptions import ValidationError

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -12,10 +12,6 @@ import tempfile
 import time
 from datetime import datetime
 
-from jsonschema.exceptions import ValidationError
-from tabulate import tabulate
-from termcolor import colored
-
 from buildtest import BUILDTEST_VERSION
 from buildtest.buildsystem.builders import Builder
 from buildtest.buildsystem.parser import BuildspecParser
@@ -30,6 +26,9 @@ from buildtest.executors.setup import BuildExecutor
 from buildtest.system import system
 from buildtest.utils.file import create_dir, is_file, load_json, resolve_path, walk_tree
 from buildtest.utils.tools import Hasher, deep_get
+from jsonschema.exceptions import ValidationError
+from tabulate import tabulate
+from termcolor import colored
 
 logger = logging.getLogger(__name__)
 

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -2,19 +2,20 @@ import json
 import logging
 import os
 
+from jsonschema.exceptions import ValidationError
 from tabulate import tabulate
 from termcolor import colored
-from jsonschema.exceptions import ValidationError
-from buildtest.cli.build import discover_buildspecs
+
 from buildtest.buildsystem.parser import BuildspecParser
+from buildtest.cli.build import discover_buildspecs
 from buildtest.defaults import (
     BUILDSPEC_CACHE_FILE,
-    BUILDSPEC_ERROR_FILE,
     BUILDSPEC_DEFAULT_PATH,
+    BUILDSPEC_ERROR_FILE,
     BUILDTEST_BUILDSPEC_DIR,
 )
+from buildtest.exceptions import BuildspecError, BuildTestError
 from buildtest.executors.setup import BuildExecutor
-from buildtest.exceptions import BuildTestError, BuildspecError
 from buildtest.utils.file import (
     create_dir,
     is_dir,

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -2,10 +2,6 @@ import json
 import logging
 import os
 
-from jsonschema.exceptions import ValidationError
-from tabulate import tabulate
-from termcolor import colored
-
 from buildtest.buildsystem.parser import BuildspecParser
 from buildtest.cli.build import discover_buildspecs
 from buildtest.defaults import (
@@ -25,6 +21,9 @@ from buildtest.utils.file import (
     resolve_path,
     walk_tree,
 )
+from jsonschema.exceptions import ValidationError
+from tabulate import tabulate
+from termcolor import colored
 
 logger = logging.getLogger(__name__)
 

--- a/buildtest/cli/cdash.py
+++ b/buildtest/cli/cdash.py
@@ -13,7 +13,6 @@ from urllib.request import Request, urlopen
 
 import requests
 import yaml
-
 from buildtest.defaults import BUILD_REPORT
 from buildtest.utils.file import read_file, resolve_path
 from buildtest.utils.tools import deep_get

--- a/buildtest/cli/cdash.py
+++ b/buildtest/cli/cdash.py
@@ -3,18 +3,19 @@ import hashlib
 import json
 import os.path
 import re
-import requests
 import sys
 import webbrowser
 import xml.etree.cElementTree as ET
-import yaml
 import zlib
-
 from datetime import datetime
-from urllib.request import urlopen, Request
 from urllib.parse import urlencode, urljoin
+from urllib.request import Request, urlopen
+
+import requests
+import yaml
+
 from buildtest.defaults import BUILD_REPORT
-from buildtest.utils.file import resolve_path, read_file
+from buildtest.utils.file import read_file, resolve_path
 from buildtest.utils.tools import deep_get
 
 

--- a/buildtest/cli/compilers.py
+++ b/buildtest/cli/compilers.py
@@ -4,13 +4,12 @@ import re
 import subprocess
 
 import yaml
-from lmod.module import Module
-from lmod.spider import Spider
-
 from buildtest.config import SiteConfiguration
 from buildtest.exceptions import BuildTestError, ConfigurationError
 from buildtest.schemas.defaults import custom_validator, schema_table
 from buildtest.utils.tools import deep_get
+from lmod.module import Module
+from lmod.spider import Spider
 
 
 def compiler_cmd(args, configuration):

--- a/buildtest/cli/compilers.py
+++ b/buildtest/cli/compilers.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import subprocess
+
 import yaml
 from lmod.module import Module
 from lmod.spider import Spider

--- a/buildtest/cli/config.py
+++ b/buildtest/cli/config.py
@@ -5,15 +5,14 @@ import shutil
 import sys
 
 import yaml
-from jsonschema import ValidationError
-from tabulate import tabulate
-from termcolor import colored
-
 from buildtest import BUILDTEST_VERSION
 from buildtest.defaults import BUILDSPEC_CACHE_FILE, supported_schemas
 from buildtest.exceptions import ConfigurationError
 from buildtest.executors.setup import BuildExecutor
 from buildtest.system import system
+from jsonschema import ValidationError
+from tabulate import tabulate
+from termcolor import colored
 
 
 def config_cmd(args, configuration):

--- a/buildtest/cli/config.py
+++ b/buildtest/cli/config.py
@@ -1,12 +1,14 @@
-import json
 import getpass
+import json
 import os
 import shutil
 import sys
+
 import yaml
 from jsonschema import ValidationError
 from tabulate import tabulate
 from termcolor import colored
+
 from buildtest import BUILDTEST_VERSION
 from buildtest.defaults import BUILDSPEC_CACHE_FILE, supported_schemas
 from buildtest.exceptions import ConfigurationError

--- a/buildtest/cli/history.py
+++ b/buildtest/cli/history.py
@@ -3,10 +3,9 @@ import logging
 import os
 import sys
 
-from tabulate import tabulate
-
 from buildtest.defaults import BUILD_HISTORY_DIR
 from buildtest.utils.file import is_dir, load_json, walk_tree
+from tabulate import tabulate
 
 logger = logging.getLogger(__name__)
 

--- a/buildtest/cli/history.py
+++ b/buildtest/cli/history.py
@@ -1,10 +1,12 @@
-import logging
 import json
+import logging
 import os
 import sys
+
 from tabulate import tabulate
+
 from buildtest.defaults import BUILD_HISTORY_DIR
-from buildtest.utils.file import walk_tree, load_json, is_dir
+from buildtest.utils.file import is_dir, load_json, walk_tree
 
 logger = logging.getLogger(__name__)
 

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -4,8 +4,9 @@ to retrieve test record from report file in JSON format."""
 import json
 import os
 import sys
-from termcolor import colored
+
 from tabulate import tabulate
+from termcolor import colored
 
 from buildtest.defaults import BUILD_REPORT
 from buildtest.utils.file import load_json, resolve_path

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -5,11 +5,10 @@ import json
 import os
 import sys
 
-from tabulate import tabulate
-from termcolor import colored
-
 from buildtest.defaults import BUILD_REPORT
 from buildtest.utils.file import load_json, resolve_path
+from tabulate import tabulate
+from termcolor import colored
 
 
 def inspect_cmd(args):

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -2,12 +2,11 @@ import logging
 import os
 import sys
 
-from tabulate import tabulate
-from termcolor import colored
-
 from buildtest.defaults import BUILD_REPORT
 from buildtest.exceptions import BuildTestError
 from buildtest.utils.file import is_file, load_json, resolve_path
+from tabulate import tabulate
+from termcolor import colored
 
 logger = logging.getLogger(__name__)
 

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -2,11 +2,11 @@ import logging
 import os
 import sys
 
-from termcolor import colored
-from tabulate import tabulate
 from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORT_SUMMARY
 from buildtest.exceptions import BuildTestError
-from buildtest.utils.file import is_file, load_json, resolve_path, read_file
+from buildtest.utils.file import is_file, load_json, read_file, resolve_path
+from tabulate import tabulate
+from termcolor import colored
 
 logger = logging.getLogger(__name__)
 
@@ -427,13 +427,14 @@ def report_cmd(args):
 
     if args.report_subcommand == "list":
         if not is_file(BUILDTEST_REPORT_SUMMARY):
-            print("There are no report files, please run 'buildtest build' to generate a report file.")
+            print(
+                "There are no report files, please run 'buildtest build' to generate a report file."
+            )
             return
 
         content = read_file(BUILDTEST_REPORT_SUMMARY)
         print(content)
         return
-
 
     results = Report(args.filter, args.format, args.latest, args.oldest, args.report)
     if args.helpfilter:

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -1,8 +1,10 @@
 import logging
 import os
 import sys
-from termcolor import colored
+
 from tabulate import tabulate
+from termcolor import colored
+
 from buildtest.defaults import BUILD_REPORT
 from buildtest.exceptions import BuildTestError
 from buildtest.utils.file import is_file, load_json, resolve_path

--- a/buildtest/cli/schema.py
+++ b/buildtest/cli/schema.py
@@ -1,8 +1,9 @@
 import json
 import os
-from buildtest.schemas.utils import here
+
 from buildtest.schemas.defaults import schema_table
-from buildtest.utils.file import walk_tree, read_file
+from buildtest.schemas.utils import here
+from buildtest.utils.file import read_file, walk_tree
 
 
 def schema_cmd(args):

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -1,19 +1,19 @@
-import logging
 import json
+import logging
 import re
+
 from buildtest.defaults import (
-    USER_SETTINGS_FILE,
     DEFAULT_SETTINGS_FILE,
     DEFAULT_SETTINGS_SCHEMA,
+    USER_SETTINGS_FILE,
 )
+from buildtest.exceptions import ConfigurationError
 from buildtest.schemas.defaults import custom_validator
-from buildtest.schemas.utils import load_schema, load_recipe
-from buildtest.system import Slurm, LSF, Cobalt, PBS, system
+from buildtest.schemas.utils import load_recipe, load_schema
+from buildtest.system import LSF, PBS, Cobalt, Slurm, system
 from buildtest.utils.command import BuildTestCommand
 from buildtest.utils.file import resolve_path
 from buildtest.utils.tools import deep_get
-from buildtest.exceptions import ConfigurationError
-
 
 logger = logging.getLogger(__name__)
 

--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -3,8 +3,8 @@ Buildtest defaults, including environment variables and paths, are defined
 or derived here.
 """
 
-import pwd
 import os
+import pwd
 
 supported_type_schemas = ["script-v1.0.schema.json", "compiler-v1.0.schema.json"]
 

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -5,6 +5,7 @@ BuildExecutor: manager for test executors
 import logging
 import os
 import re
+
 from buildtest.utils.file import read_file
 
 

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -1,15 +1,16 @@
 """This method implements CobaltExecutor class which is defines how cobalt executor
 submit job to Cobalt scheduler."""
-import logging
 import json
+import logging
 import os
 import re
-import time
 import shutil
+import time
+
 from buildtest.executors.base import BaseExecutor
 from buildtest.executors.job import Job
 from buildtest.utils.command import BuildTestCommand
-from buildtest.utils.file import read_file, is_file
+from buildtest.utils.file import is_file, read_file
 from buildtest.utils.tools import deep_get
 
 logger = logging.getLogger(__name__)

--- a/buildtest/executors/lsf.py
+++ b/buildtest/executors/lsf.py
@@ -4,10 +4,11 @@ jobs to LSF Scheduler. This class is called in class BuildExecutor
 when initializing the executors.
 """
 
-import logging
 import json
+import logging
 import os
 import re
+
 from buildtest.executors.base import BaseExecutor
 from buildtest.executors.job import Job
 from buildtest.utils.command import BuildTestCommand

--- a/buildtest/executors/pbs.py
+++ b/buildtest/executors/pbs.py
@@ -1,7 +1,7 @@
 """This module implements PBSExecutor class that defines how executors submit
 job to PBS Scheduler"""
-import logging
 import json
+import logging
 import os
 
 from buildtest.executors.base import BaseExecutor

--- a/buildtest/executors/setup.py
+++ b/buildtest/executors/setup.py
@@ -9,13 +9,13 @@ import logging
 import os
 
 from buildtest.defaults import BUILDTEST_EXECUTOR_DIR
+from buildtest.exceptions import ExecutorError
 from buildtest.executors.base import BaseExecutor
 from buildtest.executors.cobalt import CobaltExecutor
 from buildtest.executors.local import LocalExecutor
 from buildtest.executors.lsf import LSFExecutor
-from buildtest.executors.slurm import SlurmExecutor
 from buildtest.executors.pbs import PBSExecutor
-from buildtest.exceptions import ExecutorError
+from buildtest.executors.slurm import SlurmExecutor
 from buildtest.utils.file import create_dir, write_file
 
 logger = logging.getLogger(__name__)

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -2,18 +2,19 @@
 
 import os
 import webbrowser
-from buildtest.config import SiteConfiguration
-from buildtest.defaults import (
-    BUILDTEST_USER_HOME,
-    BUILDTEST_EXECUTOR_DIR,
-    BUILDTEST_BUILDSPEC_DIR,
-)
+
 from buildtest.cli import get_parser
 from buildtest.cli.build import BuildTest
 from buildtest.cli.history import build_history
-from buildtest.system import BuildTestSystem
+from buildtest.config import SiteConfiguration
+from buildtest.defaults import (
+    BUILDTEST_BUILDSPEC_DIR,
+    BUILDTEST_EXECUTOR_DIR,
+    BUILDTEST_USER_HOME,
+)
 from buildtest.log import init_logfile
-from buildtest.utils.file import create_dir, is_file, resolve_path, remove_file
+from buildtest.system import BuildTestSystem
+from buildtest.utils.file import create_dir, is_file, remove_file, resolve_path
 
 # column width for linewrap for argparse library
 os.environ["COLUMNS"] = "120"

--- a/buildtest/schemas/defaults.py
+++ b/buildtest/schemas/defaults.py
@@ -1,5 +1,7 @@
 import os
-from jsonschema import RefResolver, Draft7Validator
+
+from jsonschema import Draft7Validator, RefResolver
+
 from buildtest.schemas.utils import load_schema
 
 here = os.path.dirname(os.path.abspath(__file__))

--- a/buildtest/schemas/defaults.py
+++ b/buildtest/schemas/defaults.py
@@ -1,8 +1,7 @@
 import os
 
-from jsonschema import Draft7Validator, RefResolver
-
 from buildtest.schemas.utils import load_schema
+from jsonschema import Draft7Validator, RefResolver
 
 here = os.path.dirname(os.path.abspath(__file__))
 

--- a/buildtest/schemas/utils.py
+++ b/buildtest/schemas/utils.py
@@ -7,7 +7,6 @@ import os
 import sys
 
 import yaml
-
 from buildtest.utils.file import load_json
 
 here = os.path.dirname(os.path.abspath(__file__))

--- a/buildtest/schemas/utils.py
+++ b/buildtest/schemas/utils.py
@@ -5,7 +5,9 @@ Utility and helper functions for schemas.
 import logging
 import os
 import sys
+
 import yaml
+
 from buildtest.utils.file import load_json
 
 here = os.path.dirname(os.path.abspath(__file__))

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -11,7 +11,6 @@ import shutil
 import sys
 
 import distro
-
 from buildtest.defaults import BUILDTEST_ROOT
 from buildtest.utils.command import BuildTestCommand
 

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -2,16 +2,18 @@
 This module detects System changes defined in class BuildTestSystem.
 """
 
-import distro
 import getpass
-import logging
 import json
+import logging
 import os
 import platform
 import shutil
 import sys
-from buildtest.utils.command import BuildTestCommand
+
+import distro
+
 from buildtest.defaults import BUILDTEST_ROOT
+from buildtest.utils.command import BuildTestCommand
 
 
 class BuildTestSystem:

--- a/buildtest/utils/command.py
+++ b/buildtest/utils/command.py
@@ -1,9 +1,10 @@
 # import locale
 import os
-import subprocess
 import shlex
 import shutil
+import subprocess
 import tempfile
+
 from buildtest.utils.file import read_file
 
 

--- a/buildtest/utils/file.py
+++ b/buildtest/utils/file.py
@@ -10,6 +10,7 @@ include the following:
 
 import json
 import os
+
 from buildtest.exceptions import BuildTestError
 
 

--- a/buildtest/utils/shell.py
+++ b/buildtest/utils/shell.py
@@ -1,4 +1,5 @@
 import shutil
+
 from buildtest.exceptions import BuildTestError
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import sys
 
 here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, here)
-from buildtest import BUILDTEST_VERSION, BUILDTEST_COPYRIGHT
+from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 
 # set BUILDTEST_ROOT environment that is generally set by 'source setup.sh'
 os.environ["BUILDTEST_ROOT"] = here

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 black==21.6b0
 codecov
 coverage
+isort
 pre-commit
 pyflakes
 pytest

--- a/docs/scripting_examples/ex1.py
+++ b/docs/scripting_examples/ex1.py
@@ -1,6 +1,7 @@
 import os
-from buildtest.defaults import BUILDTEST_ROOT, DEFAULT_SETTINGS_FILE
+
 from buildtest.cli.build import BuildTest
+from buildtest.defaults import BUILDTEST_ROOT, DEFAULT_SETTINGS_FILE
 
 input_buildspecs = [
     os.path.join(BUILDTEST_ROOT, "tutorials", "vars.yml"),

--- a/docs/scripting_examples/ex2.py
+++ b/docs/scripting_examples/ex2.py
@@ -1,6 +1,7 @@
 import os
-from buildtest.defaults import BUILDTEST_ROOT, DEFAULT_SETTINGS_FILE
+
 from buildtest.cli.build import BuildTest
+from buildtest.defaults import BUILDTEST_ROOT, DEFAULT_SETTINGS_FILE
 
 input_buildspecs = [os.path.join(BUILDTEST_ROOT, "tutorials", "vars.yml")]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [tool.isort]
 profile = "black"
 src_paths = ["buildtest", "tests"]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.isort]
+profile = "black"
+src_paths = ["buildtest", "tests"]

--- a/scripts/docgen.py
+++ b/scripts/docgen.py
@@ -2,10 +2,11 @@
 This file is used for generating documentation tests.
 """
 import os
-import subprocess
 import shutil
+import subprocess
+
+from buildtest.defaults import BUILDTEST_USER_HOME, VAR_DIR
 from buildtest.utils.file import create_dir, write_file
-from buildtest.defaults import VAR_DIR, BUILDTEST_USER_HOME
 
 root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 docgen = os.path.join(root, "docs", "docgen")

--- a/scripts/regtest.py
+++ b/scripts/regtest.py
@@ -1,8 +1,9 @@
-import coverage
-import pytest
 import os
 import shutil
 import sys
+
+import coverage
+import pytest
 
 from buildtest.defaults import BUILDTEST_USER_HOME
 from buildtest.utils.file import is_dir

--- a/tests/buildsystem/test_base.py
+++ b/tests/buildsystem/test_base.py
@@ -5,7 +5,6 @@ BuildspecParser: testing functions
 import os
 
 import pytest
-
 from buildtest.buildsystem.builders import Builder
 from buildtest.buildsystem.parser import BuildspecParser
 from buildtest.config import SiteConfiguration

--- a/tests/buildsystem/test_base.py
+++ b/tests/buildsystem/test_base.py
@@ -2,15 +2,15 @@
 BuildspecParser: testing functions
 """
 
-import pytest
 import os
 
+import pytest
 
 from buildtest.buildsystem.builders import Builder
 from buildtest.buildsystem.parser import BuildspecParser
 from buildtest.config import SiteConfiguration
 from buildtest.defaults import DEFAULT_SETTINGS_FILE
-from buildtest.exceptions import BuildTestError, BuildspecError
+from buildtest.exceptions import BuildspecError, BuildTestError
 from buildtest.executors.setup import BuildExecutor
 from buildtest.utils.file import walk_tree
 

--- a/tests/buildsystem/test_batch.py
+++ b/tests/buildsystem/test_batch.py
@@ -1,7 +1,7 @@
 from buildtest.buildsystem.batch import (
+    CobaltBatchScript,
     LSFBatchScript,
     SlurmBatchScript,
-    CobaltBatchScript,
 )
 
 

--- a/tests/cli/test_argparse.py
+++ b/tests/cli/test_argparse.py
@@ -1,7 +1,8 @@
 import argparse
+
 import pytest
 
-from buildtest.cli import positive_number, handle_kv_string, get_parser
+from buildtest.cli import get_parser, handle_kv_string, positive_number
 
 
 def test_positive_number():

--- a/tests/cli/test_argparse.py
+++ b/tests/cli/test_argparse.py
@@ -1,7 +1,6 @@
 import argparse
 
 import pytest
-
 from buildtest.cli import get_parser, handle_kv_string, positive_number
 
 

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 
 import pytest
-
 from buildtest.cli.build import BuildTest, discover_buildspecs
 from buildtest.cli.buildspec import BuildspecCache
 from buildtest.config import SiteConfiguration

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -1,14 +1,15 @@
 import os
-import pytest
 import tempfile
 
-from buildtest.defaults import BUILDTEST_ROOT
-from buildtest.exceptions import BuildTestError
-from buildtest.config import SiteConfiguration
+import pytest
+
 from buildtest.cli.build import BuildTest, discover_buildspecs
 from buildtest.cli.buildspec import BuildspecCache
-from buildtest.utils.file import walk_tree
+from buildtest.config import SiteConfiguration
+from buildtest.defaults import BUILDTEST_ROOT
+from buildtest.exceptions import BuildTestError
 from buildtest.system import BuildTestSystem
+from buildtest.utils.file import walk_tree
 
 test_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 root = os.path.dirname(test_root)

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-
 from buildtest.cli.buildspec import BuildspecCache, buildspec_validate
 from buildtest.config import SiteConfiguration
 from buildtest.defaults import BUILDTEST_ROOT

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -1,9 +1,11 @@
 import os
+
 import pytest
+
+from buildtest.cli.buildspec import BuildspecCache, buildspec_validate
 from buildtest.config import SiteConfiguration
 from buildtest.defaults import BUILDTEST_ROOT
 from buildtest.exceptions import BuildTestError
-from buildtest.cli.buildspec import BuildspecCache, buildspec_validate
 
 configuration = SiteConfiguration()
 configuration.detect_system()

--- a/tests/cli/test_cdash.py
+++ b/tests/cli/test_cdash.py
@@ -1,5 +1,7 @@
 import os
+
 import pytest
+
 from buildtest.cli.cdash import cdash_cmd
 from buildtest.config import SiteConfiguration
 

--- a/tests/cli/test_cdash.py
+++ b/tests/cli/test_cdash.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-
 from buildtest.cli.cdash import cdash_cmd
 from buildtest.config import SiteConfiguration
 

--- a/tests/cli/test_compilers.py
+++ b/tests/cli/test_compilers.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.config import SiteConfiguration
 from buildtest.exceptions import ConfigurationError

--- a/tests/cli/test_compilers.py
+++ b/tests/cli/test_compilers.py
@@ -1,5 +1,7 @@
 import os
+
 import pytest
+
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.config import SiteConfiguration
 from buildtest.exceptions import ConfigurationError

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,21 +1,19 @@
 import os
+
 import pytest
 
 from buildtest.cli.config import (
-    view_configuration,
     validate_config,
-    view_summary,
+    view_configuration,
     view_executors,
+    view_summary,
     view_system,
 )
 from buildtest.config import SiteConfiguration
-from buildtest.defaults import (
-    DEFAULT_SETTINGS_SCHEMA,
-    SCHEMA_ROOT,
-)
+from buildtest.defaults import DEFAULT_SETTINGS_SCHEMA, SCHEMA_ROOT
 from buildtest.executors.setup import BuildExecutor
 from buildtest.schemas.defaults import custom_validator
-from buildtest.schemas.utils import load_schema, load_recipe
+from buildtest.schemas.utils import load_recipe, load_schema
 from buildtest.system import BuildTestSystem
 from buildtest.utils.file import walk_tree
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-
 from buildtest.cli.config import (
     validate_config,
     view_configuration,

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -1,5 +1,6 @@
 import pytest
-from buildtest.cli.history import query_builds, build_history
+
+from buildtest.cli.history import build_history, query_builds
 
 
 def test_build_history():

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -1,5 +1,4 @@
 import pytest
-
 from buildtest.cli.history import build_history, query_builds
 
 

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -28,6 +28,7 @@ def test_buildtest_inspect_list():
 
     inspect_cmd(args)
 
+
 def test_buildtest_inspect_name():
 
     report = load_json(BUILD_REPORT)

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -1,7 +1,9 @@
-import pytest
 import random
 import string
 import uuid
+
+import pytest
+
 from buildtest.cli.inspect import get_all_ids, inspect_cmd
 from buildtest.defaults import BUILD_REPORT
 from buildtest.utils.file import load_json

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -3,7 +3,6 @@ import string
 import uuid
 
 import pytest
-
 from buildtest.cli.inspect import get_all_ids, inspect_cmd
 from buildtest.defaults import BUILD_REPORT
 from buildtest.utils.file import load_json

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -1,11 +1,13 @@
 import os
-import pytest
 import random
 import shutil
 import string
 import tempfile
-from buildtest.defaults import BUILD_REPORT, BUILDTEST_ROOT
+
+import pytest
+
 from buildtest.cli.report import report_cmd
+from buildtest.defaults import BUILD_REPORT, BUILDTEST_ROOT
 from buildtest.exceptions import BuildTestError
 
 

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -5,9 +5,8 @@ import string
 import tempfile
 
 import pytest
-
-from buildtest.defaults import BUILD_REPORT, BUILDTEST_ROOT, BUILDTEST_REPORT_SUMMARY
 from buildtest.cli.report import report_cmd
+from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORT_SUMMARY, BUILDTEST_ROOT
 from buildtest.exceptions import BuildTestError
 
 
@@ -187,6 +186,7 @@ def test_report_filter():
     # run 'buildtest report --filter returncode=-999 to ensure _filter_test_by_returncode returns True
     report_cmd(args)
 
+
 @pytest.mark.cli
 def test_report_oldest_and_latest():
     class args:
@@ -227,6 +227,7 @@ def test_report_oldest_and_latest():
 
     # buildtest report --filter tags=tutorials --oldest --latest
     report_cmd(args)
+
 
 @pytest.mark.cli
 def test_invalid_filters():
@@ -313,6 +314,7 @@ def test_invalid_filters():
     with pytest.raises(BuildTestError):
         report_cmd(args)
 
+
 @pytest.mark.cli
 def test_invalid_report_format():
 
@@ -332,9 +334,9 @@ def test_invalid_report_format():
     with pytest.raises(BuildTestError):
         report_cmd(args)
 
+
 @pytest.mark.cli
 def test_report_list():
-
     class args:
         helpformat = False
         helpfilter = False
@@ -350,6 +352,7 @@ def test_report_list():
     # now removing report summary it should print a message
     os.remove(BUILDTEST_REPORT_SUMMARY)
     report_cmd(args)
+
 
 @pytest.mark.cli
 def test_report_clear():

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -5,7 +5,6 @@ import string
 import tempfile
 
 import pytest
-
 from buildtest.cli.report import report_cmd
 from buildtest.defaults import BUILD_REPORT, BUILDTEST_ROOT
 from buildtest.exceptions import BuildTestError

--- a/tests/cli/test_schema.py
+++ b/tests/cli/test_schema.py
@@ -1,5 +1,4 @@
 import pytest
-
 from buildtest.cli.schema import schema_cmd
 
 

--- a/tests/cli/test_schema.py
+++ b/tests/cli/test_schema.py
@@ -1,4 +1,5 @@
 import pytest
+
 from buildtest.cli.schema import schema_cmd
 
 

--- a/tests/executors/test_base.py
+++ b/tests/executors/test_base.py
@@ -9,9 +9,8 @@ from jsonschema.exceptions import ValidationError
 from buildtest.buildsystem.builders import Builder
 from buildtest.buildsystem.parser import BuildspecParser
 from buildtest.config import SiteConfiguration
-from buildtest.exceptions import BuildTestError, BuildspecError
+from buildtest.exceptions import BuildspecError, BuildTestError
 from buildtest.executors.setup import BuildExecutor
-
 
 pytest_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/tests/executors/test_base.py
+++ b/tests/executors/test_base.py
@@ -4,13 +4,12 @@ BuildExecutor: testing functions
 
 import os
 
-from jsonschema.exceptions import ValidationError
-
 from buildtest.buildsystem.builders import Builder
 from buildtest.buildsystem.parser import BuildspecParser
 from buildtest.config import SiteConfiguration
 from buildtest.exceptions import BuildspecError, BuildTestError
 from buildtest.executors.setup import BuildExecutor
+from jsonschema.exceptions import ValidationError
 
 pytest_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/tests/schema_tests/test_compiler.py
+++ b/tests/schema_tests/test_compiler.py
@@ -1,8 +1,9 @@
 import os
-import pytest
 import re
 
+import pytest
 from jsonschema.exceptions import ValidationError
+
 from buildtest.defaults import SCHEMA_ROOT
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema

--- a/tests/schema_tests/test_compiler.py
+++ b/tests/schema_tests/test_compiler.py
@@ -2,11 +2,10 @@ import os
 import re
 
 import pytest
-from jsonschema.exceptions import ValidationError
-
 from buildtest.defaults import SCHEMA_ROOT
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema
+from jsonschema.exceptions import ValidationError
 
 here = os.path.dirname(os.path.abspath(__file__))
 schemaroot = os.path.join(os.path.dirname(here), "schemas")

--- a/tests/schema_tests/test_global.py
+++ b/tests/schema_tests/test_global.py
@@ -1,8 +1,9 @@
 import os
 import re
-import pytest
 
+import pytest
 from jsonschema.exceptions import ValidationError
+
 from buildtest.defaults import SCHEMA_ROOT
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema

--- a/tests/schema_tests/test_global.py
+++ b/tests/schema_tests/test_global.py
@@ -2,11 +2,10 @@ import os
 import re
 
 import pytest
-from jsonschema.exceptions import ValidationError
-
 from buildtest.defaults import SCHEMA_ROOT
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema
+from jsonschema.exceptions import ValidationError
 
 schema_name = "global"
 schema_file = f"{schema_name}.schema.json"

--- a/tests/schema_tests/test_script.py
+++ b/tests/schema_tests/test_script.py
@@ -2,11 +2,10 @@ import os
 import re
 
 import pytest
-from jsonschema.exceptions import ValidationError
-
 from buildtest.defaults import SCHEMA_ROOT
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema
+from jsonschema.exceptions import ValidationError
 
 schema_name = "script"
 schema_file = f"{schema_name}-v1.0.schema.json"

--- a/tests/schema_tests/test_script.py
+++ b/tests/schema_tests/test_script.py
@@ -1,12 +1,12 @@
 import os
 import re
-import pytest
 
+import pytest
 from jsonschema.exceptions import ValidationError
+
 from buildtest.defaults import SCHEMA_ROOT
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema
-
 
 schema_name = "script"
 schema_file = f"{schema_name}-v1.0.schema.json"

--- a/tests/schema_tests/test_settings.py
+++ b/tests/schema_tests/test_settings.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from buildtest.defaults import SCHEMA_ROOT

--- a/tests/schema_tests/test_settings.py
+++ b/tests/schema_tests/test_settings.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-
 from buildtest.defaults import SCHEMA_ROOT
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema

--- a/tests/schema_tests/test_spack.py
+++ b/tests/schema_tests/test_spack.py
@@ -1,8 +1,9 @@
 import os
-import pytest
 import re
 
+import pytest
 from jsonschema.exceptions import ValidationError
+
 from buildtest.defaults import SCHEMA_ROOT
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema

--- a/tests/schema_tests/test_spack.py
+++ b/tests/schema_tests/test_spack.py
@@ -2,11 +2,10 @@ import os
 import re
 
 import pytest
-from jsonschema.exceptions import ValidationError
-
 from buildtest.defaults import SCHEMA_ROOT
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema
+from jsonschema.exceptions import ValidationError
 
 here = os.path.dirname(os.path.abspath(__file__))
 schemaroot = os.path.join(os.path.dirname(here), "schemas")

--- a/tests/schemas/test_utils.py
+++ b/tests/schemas/test_utils.py
@@ -1,8 +1,9 @@
 import os
-import pytest
 import tempfile
 
-from buildtest.schemas.utils import load_schema, load_recipe
+import pytest
+
+from buildtest.schemas.utils import load_recipe, load_schema
 
 root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/tests/schemas/test_utils.py
+++ b/tests/schemas/test_utils.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 
 import pytest
-
 from buildtest.schemas.utils import load_recipe, load_schema
 
 root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/test_ascent.py
+++ b/tests/test_ascent.py
@@ -2,7 +2,6 @@ import os
 import socket
 
 import pytest
-
 from buildtest.cli.build import BuildTest
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.config import SiteConfiguration

--- a/tests/test_ascent.py
+++ b/tests/test_ascent.py
@@ -1,6 +1,8 @@
 import os
-import pytest
 import socket
+
+import pytest
+
 from buildtest.cli.build import BuildTest
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.config import SiteConfiguration

--- a/tests/test_cori.py
+++ b/tests/test_cori.py
@@ -2,7 +2,6 @@ import os
 import socket
 
 import pytest
-
 from buildtest.cli.build import BuildTest
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.config import SiteConfiguration

--- a/tests/test_cori.py
+++ b/tests/test_cori.py
@@ -1,6 +1,8 @@
 import os
-import pytest
 import socket
+
+import pytest
+
 from buildtest.cli.build import BuildTest
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.config import SiteConfiguration

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,4 @@
 import pytest
-
 from buildtest.exceptions import BuildTestError
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,5 @@
 import pytest
+
 from buildtest.exceptions import BuildTestError
 
 

--- a/tests/test_jlse.py
+++ b/tests/test_jlse.py
@@ -2,7 +2,6 @@ import os
 import socket
 
 import pytest
-
 from buildtest.cli.build import BuildTest
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.config import SiteConfiguration

--- a/tests/test_jlse.py
+++ b/tests/test_jlse.py
@@ -1,11 +1,13 @@
 import os
-import pytest
 import socket
+
+import pytest
+
 from buildtest.cli.build import BuildTest
-from buildtest.utils.file import walk_tree
 from buildtest.cli.compilers import BuildtestCompilers
 from buildtest.config import SiteConfiguration
 from buildtest.system import BuildTestSystem
+from buildtest.utils.file import walk_tree
 
 hostname = socket.getfqdn()
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,5 @@
 import tempfile
+
 from buildtest.log import init_logfile
 from buildtest.utils.file import read_file
 

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -2,7 +2,6 @@ import os
 import shutil
 
 import pytest
-
 from buildtest.cli.build import BuildTest
 from buildtest.config import SiteConfiguration
 from buildtest.system import BuildTestSystem

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -1,10 +1,12 @@
 import os
-import pytest
 import shutil
+
+import pytest
+
 from buildtest.cli.build import BuildTest
-from buildtest.utils.file import walk_tree
 from buildtest.config import SiteConfiguration
 from buildtest.system import BuildTestSystem
+from buildtest.utils.file import walk_tree
 
 
 def test_pbs():

--- a/tests/utils/test_command.py
+++ b/tests/utils/test_command.py
@@ -1,5 +1,4 @@
 import pytest
-
 from buildtest.utils.command import BuildTestCommand
 
 

--- a/tests/utils/test_command.py
+++ b/tests/utils/test_command.py
@@ -1,4 +1,5 @@
 import pytest
+
 from buildtest.utils.command import BuildTestCommand
 
 

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -6,7 +6,6 @@ import tempfile
 import uuid
 
 import pytest
-
 from buildtest.exceptions import BuildTestError
 from buildtest.utils.file import (
     create_dir,

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -1,23 +1,24 @@
-import pytest
 import os
 import random
 import shutil
 import string
-import uuid
 import tempfile
+import uuid
 
+import pytest
+
+from buildtest.exceptions import BuildTestError
 from buildtest.utils.file import (
+    create_dir,
     is_dir,
     is_file,
-    create_dir,
     load_json,
     read_file,
-    resolve_path,
     remove_file,
+    resolve_path,
     walk_tree,
     write_file,
 )
-from buildtest.exceptions import BuildTestError
 
 here = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/utils/test_shell.py
+++ b/tests/utils/test_shell.py
@@ -1,5 +1,7 @@
-import pytest
 import shutil
+
+import pytest
+
 from buildtest.exceptions import BuildTestError
 from buildtest.utils.shell import Shell
 

--- a/tests/utils/test_shell.py
+++ b/tests/utils/test_shell.py
@@ -1,7 +1,6 @@
 import shutil
 
 import pytest
-
 from buildtest.exceptions import BuildTestError
 from buildtest.utils.shell import Shell
 


### PR DESCRIPTION
This PR will sort all python imports
Add github action provided by https://pycqa.github.io/isort/docs/configuration/github_action.html
Add `.isort.cfg` to specify isort configuration
Run isort against all files