### PR TITLE
fix bug with copying output and error file with multiple tests

### DIFF
--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -305,11 +305,11 @@ class BuilderBase(ABC):
         """Copy output and error file into test root directory since stage directory will be removed."""
 
         shutil.copy2(
-            self.metadata["outfile"],
+            os.path.join(self.stage_dir, os.path.basename(self.metadata["outfile"])),
             os.path.join(self.test_root, os.path.basename(self.metadata["outfile"])),
         )
         shutil.copy2(
-            self.metadata["errfile"],
+            os.path.join(self.stage_dir, os.path.basename(self.metadata["errfile"])),
             os.path.join(self.test_root, os.path.basename(self.metadata["errfile"])),
         )
 


### PR DESCRIPTION
This PR fix a bug reported in #840 which had an issue copying output and error file during batch job submission.

We have a buildspec with three tests

```
version: "1.0"
buildspecs:
  test1:
    type: script
    executor: generic.pbs.workq
    pbs: ["-l nodes=1", "-l walltime=00:02:00"]
    run: |
      date
      whoami
      sleep 10
      hostname -f

  test2:
    type: script
    executor: generic.pbs.workq
    pbs: ["-l nodes=1", "-l walltime=00:01:00"]
    run: echo "This is a sample job 2"

  test3:
    type: script
    executor: generic.pbs.workq
    pbs: ["-l nodes=1", "-l walltime=00:01:00"]
    run: echo "This is a sample job 3"
```


We were able to build all three tests and tests were captured in the report file.

```
[pbsuser@pbs buildtest]$ buildtest -c tests/settings/pbs.yml build -b tests/examples/pbs/multiple_tests.yml 


User:  pbsuser
Hostname:  pbs
Platform:  Linux
Current Time:  2021/08/02 20:01:28
buildtest path: /tmp/GitHubDesktop/buildtest/bin/buildtest
buildtest version:  0.10.1
python path: /usr/bin/python
python version:  3.6.8
Test Directory:  /tmp/GitHubDesktop/buildtest/var/tests
Configuration File:  /tmp/GitHubDesktop/buildtest/tests/settings/pbs.yml
Command: /tmp/GitHubDesktop/buildtest/bin/buildtest -c tests/settings/pbs.yml build -b tests/examples/pbs/multiple_tests.yml

+-------------------------------+
| Stage: Discovering Buildspecs |
+-------------------------------+ 

+--------------------------------------------------------------------+
| Discovered Buildspecs                                              |
+====================================================================+
| /tmp/GitHubDesktop/buildtest/tests/examples/pbs/multiple_tests.yml |
+--------------------------------------------------------------------+
Discovered Buildspecs:  1
Excluded Buildspecs:  0
Detected Buildspecs after exclusion:  1

+---------------------------+
| Stage: Parsing Buildspecs |
+---------------------------+ 

 schemafile              | validstate   | buildspec
-------------------------+--------------+--------------------------------------------------------------------
 script-v1.0.schema.json | True         | /tmp/GitHubDesktop/buildtest/tests/examples/pbs/multiple_tests.yml



name    description
------  -------------
test1
test2
test3

+----------------------+
| Stage: Building Test |
+----------------------+ 

 name   | id       | type   | executor          | tags   | testpath
--------+----------+--------+-------------------+--------+------------------------------------------------------------------------------------------------
 test1  | 206fc460 | script | generic.pbs.workq |        | /tmp/GitHubDesktop/buildtest/var/tests/generic.pbs.workq/multiple_tests/test1/0/test1_build.sh
 test2  | 9a286972 | script | generic.pbs.workq |        | /tmp/GitHubDesktop/buildtest/var/tests/generic.pbs.workq/multiple_tests/test2/0/test2_build.sh
 test3  | 0adec488 | script | generic.pbs.workq |        | /tmp/GitHubDesktop/buildtest/var/tests/generic.pbs.workq/multiple_tests/test3/0/test3_build.sh





+---------------------+
| Stage: Running Test |
+---------------------+ 

[test1] JobID: 13.pbs dispatched to scheduler
[test2] JobID: 14.pbs dispatched to scheduler
[test3] JobID: 15.pbs dispatched to scheduler
 name   | id       | executor          | status   |   returncode
--------+----------+-------------------+----------+--------------
 test1  | 206fc460 | generic.pbs.workq | N/A      |           -1
 test2  | 9a286972 | generic.pbs.workq | N/A      |           -1
 test3  | 0adec488 | generic.pbs.workq | N/A      |           -1


Polling Jobs in 10 seconds
________________________________________
Job Queue: ['13.pbs', '14.pbs', '15.pbs']


Pending Jobs
________________________________________


+-------+-------------------+--------+----------+
| name  |     executor      | jobID  | jobstate |
+-------+-------------------+--------+----------+
| test1 | generic.pbs.workq | 13.pbs |    F     |
| test2 | generic.pbs.workq | 14.pbs |    F     |
| test3 | generic.pbs.workq | 15.pbs |    F     |
+-------+-------------------+--------+----------+


Polling Jobs in 10 seconds
________________________________________
Job Queue: ['14.pbs']


Completed Jobs
________________________________________


+-------+-------------------+--------+----------+
| name  |     executor      | jobID  | jobstate |
+-------+-------------------+--------+----------+
| test1 | generic.pbs.workq | 13.pbs |    F     |
| test3 | generic.pbs.workq | 15.pbs |    F     |
+-------+-------------------+--------+----------+


Pending Jobs
________________________________________


+-------+-------------------+--------+----------+
| name  |     executor      | jobID  | jobstate |
+-------+-------------------+--------+----------+
| test2 | generic.pbs.workq | 14.pbs |    F     |
+-------+-------------------+--------+----------+


Polling Jobs in 10 seconds
________________________________________
Job Queue: []


Completed Jobs
________________________________________


+-------+-------------------+--------+----------+
| name  |     executor      | jobID  | jobstate |
+-------+-------------------+--------+----------+
| test2 | generic.pbs.workq | 14.pbs |    F     |
| test1 | generic.pbs.workq | 13.pbs |    F     |
| test3 | generic.pbs.workq | 15.pbs |    F     |
+-------+-------------------+--------+----------+

+---------------------------------------------+
| Stage: Final Results after Polling all Jobs |
+---------------------------------------------+ 
        
 name   | id       | executor          | status   |   returncode
--------+----------+-------------------+----------+--------------
 test1  | 206fc460 | generic.pbs.workq | PASS     |            0
 test2  | 9a286972 | generic.pbs.workq | PASS     |            0
 test3  | 0adec488 | generic.pbs.workq | PASS     |            0

+----------------------+
| Stage: Test Summary  |
+----------------------+ 
    
Passed Tests: 3/3 Percentage: 100.000%
Failed Tests: 0/3 Percentage: 0.000%


Writing Logfile to: /tmp/buildtest_cox_yp7m.log
A copy of logfile can be found at $BUILDTEST_ROOT/buildtest.log -  /tmp/GitHubDesktop/buildtest/buildtest.log
[pbsuser@pbs buildtest]$ ls /tmp/GitHubDesktop/buildtest/var/tests/generic.pbs.workq/multiple_tests/test1/0/
test1.e13  test1.o13  test1.sh  test1_build.sh

```

Query the output of `test1`, `test2`, `test3`

```
[pbsuser@pbs buildtest]$ buildtest inspect query -o test1 test2 test3
______________________________ test1 (ID: 206fc460-0fb3-48b6-8f22-a3a1aa3c22e9) ______________________________
description:  None
state:  PASS
returncode:  0
runtime:  20.229591
starttime:  2021/08/02 20:01:28
endtime:  2021/08/02 20:01:48
************************* Start of Output File: /tmp/GitHubDesktop/buildtest/var/tests/generic.pbs.workq/multiple_tests/test1/0/test1.o13 *************************
Mon Aug  2 20:01:28 UTC 2021
pbsuser
pbs

************************* End of Output File: /tmp/GitHubDesktop/buildtest/var/tests/generic.pbs.workq/multiple_tests/test1/0/test1.o13 *************************

______________________________ test2 (ID: 9a286972-baa3-4363-a179-576683fc90e8) ______________________________
description:  None
state:  PASS
returncode:  0
runtime:  30.350695
starttime:  2021/08/02 20:01:28
endtime:  2021/08/02 20:01:58
************************* Start of Output File: /tmp/GitHubDesktop/buildtest/var/tests/generic.pbs.workq/multiple_tests/test2/0/test2.o14 *************************
This is a sample job 2

************************* End of Output File: /tmp/GitHubDesktop/buildtest/var/tests/generic.pbs.workq/multiple_tests/test2/0/test2.o14 *************************

______________________________ test3 (ID: 0adec488-b1fb-4318-9ba0-6e2c6f2a1034) ______________________________
description:  None
state:  PASS
returncode:  0
runtime:  20.230171
starttime:  2021/08/02 20:01:28
endtime:  2021/08/02 20:01:48
************************* Start of Output File: /tmp/GitHubDesktop/buildtest/var/tests/generic.pbs.workq/multiple_tests/test3/0/test3.o15 *************************
This is a sample job 3

************************* End of Output File: /tmp/GitHubDesktop/buildtest/var/tests/generic.pbs.workq/multiple_tests/test3/0/test3.o15 *************************


```

