### PR TITLE
CDASH buildscript content fix

### DIFF
--- a/buildtest/cli/cdash.py
+++ b/buildtest/cli/cdash.py
@@ -321,7 +321,7 @@ def upload_test_cdash(build_name, configuration, site=None, report_file=None):
             type="text/preformatted",
             name="Build Script Content",
         )
-        ET.SubElement(build_script_content, "Value").text = test["buildspec_content"]
+        ET.SubElement(build_script_content, "Value").text = test["buildscript_content"]
 
         output_measurement = ET.SubElement(results_element, "Measurement")
 


### PR DESCRIPTION
This fixed a bug where "Build Script Content" was showing content of buildspec file see https://my.cdash.org//test/40461120

<img width="496" alt="Screen Shot 2021-09-07 at 8 13 43 PM" src="https://user-images.githubusercontent.com/12942230/132425591-1a116a36-dd97-4e99-a216-31472dba95dc.png">

With this change we are able to produce content of build script.  See https://my.cdash.org//test/40723023
<img width="855" alt="Screen Shot 2021-09-07 at 8 14 22 PM" src="https://user-images.githubusercontent.com/12942230/132425630-6f85c4f8-3cd3-4610-be8d-68c47ed14530.png">
