### PR TITLE
update configuration via 'buildtest config compilers find'

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -139,7 +139,7 @@ _buildtest ()
           local opts="--help --json --yaml -h -j -y find"
           COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
           if [[ "${prev}" == "find" ]]; then
-            local opts="--debug --help -d -h"
+            local opts="--debug --help --update -d -h -u"
             COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
           fi
           ;;

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -589,6 +589,12 @@ def config_menu(subparsers):
         help="Display Debugging output when finding compilers",
         action="store_true",
     )
+    compiler_find.add_argument(
+        "-u",
+        "--update",
+        action="store_true",
+        help="Update configuration file with new compilers",
+    )
 
 
 def report_menu(subparsers):


### PR DESCRIPTION
to update configuration file.
By default it will not update configuration unless this option is specified. buildtest
will create a backup file in same directory where configuration exist before writing to file