### PR TITLE
add options to buildtest unittest command

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -257,7 +257,12 @@ _buildtest ()
       fi
       ;;
     stylecheck|style)
-     local opts="--help --no-black --no-isort --no-pyflakes --apply -h"
+      local opts="--help --no-black --no-isort --no-pyflakes --apply -h"
+
+      COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
+      ;;
+    unittests)
+      local opts="--help --pytestopts --sourcefiles -h -p -s"
 
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       ;;

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -262,7 +262,7 @@ _buildtest ()
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       ;;
     unittests)
-      local opts="--help --pytestopts --sourcefiles -h -p -s"
+      local opts="--coverage --help --pytestopts --sourcefiles -c -h -p -s"
 
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       ;;

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -5,7 +5,7 @@ interact with a global configuration for buildtest.
 import argparse
 
 from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
-from buildtest.defaults import BUILD_REPORT, console
+from buildtest.defaults import BUILD_REPORT, BUILDTEST_UNITTEST_ROOT, console
 from buildtest.schemas.defaults import schema_table
 
 
@@ -197,10 +197,20 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         ],
         help="Show help message for command",
     )
-    subparsers.add_parser(
+    unittests_parser = subparsers.add_parser(
         "unittests",
         help="Run buildtest unit tests",
     )
+    unittests_parser.add_argument(
+        "-p", "--pytestopts", type=str, help="Specify option to pytest"
+    )
+    unittests_parser.add_argument(
+        "-s",
+        "--sourcefiles",
+        help="Specify path to file or directory when running regression test",
+        nargs="+",
+    )
+
     stylecheck_parser = subparsers.add_parser(
         "stylecheck", aliases=["style"], help="Run buildtest style checks"
     )

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -202,6 +202,12 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         help="Run buildtest unit tests",
     )
     unittests_parser.add_argument(
+        "-c",
+        "--coverage",
+        action="store_true",
+        help="Enable coverage when running regression test",
+    )
+    unittests_parser.add_argument(
         "-p", "--pytestopts", type=str, help="Specify option to pytest"
     )
     unittests_parser.add_argument(

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -5,7 +5,7 @@ interact with a global configuration for buildtest.
 import argparse
 
 from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
-from buildtest.defaults import BUILD_REPORT, BUILDTEST_UNITTEST_ROOT, console
+from buildtest.defaults import BUILD_REPORT, console
 from buildtest.schemas.defaults import schema_table
 
 

--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -24,6 +24,8 @@ BUILDTEST_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 SCHEMA_ROOT = os.path.join(BUILDTEST_ROOT, "buildtest", "schemas")
 
+BUILDTEST_UNITTEST_ROOT = os.path.join(BUILDTEST_ROOT, "tests")
+
 # root of buildtest user home, default shell
 BUILDTEST_USER_HOME = os.path.join(userhome, ".buildtest")
 

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -206,7 +206,7 @@ def main():
         print_debug_report(system, configuration)
 
     elif args.subcommands == "unittests":
-        run_unit_tests()
+        run_unit_tests(pytestopts=args.pytestopts, sourcefiles=args.sourcefiles)
 
     elif args.subcommands in ["stylecheck", "style"]:
         run_style_checks(

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -206,7 +206,11 @@ def main():
         print_debug_report(system, configuration)
 
     elif args.subcommands == "unittests":
-        run_unit_tests(pytestopts=args.pytestopts, sourcefiles=args.sourcefiles)
+        run_unit_tests(
+            pytestopts=args.pytestopts,
+            sourcefiles=args.sourcefiles,
+            enable_coverage=args.coverage,
+        )
 
     elif args.subcommands in ["stylecheck", "style"]:
         run_style_checks(


### PR DESCRIPTION
Add the following options: `--pytestopt`, `--sourcefiles` and `--coverage` which configures behavior of `buildtest unittest` command. Now one can specify options to pytest when running regression test along with arbitrary sourcefiles via `--sourcefiles` option which can be a list of files or directories. The `--coverage` can be used to enable coverage report. 