### PR TITLE
add variable declaration BUILDTEST_NUMPROCS in build script

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -109,7 +109,7 @@ _buildtest ()
       COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
       ;;
     path)
-      local opts="-b -e -h -o -t --buildscript --errfile --help --outfile --stagedir --testpath"
+      local opts="-b -e -h -o -s -t --buildscript --errfile --help --outfile --stagedir --testpath"
       COMPREPLY=( $( compgen -W "$(_builder_names)" -- $cur ) )
       if [[ $cur == -* ]] ; then
         COMPREPLY=( $( compgen -W "$opts" -- $cur ) )

--- a/buildtest/buildsystem/base.py
+++ b/buildtest/buildsystem/base.py
@@ -495,6 +495,10 @@ class BuilderBase(ABC):
         )
         lines.append(f"export BUILDTEST_STAGE_DIR={self.stage_dir}")
         lines.append(f"export BUILDTEST_TEST_ID={self.metadata['full_id']}")
+
+        if self.numprocs:
+            lines.append(f"export BUILDTEST_NUMPROCS={self.numprocs}")
+
         lines.append(
             "############# END VARIABLE DECLARATION   ########################"
         )

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -159,7 +159,7 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         "-b", "--buildscript", action="store_true", help="Show path to build script"
     )
     path_group.add_argument(
-        "--stagedir", action="store_true", help="Show path to stage directory"
+        "-s", "--stagedir", action="store_true", help="Show path to stage directory"
     )
 
     path.add_argument("name", help="Name of test")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ extensions = [
     "sphinx_copybutton",
 ]
 
-# Document Python Code
+# Sphinx AutoApi configuration see https://sphinx-autoapi.readthedocs.io/en/latest/
 autoapi_type = "python"
 autoapi_dirs = [os.path.join(BUILDTEST_ROOT, "buildtest")]
 autoapi_add_toctree_entry = True
@@ -89,6 +89,7 @@ autoapi_keep_files = True
 autoapi_python_class_content = "both"
 autoapi_template_dir = "_templates/autoapi"
 
+# sphinx napoleon setting see https://sphinxcontrib-napoleon.readthedocs.io/en/latest/sphinxcontrib.napoleon.html#module-sphinxcontrib.napoleon
 napoleon_include_init_with_doc = False
 
 intersphinx_mapping = {
@@ -100,6 +101,7 @@ suppress_warnings = ["autoapi"]
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
+# configuration for sphinx-copybutton see https://sphinx-copybutton.readthedocs.io/en/latest/
 copybutton_prompt_text = r">>> |\.\.\. |\$ "
 copybutton_prompt_is_regexp = True
 
@@ -133,7 +135,6 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = 'alabaster'
 html_theme = "sphinx_rtd_theme"
 
 

--- a/docs/contributing/regression_testing.rst
+++ b/docs/contributing/regression_testing.rst
@@ -41,8 +41,7 @@ For more details on writing tests with pytest see
 Running Unit Test
 ------------------------
 
-The **buildtest unittests** command can be used to run buildtest unit test. The script
-is can be run as a standalone python script by running ``python $BUILDTEST_ROOT/tools/unittests.py``. Shown
+The **buildtest unittests** command can be used to run buildtest unit test. Shown
 below is the help option for ``buildtest unittests`` command.
 
 .. command-output:: buildtest unittests --help
@@ -58,7 +57,7 @@ a subset of regression test without running all of them.
 
 .. code-block:: console
 
-    (buildtest) bash-3.2$ buildtest unittests --pytestopts="-v" -s $BUILDTEST_ROOT/tests/utils/test_shell.py -s $BUILDTEST_ROOT/tests/utils/test_command.py
+    $ buildtest unittests --pytestopts="-v" -s $BUILDTEST_ROOT/tests/utils/test_shell.py -s $BUILDTEST_ROOT/tests/utils/test_command.py
     ========================================================================================================== test session starts ===========================================================================================================
     platform darwin -- Python 3.7.3, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /Users/siddiq90/.local/share/virtualenvs/buildtest-KLOcDrW0/bin/python3
     cachedir: .pytest_cache
@@ -103,6 +102,20 @@ a subset of regression test without running all of them.
     SKIPPED [1] ../../../../../../tmp/tests/utils/test_shell.py:89: Skipping test for tcsh shell
     ====================================================================================================== 7 passed, 3 skipped in 0.04s ======================================================================================================
 
+You can run buildtest unittest via python by running the following script
+
+.. code-block::
+
+    python $BUILDTEST_ROOT/buildtest/tools/unittests.py
+
+
+The ``buildtest unittest`` command will run this script, shown below are the options if you want to run
+the script via python
+
+.. command-output:: python $BUILDTEST_ROOT/buildtest/tools/unittests.py --help
+   :shell:
+
+
 The `pytest.ini <https://github.com/buildtesters/buildtest/blob/devel/pytest.ini>`_
 found in top-level folder defines pytest configuration for running the unit tests. Some of the unit tests are
 assigned a `marker <https://docs.pytest.org/en/6.2.x/example/markers.html>`_ which allows one to run a group of test together. You
@@ -113,8 +126,8 @@ If you want to run all tests with ``schema`` marker you can do the following::
    # run via buildtest unittests
    buildtest unittests -p="-m schema"
 
-   # run via coverage
-   coverage run -m pytest -m schema
+   # run via script
+   python $BUILDTEST_ROOT/buildtest/tools/unittests.py -p="-m schema"
 
 For a complete list of options refer to pytest `documentation <https://docs.pytest.org/en/latest/contents.html>`_
 or run ``pytest --help``.
@@ -129,10 +142,95 @@ in root of buildtest that is read by **coverage** utility. The `buildtest/tools/
 will collect coverage details upon completion of regression test which is equivalent to running ``coverage run -m pytest`` but we make some additional checks when
 running the script.
 
+To enable coverage report during regression test you can pass the ``--coverage`` option. The output will show results via `coverage report`
+and link to coverage results which can be viewed in your browser. In next example we run unit test with coverage report.
+
+.. code-block:: console
+
+
+    $ python $BUILDTEST_ROOT/buildtest/tools/unittests.py -p="-m schema" -c
+    ============================================================================= test session starts =============================================================================
+    platform darwin -- Python 3.7.3, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /Users/siddiq90/.local/share/virtualenvs/buildtest-KLOcDrW0/bin/python
+    cachedir: .pytest_cache
+    rootdir: /Users/siddiq90/Documents/GitHubDesktop/buildtest, configfile: pytest.ini
+    collected 107 items / 101 deselected / 6 selected
+
+    tests/cli/test_schema.py::test_schema_cmd PASSED                                                                                                                        [ 16%]
+    tests/schema_tests/test_compiler.py::test_compiler_examples PASSED                                                                                                      [ 33%]
+    tests/schema_tests/test_global.py::test_global_examples PASSED                                                                                                          [ 50%]
+    tests/schema_tests/test_script.py::test_script_examples PASSED                                                                                                          [ 66%]
+    tests/schema_tests/test_settings.py::test_settings_examples PASSED                                                                                                      [ 83%]
+    tests/schema_tests/test_spack.py::test_spack_examples PASSED                                                                                                            [100%]
+
+    ============================================================================ slowest 20 durations =============================================================================
+    0.57s call     tests/cli/test_schema.py::test_schema_cmd
+    0.18s call     tests/schema_tests/test_compiler.py::test_compiler_examples
+    0.14s call     tests/schema_tests/test_script.py::test_script_examples
+    0.08s call     tests/schema_tests/test_spack.py::test_spack_examples
+    0.06s call     tests/schema_tests/test_settings.py::test_settings_examples
+    0.01s call     tests/schema_tests/test_global.py::test_global_examples
+
+    (12 durations < 0.005s hidden.  Use -vv to show these durations.)
+    ====================================================================== 6 passed, 101 deselected in 1.60s ======================================================================
+    Name                                       Stmts   Miss Branch BrPart     Cover
+    -------------------------------------------------------------------------------
+    buildtest/utils/tools.py                       3      0      2      0   100.00%
+    buildtest/schemas/defaults.py                 36      0      0      0   100.00%
+    buildtest/cli/schema.py                       28      0     16      2    95.45%
+    buildtest/utils/command.py                    76      8     24      6    86.00%
+    buildtest/utils/shell.py                      69     15     22      6    76.92%
+    buildtest/executors/job.py                    13      4      2      0    73.33%
+    buildtest/schemas/utils.py                    25      6      8      4    69.70%
+    buildtest/system.py                          191     87     54     14    53.06%
+    buildtest/executors/base.py                   20     10      4      0    50.00%
+    buildtest/utils/timer.py                      17     10      8      0    44.00%
+    buildtest/buildsystem/batch.py                31     21     18      0    40.82%
+    buildtest/utils/file.py                       91     55     40      9    40.46%
+    buildtest/config.py                          198    104     82     13    40.36%
+    buildtest/cli/debugreport.py                  18     12      2      0    30.00%
+    buildtest/cli/compilers.py                   122     83     56      3    26.97%
+    buildtest/executors/pbs.py                   125     92     18      0    25.87%
+    buildtest/executors/cobalt.py                149    112     24      0    23.70%
+    buildtest/log.py                              20     15      2      0    22.73%
+    buildtest/executors/slurm.py                 153    117     34      0    21.39%
+    buildtest/executors/local.py                  51     40     10      0    21.31%
+    buildtest/executors/lsf.py                   157    124     22      0    20.67%
+    buildtest/executors/setup.py                 104     75     46      0    20.67%
+    buildtest/cli/config.py                       62     46     20      0    19.51%
+    buildtest/buildsystem/compilerbuilder.py     202    157     40      0    19.42%
+    buildtest/buildsystem/parser.py               66     51     28      0    18.09%
+    buildtest/executors/poll.py                   54     43     28      0    15.85%
+    buildtest/buildsystem/scriptbuilder.py        57     46     26      0    15.66%
+    buildtest/cli/history.py                      62     49     32      0    13.83%
+    buildtest/buildsystem/base.py                452    383    114      0    12.54%
+    buildtest/cli/clean.py                        34     28     20      0    11.11%
+    buildtest/tools/stylecheck.py                 59     51     18      0    10.39%
+    buildtest/cli/report.py                      272    230    164      0    10.09%
+    buildtest/cli/buildspec.py                   455    396    248      0     8.68%
+    buildtest/buildsystem/builders.py            160    141     88      0     8.47%
+    buildtest/cli/build.py                       481    428    200      0     8.37%
+    buildtest/cli/cdash.py                       195    176     48      0     7.82%
+    buildtest/cli/__init__.py                    205    189     12      0     7.37%
+    buildtest/cli/help.py                        175    162     20      0     6.67%
+    buildtest/buildsystem/spack.py               134    122     90      0     6.25%
+    buildtest/cli/inspect.py                     147    133     78      0     6.22%
+    buildtest/cli/path.py                         30     27     20      0     6.00%
+    buildtest/modules.py                          15     14     12      0     3.70%
+    buildtest/exceptions.py                       20     20     14      0     0.00%
+    -------------------------------------------------------------------------------
+    TOTAL                                       5034   3882   1814     57    19.52%
+
+    5 empty files skipped.
+
+
+
+    Writing coverage results to:  /Users/siddiq90/Documents/GitHubDesktop/buildtest/htmlcov
+    You can view coverage report by viewing file:  /Users/siddiq90/Documents/GitHubDesktop/buildtest/htmlcov/index.html
+
+
 If you want to view the coverage details locally in a browser you can run ``coverage html`` which will
-write the coverage report to directory **htmlcov**. You can open the file ``open htmlcov/index.html`` and it will show you
-a summary of coverage results that you would see from codecov. Shown below is a preview of coverage report that
-you would see after running your regression test.
+write the coverage report to directory **htmlcov**. You can open the file in your browser to preview coverage results.
+Shown below is a preview of what the coverage results would look like in your browser.
 
 .. image:: coverage_locally.png
 


### PR DESCRIPTION
the variable BUILDTEST_NUMPROCS will be used to reference value of processor when using `buildtest build --procs`