### PR TITLE
add global option 'buildtest --report' to specify report file

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -69,14 +69,14 @@ _buildtest ()
 
   local cmds="build buildspec cd cdash clean config debugreport docs edit help inspect history path report schema schemadocs stylecheck unittests"
   local alias_cmds="bd bc cg it et h hy rt style"
-  local opts="--color --config --debug --help --version -c -d -h -V"
+  local opts="--color --config --debug --help --report --version -c -d -h -r -V"
 
   next=${COMP_WORDS[1]}
 
   case "$next" in
     build|bd)
-      local shortoption="-b -e -f -k -r -s -t -x"
-      local longoption="--buildspec --disable-executor-check --executor --exclude --filter --helpfilter --maxpendtime --nodes --pollinterval --procs --report --retry --stage --tags"
+      local shortoption="-b -e -f -k -s -t -x"
+      local longoption="--buildspec --disable-executor-check --executor --exclude --filter --helpfilter --maxpendtime --nodes --pollinterval --procs --retry --stage --tags"
       local allopts="${longoption} ${shortoption}"
 
       COMPREPLY=( $( compgen -W "$allopts" -- $cur ) )
@@ -126,7 +126,7 @@ _buildtest ()
       ;;
 
     report|rt)
-      local opts="--filter --format --help --helpfilter --helpformat --latest --no-header --oldest --report  --terse  -h -n -r -t clear list summary"
+      local opts="--filter --format --help --helpfilter --helpformat --latest --no-header --oldest --terse  -h -n -t clear list summary"
       COMPREPLY=( $( compgen -W "$opts" -- $cur ) );;
 
     config|cg)
@@ -152,7 +152,7 @@ _buildtest ()
       esac
       ;;
     inspect|it)
-      local cmds="--help --report -h -r buildspec list name query"
+      local cmds="--help -h buildspec list name query"
 
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )
 
@@ -249,10 +249,10 @@ _buildtest ()
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )
 
       if [[ "${prev}" == "view" ]]; then
-        local opts="-h --help --url"
+        local opts="-h --help"
         COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       elif [[ "${prev}" == "upload" ]]; then
-        local opts="-h --help --site -r --report"
+        local opts="-h --help --site"
         COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       fi
       ;;

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -373,11 +373,7 @@ def build_menu(subparsers):
         type=positive_number,
         help="Rebuild test X number of times. Must be a positive number between [1-50]",
     )
-    # extra_group.add_argument(
-    #    "-r",
-    #    "--report",
-    #    help="Specify a report file where tests will be written.",
-    # )
+
     extra_group.add_argument(
         "--retry", help="Retry failed jobs", type=positive_number, default=1
     )
@@ -709,12 +705,6 @@ def report_menu(subparsers):
         help="Don't print headers column used with terse option (--terse).",
     )
 
-    # parser_report.add_argument(
-    #    "-r",
-    #    "--report",
-    #    help="Specify a report file to read",
-    #    default=BUILD_REPORT,
-    # )
     parser_report.add_argument(
         "-t",
         "--terse",
@@ -729,9 +719,7 @@ def inspect_menu(subparsers):
     parser_inspect = subparsers.add_parser(
         "inspect", aliases=["it"], help="Inspect a test based on NAME or ID "
     )
-    # parser_inspect.add_argument(
-    #    "-r", "--report", help="Specify a report file to load when inspecting test"
-    # )
+
     subparser = parser_inspect.add_subparsers(
         description="Inspect Test result based on Test ID or Test Name",
         dest="inspect",
@@ -825,8 +813,6 @@ def cdash_menu(subparsers):
     subparser.add_parser("view", help="Open CDASH project in webbrowser")
 
     upload = subparser.add_parser("upload", help="Upload Test to CDASH server")
-    # upload.add_argument(
-    #    "-r", "--report", help="Path to report file to upload test results"
-    # )
+
     upload.add_argument("--site", help="Specify site name reported in CDASH")
     upload.add_argument("buildname", help="Specify Build Name reported in CDASH")

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -120,7 +120,7 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
     parser.add_argument(
         "--no-color", help="Disable colored output", action="store_true"
     )
-
+    parser.add_argument("-r", "--report", help="Specify path to test report file")
     subparsers = parser.add_subparsers(title="COMMANDS", dest="subcommands", metavar="")
 
     build_menu(subparsers)
@@ -373,11 +373,11 @@ def build_menu(subparsers):
         type=positive_number,
         help="Rebuild test X number of times. Must be a positive number between [1-50]",
     )
-    extra_group.add_argument(
-        "-r",
-        "--report",
-        help="Specify a report file where tests will be written.",
-    )
+    # extra_group.add_argument(
+    #    "-r",
+    #    "--report",
+    #    help="Specify a report file where tests will be written.",
+    # )
     extra_group.add_argument(
         "--retry", help="Retry failed jobs", type=positive_number, default=1
     )
@@ -669,7 +669,7 @@ def report_menu(subparsers):
         metavar="",
         dest="report_subcommand",
     )
-    subparsers.add_parser("clear", help="delete report file")
+    subparsers.add_parser("clear", help="Remove all report file")
     subparsers.add_parser("list", help="List all report files")
     subparsers.add_parser("summary", help="Summarize test report")
 
@@ -709,12 +709,12 @@ def report_menu(subparsers):
         help="Don't print headers column used with terse option (--terse).",
     )
 
-    parser_report.add_argument(
-        "-r",
-        "--report",
-        help="Specify a report file to read",
-        default=BUILD_REPORT,
-    )
+    # parser_report.add_argument(
+    #    "-r",
+    #    "--report",
+    #    help="Specify a report file to read",
+    #    default=BUILD_REPORT,
+    # )
     parser_report.add_argument(
         "-t",
         "--terse",
@@ -729,9 +729,9 @@ def inspect_menu(subparsers):
     parser_inspect = subparsers.add_parser(
         "inspect", aliases=["it"], help="Inspect a test based on NAME or ID "
     )
-    parser_inspect.add_argument(
-        "-r", "--report", help="Specify a report file to load when inspecting test"
-    )
+    # parser_inspect.add_argument(
+    #    "-r", "--report", help="Specify a report file to load when inspecting test"
+    # )
     subparser = parser_inspect.add_subparsers(
         description="Inspect Test result based on Test ID or Test Name",
         dest="inspect",
@@ -822,12 +822,11 @@ def cdash_menu(subparsers):
     subparser = parser_cdash.add_subparsers(
         description="buildtest CDASH integeration", dest="cdash", metavar=""
     )
-    view = subparser.add_parser("view", help="Open CDASH project in webbrowser")
-    view.add_argument("--url", help="Specify a url to CDASH project")
+    subparser.add_parser("view", help="Open CDASH project in webbrowser")
 
     upload = subparser.add_parser("upload", help="Upload Test to CDASH server")
-    upload.add_argument(
-        "-r", "--report", help="Path to report file to upload test results"
-    )
+    # upload.add_argument(
+    #    "-r", "--report", help="Path to report file to upload test results"
+    # )
     upload.add_argument("--site", help="Specify site name reported in CDASH")
     upload.add_argument("buildname", help="Specify Build Name reported in CDASH")

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -5,7 +5,7 @@ interact with a global configuration for buildtest.
 import argparse
 
 from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
-from buildtest.defaults import BUILD_REPORT, console
+from buildtest.defaults import console
 from buildtest.schemas.defaults import schema_table
 
 

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -38,7 +38,6 @@ from buildtest.utils.file import (
     is_dir,
     is_file,
     load_json,
-    read_file,
     resolve_path,
     walk_tree,
 )

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -24,7 +24,7 @@ from buildtest.defaults import (
     BUILDSPEC_CACHE_FILE,
     BUILDTEST_DEFAULT_TESTDIR,
     BUILDTEST_LOGFILE,
-    BUILDTEST_REPORT_SUMMARY,
+    BUILDTEST_REPORTS,
     DEFAULT_LOGDIR,
     console,
 )
@@ -1261,16 +1261,15 @@ def update_report(valid_builders, report_file):
 
     logger.debug(f"Updating report file: {report_file}")
     console.print(f"Adding {len(valid_builders)} test results to {report_file}")
-    #  BUILDTEST_REPORT_SUMMARY file keeps track of all report files which
+    #  BUILDTEST_REPORTS file keeps track of all report files which
     #  contains a single line that denotes path to report file. This file only contains unique report files
 
     content = []
-    if is_file(BUILDTEST_REPORT_SUMMARY):
-        content = read_file(BUILDTEST_REPORT_SUMMARY)
-        content = content.split("\n")
+    if is_file(BUILDTEST_REPORTS):
+        content = load_json(BUILDTEST_REPORTS)
 
     if report_file not in content:
         content.append(report_file)
 
-    with open(BUILDTEST_REPORT_SUMMARY, "w") as fd:
-        fd.write("\n".join(content))
+    with open(BUILDTEST_REPORTS, "w") as fd:
+        json.dump(content, fd, indent=2)

--- a/buildtest/cli/cdash.py
+++ b/buildtest/cli/cdash.py
@@ -13,12 +13,12 @@ from urllib.request import Request, urlopen
 
 import requests
 import yaml
-from buildtest.defaults import BUILD_REPORT
+from buildtest.defaults import BUILD_REPORT, console
 from buildtest.utils.file import resolve_path
 from buildtest.utils.tools import deep_get
 
 
-def cdash_cmd(args, default_configuration=None, open_browser=True):
+def cdash_cmd(args, default_configuration=None, open_browser=True, report_file=None):
     """This method is entry point for ``buildtest cdash`` command which implements uploading
     results to CDASH server and command line interface to open CDASH project.
 
@@ -38,8 +38,6 @@ def cdash_cmd(args, default_configuration=None, open_browser=True):
     if not configuration.target_config:
         sys.exit("Unable to load a configuration file")
 
-    print("Reading configuration file: ", configuration.file)
-
     cdash_config = deep_get(configuration.target_config, "cdash")
 
     if not cdash_config:
@@ -48,16 +46,12 @@ def cdash_cmd(args, default_configuration=None, open_browser=True):
         )
 
     if args.cdash == "view":
-        # if url is specified on command line (buildtest cdash view --url) then open link as is
-        if args.url and open_browser:
-            webbrowser.open(args.url)
-            return
 
         url = cdash_config["url"]
         project = cdash_config["project"]
         target_url = urljoin(url, f"index.php?project={project}")
 
-        print("URL:", target_url)
+        console.print("Opening URL:", target_url)
         # check for url via requests, it can raise an exception if its invalid URL in that case we print a message
         try:
             r = requests.get(target_url)
@@ -84,7 +78,7 @@ def cdash_cmd(args, default_configuration=None, open_browser=True):
             build_name=args.buildname,
             configuration=configuration,
             site=args.site,
-            report_file=args.report,
+            report_file=report_file,
         )
 
 

--- a/buildtest/cli/clean.py
+++ b/buildtest/cli/clean.py
@@ -6,7 +6,7 @@ from buildtest.defaults import (
     BUILD_HISTORY_DIR,
     BUILD_REPORT,
     BUILDSPEC_CACHE_FILE,
-    BUILDTEST_REPORT_SUMMARY,
+    BUILDTEST_REPORTS,
 )
 from buildtest.utils.file import is_dir, is_file
 
@@ -54,8 +54,8 @@ def clean(configuration, yes):
         print("======> Removing Report File")
         if is_file(BUILD_REPORT):
             os.remove(BUILD_REPORT)
-        if is_file(BUILDTEST_REPORT_SUMMARY):
-            os.remove(BUILDTEST_REPORT_SUMMARY)
+        if is_file(BUILDTEST_REPORTS):
+            os.remove(BUILDTEST_REPORTS)
 
     if remove_history == "y":
         print("======> Removing History Directory")

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -274,8 +274,8 @@ def print_report_help():
     table.add_row("buildtest report --helpformat", "List all format fields")
     table.add_row("buildtest report --latest", "Retrieve latest record for all tests")
     table.add_row(
-        "buildtest report -r <report-file>",
-        "Specify alternate report file to display test results",
+        "buildtest -r /tmp/result.json report",
+        "Read report file /tmp/result.json and display result",
     )
     table.add_row("buildtest report --terse", "Print report in terse format")
     table.add_row("buildtest report list", "List all report files")
@@ -329,22 +329,15 @@ def print_cdash_help():
         "Upload all tests to cdash with build name 'DEMO'",
     )
     table.add_row(
-        "buildtest cdash upload 'DAILY_CHECK' --report result.json",
-        "Upload all tests from report file 'result.json' with build name 'DAILY_CHECK'",
+        "buildtest --report /tmp/result.json cdash upload DAILY_CHECK ",
+        "Upload all tests from report file '/tmp/result.json' with build name DAILY_CHECK",
     )
     table.add_row(
         "buildtest cdash upload --site laptop DEMO",
         "Upload tests to CDASH with site named called 'laptop'",
     )
-    table.add_row(
-        "buildtest cdash upload -r /tmp/nightly.json nightly",
-        "Upload tests from /tmp/nightly.json to CDASH with buildname 'nightly'",
-    )
+
     table.add_row("buildtest cdash view", "Open CDASH project in web-browser")
-    table.add_row(
-        "buildtest cdash view --url <url>",
-        "Open CDASH project in web-browser with a specified url",
-    )
 
     console.print(table)
 

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -11,22 +11,18 @@ from rich.syntax import Syntax
 from rich.table import Column, Table
 
 
-def inspect_cmd(args):
+def inspect_cmd(args, report_file):
     """Entry point for ``buildtest inspect`` command
 
     Args:
         args (dict): Parsed arguments from `ArgumentParser.parse_args <https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_args>`_
     """
 
-    report_file = BUILD_REPORT
-    if args.report:
-
-        report_file = resolve_path(args.report)
+    # report_file = BUILD_REPORT
+    if report_file:
+        report_file = resolve_path(report_file)
 
     report = Report(report_file)
-
-    # if not args.parse:
-    #    print(f"Reading Report File: {report_file} \n")
 
     # implements command 'buildtest inspect list'
     if args.inspect == "list":

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -4,7 +4,7 @@ import re
 import sys
 
 from buildtest.cli.report import Report
-from buildtest.defaults import BUILD_REPORT, console
+from buildtest.defaults import console
 from buildtest.utils.file import read_file, resolve_path
 from rich.pretty import pprint
 from rich.syntax import Syntax

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -11,16 +11,12 @@ from rich.syntax import Syntax
 from rich.table import Column, Table
 
 
-def inspect_cmd(args, report_file):
+def inspect_cmd(args, report_file=None):
     """Entry point for ``buildtest inspect`` command
 
     Args:
         args (dict): Parsed arguments from `ArgumentParser.parse_args <https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_args>`_
     """
-
-    # report_file = BUILD_REPORT
-    if report_file:
-        report_file = resolve_path(report_file)
 
     report = Report(report_file)
 
@@ -109,24 +105,26 @@ def inspect_list(report, terse=None, header=None, builder=None):
     if terse:
         # print column headers if --no-header is not specified
         if not header:
-            print("name|id|buildspec")
+            console.print("[blue]id|name|buildspec")
 
         for identifier in test_ids.keys():
-            print(
+            console.print(
                 f"{identifier}|{test_ids[identifier]['name']}|{test_ids[identifier]['buildspec']}"
             )
 
         return
 
     table = Table(
-        "[blue]name",
         "[blue]id",
+        "[blue]name",
         Column(header="[blue]buildspec", overflow="fold"),
         title="Test Summary by name, id, buildspec",
     )
     for identifier in test_ids.keys():
         table.add_row(
-            identifier, test_ids[identifier]["name"], test_ids[identifier]["buildspec"]
+            f"[red]{identifier}",
+            f"[cyan]{test_ids[identifier]['name']}",
+            f"[green]{test_ids[identifier]['buildspec']}",
         )
     console.print(table)
 

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -612,10 +612,11 @@ class Report:
         return records
 
 
-def report_cmd(args, report_file):
+def report_cmd(args, report_file=None):
     """Entry point for ``buildtest report`` command"""
 
     if args.report_subcommand == "clear":
+        # if BUILDTEST_REPORTS file is not present then we have no report files to delete since it tracks all report files that are created
         if not is_file(BUILDTEST_REPORTS):
             sys.exit(f"There is no report file to delete")
 
@@ -629,10 +630,11 @@ def report_cmd(args, report_file):
 
     if args.report_subcommand == "list":
         if not is_file(BUILDTEST_REPORTS):
-            console.print(
-                "There are no report files, please run 'buildtest build' to generate a report file."
+            sys.exit(
+                console.print(
+                    "There are no report files, please run 'buildtest build' to generate a report file."
+                )
             )
-            sys.exit(0)
 
         content = load_json(BUILDTEST_REPORTS)
         for fname in content:

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -4,7 +4,7 @@ import sys
 
 from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORTS, console
 from buildtest.exceptions import BuildTestError
-from buildtest.utils.file import is_file, load_json, read_file, resolve_path
+from buildtest.utils.file import is_file, load_json, resolve_path
 from rich.table import Table
 
 logger = logging.getLogger(__name__)
@@ -618,7 +618,7 @@ def report_cmd(args, report_file=None):
     if args.report_subcommand == "clear":
         # if BUILDTEST_REPORTS file is not present then we have no report files to delete since it tracks all report files that are created
         if not is_file(BUILDTEST_REPORTS):
-            sys.exit(f"There is no report file to delete")
+            sys.exit("There is no report file to delete")
 
         reports = load_json(BUILDTEST_REPORTS)
         for report in reports:

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORT_SUMMARY, console
+from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORTS, console
 from buildtest.exceptions import BuildTestError
 from buildtest.utils.file import is_file, load_json, read_file, resolve_path
 from rich.table import Table
@@ -93,13 +93,15 @@ class Report:
         self.oldest = oldest
         self.filter = filter_args
         self.format = format_args
+
         self.input_report = report_file
 
-        # if no report set we read the default report file
-        if report_file:
-            self._reportfile = resolve_path(report_file)
-        else:
+        # if no report specified use default report
+        if not self.input_report:
             self._reportfile = BUILD_REPORT
+        # otherwise honor report file specified on argument
+        else:
+            self._reportfile = resolve_path(report_file)
 
         self.report = self.load()
         self._check_filter_fields()
@@ -185,11 +187,17 @@ class Report:
         """
 
         if not self._reportfile:
-            sys.exit(f"Unable to resolve path to report file: {self.input_report}")
+            sys.exit(
+                console.print(
+                    f"[red]Unable to resolve path to report file: {self.input_report}"
+                )
+            )
 
         if not is_file(self._reportfile):
             sys.exit(
-                f"Unable to find report please check if {self._reportfile} is a file"
+                console.print(
+                    f"Unable to find report please check if {self._reportfile} is a file or run a test via 'buildtest build' to generate report file"
+                )
             )
 
         report = load_json(self._reportfile)
@@ -604,25 +612,31 @@ class Report:
         return records
 
 
-def report_cmd(args):
+def report_cmd(args, report_file):
     """Entry point for ``buildtest report`` command"""
 
     if args.report_subcommand == "clear":
-        if not is_file(args.report):
-            sys.exit(f"There is no report file: {args.report} to delete")
-        print(f"Removing report file: {args.report}")
-        os.remove(BUILD_REPORT)
+        if not is_file(BUILDTEST_REPORTS):
+            sys.exit(f"There is no report file to delete")
+
+        reports = load_json(BUILDTEST_REPORTS)
+        for report in reports:
+            console.print(f"Removing report file: {report}")
+            os.remove(report)
+
+        os.remove(BUILDTEST_REPORTS)
         return
 
     if args.report_subcommand == "list":
-        if not is_file(BUILDTEST_REPORT_SUMMARY):
-            print(
+        if not is_file(BUILDTEST_REPORTS):
+            console.print(
                 "There are no report files, please run 'buildtest build' to generate a report file."
             )
-            return
+            sys.exit(0)
 
-        content = read_file(BUILDTEST_REPORT_SUMMARY)
-        print(content)
+        content = load_json(BUILDTEST_REPORTS)
+        for fname in content:
+            console.print(fname)
         return
 
     results = Report(
@@ -630,7 +644,7 @@ def report_cmd(args):
         format_args=args.format,
         latest=args.latest,
         oldest=args.oldest,
-        report_file=args.report,
+        report_file=report_file,
     )
     if args.report_subcommand == "summary":
         report_summary(results)

--- a/buildtest/defaults.py
+++ b/buildtest/defaults.py
@@ -39,11 +39,11 @@ BUILDSPEC_CACHE_FILE = os.path.join(BUILDTEST_BUILDSPEC_DIR, "cache.json")
 
 BUILD_REPORT = os.path.join(VAR_DIR, "report.json")
 
-#  BUILDTEST_REPORT_SUMMARY file keeps track of all unique report files as result of 'buildtest build' commands.
+#  BUILDTEST_REPORTS file keeps track of all unique report files as result of 'buildtest build' commands.
 #  The file contains a single line that denotes path to report file and one can specify alternate path to report file
 # using 'buildtest build -r <report>' and this is used by 'buildtest inspect' and 'buildtest report' if one wants to
 # read a different report file
-BUILDTEST_REPORT_SUMMARY = os.path.join(VAR_DIR, "report-summary.txt")
+BUILDTEST_REPORTS = os.path.join(VAR_DIR, "list-report.json")
 
 BUILDSPEC_DEFAULT_PATH = [
     os.path.join(BUILDTEST_ROOT, "tutorials"),

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -59,6 +59,8 @@ def main():
 
     console.no_color = no_color
 
+    report_file = args.report
+
     # if no commands just print the help message and return.
     if not args.subcommands:
         print(parser.print_help())
@@ -114,7 +116,7 @@ def main():
                 stage=args.stage,
                 testdir=args.testdir,
                 buildtest_system=system,
-                report_file=args.report,
+                report_file=report_file,
                 maxpendtime=args.maxpendtime,
                 poll_interval=args.pollinterval,
                 keep_stage_dir=args.keep_stage_dir,
@@ -157,7 +159,7 @@ def main():
 
     # running buildtest inspect
     elif args.subcommands in ["inspect", "it"]:
-        inspect_cmd(args)
+        inspect_cmd(args, report_file=report_file)
 
     # running buildtest config
     elif args.subcommands in ["config", "cg"]:
@@ -169,7 +171,7 @@ def main():
 
     # buildtest report
     elif args.subcommands in ["report", "rt"]:
-        report_cmd(args)
+        report_cmd(args, report_file)
 
     elif args.subcommands == "path":
         path_cmd(
@@ -186,7 +188,7 @@ def main():
 
     # running buildtest cdash
     elif args.subcommands == "cdash":
-        cdash_cmd(args, default_configuration=configuration)
+        cdash_cmd(args, default_configuration=configuration, report_file=report_file)
 
     elif args.subcommands in ["help", "h"]:
         buildtest_help(command=args.command)

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -114,12 +114,12 @@ the test results with different buildname assuming you have different paths to r
 Let's say we want to build all python tests using tags and store them in a report file which we
 want to push to CDASH with buildgroup name ``python`` we can do that as follows
 
-.. command-output:: buildtest build --tags python -r $BUILDTEST_ROOT/python.json
+.. command-output:: buildtest -r $BUILDTEST_ROOT/python.json build --tags python
     :shell:
 
 Next we upload the tests using the ``-r`` option to specify the report file
 
-.. command-output:: buildtest cdash upload -r $BUILDTEST_ROOT/python.json python
+.. command-output:: buildtest -r $BUILDTEST_ROOT/python.json cdash upload python
     :shell:
 
 The ``buildtest cdash view`` command can be used to open CDASH project in a web browser
@@ -213,15 +213,14 @@ If you want to see content of output file, you can use ``-o`` option with **cat*
     :shell:
 
 In this next example we will query test **circle_area** with build ID **aaa** and buildtest will find the first match record that
-starts with this record and resolves to **aaaa622d** which is the short ID of test.
+starts with this record and resolves to **aaaa622d** which is the short ID of test. In the second example we query the latest path
+for latest run for test **circle_area**
 
 .. code-block:: console
 
-    # query testroot for circle_area with build ID "aaa"
     $ buildtest path circle_area/aaa
     /Users/siddiq90/Documents/GitHubDesktop/buildtest/var/tests/generic.local.python/python-shell/circle_area/aaaa622d
 
-    # query testroot for latest run of circle_area
     $ buildtest path circle_area
     /Users/siddiq90/Documents/GitHubDesktop/buildtest/var/tests/generic.local.python/python-shell/circle_area/fc221b84
 

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -341,10 +341,10 @@ Using Alternate Report File
 The ``buildtest report`` and ``buildtest inspect`` command will read from the report file tracked by buildtest which is
 stored in **$BUILDTEST_ROOT/var/report.json**. This single file can became an issue if you are running jobs through CI where you
 can potentially overwrite same file or if you want separate report files for each set of builds. Luckily we have an option to handle
-this using the ``buildtest build -r /path/to/report`` option which can be used to specify an alternate location to report file.
+this using the ``buildtest -r <report_path> build -b <buildspec_path>`` option which can be used to specify an alternate location to report file.
 
 buildtest will write the report file in the desired location, then you can specify the path to report file via
-``buildtest report -r /path/to/report`` and ``buildtest inspect -r /path/to/report`` to load the report file when reporting tests.
+``buildtest -r <report_path> report`` and ``buildtest -r <report_path> inspect`` to load the report file when reporting tests.
 
 The report file must be valid JSON file that buildtest understands in order to use `buildtest report` and
 `buildtest inspect` command. Shown below are some examples using the alternate report file using ``buildtest report`` and
@@ -352,7 +352,7 @@ The report file must be valid JSON file that buildtest understands in order to u
 
 .. code-block:: console
 
-    $ buildtest report -r $BUILDTEST_ROOT/python.json --format name,id
+    $ buildtest -r $BUILDTEST_ROOT/python.json report --format name,id
                           Report File: /Users/siddiq90/Documents/GitHubDesktop/buildtest/python.json
     ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     ┃ name                                                               ┃ id                                            ┃

--- a/setup.sh
+++ b/setup.sh
@@ -34,8 +34,13 @@ fi
 
 python=python3
 
+# Need 'set +e' so that process is not terminated especially when using in CI
+set +e
+
 $python -c "import buildtest.main" &> /dev/null
 returncode=$?
+
+set -e
 
 # if we are unable to import buildtest.main then install buildtest dependencies
 if [ $returncode -ne 0 ]; then

--- a/tests/cli/test_cdash.py
+++ b/tests/cli/test_cdash.py
@@ -22,7 +22,6 @@ def test_cdash_upload():
         cdash = "upload"
         buildname = "TESTING"
         site = None
-        report = None
 
     cdash_cmd(args, default_configuration=configuration)
 
@@ -32,7 +31,6 @@ def test_cdash_upload_exceptions():
         cdash = "upload"
         buildname = None
         site = None
-        report = None
 
     # a buildname must be specified, a None will result in error
     with pytest.raises(SystemExit):
@@ -49,7 +47,6 @@ def test_cdash_upload_exceptions():
         cdash = "upload"
         buildname = "DEMO"
         site = None
-        report = None
 
     # in configuration file we have invalid url to CDASH server
     with pytest.raises(SystemExit):
@@ -64,7 +61,6 @@ def test_cdash_upload_exceptions():
         cdash = "upload"
         buildname = "DEMO"
         site = None
-        report = None
 
     # in configuration file we have invalid project name in CDASH
     with pytest.raises(SystemExit):

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -14,9 +14,8 @@ def test_buildtest_inspect_list():
 
     # running buildtest inspect list
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "list"
-        report = False
         terse = False
         no_header = False
         builder = False
@@ -25,9 +24,8 @@ def test_buildtest_inspect_list():
 
     # running buildtest inspect list --terse --no-header
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "list"
-        report = False
         terse = True
         no_header = True
         builder = False
@@ -36,9 +34,8 @@ def test_buildtest_inspect_list():
 
     # running buildtest inspect list --terse
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "list"
-        report = False
         terse = True
         no_header = False
         builder = False
@@ -47,9 +44,8 @@ def test_buildtest_inspect_list():
 
     # running buildtest inspect list --builder
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "list"
-        report = False
         terse = False
         no_header = False
         builder = True
@@ -66,7 +62,7 @@ def test_buildtest_inspect_name():
     # print(test_ids)
 
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "name"
         name = [test_names]
         report = None
@@ -75,7 +71,7 @@ def test_buildtest_inspect_name():
     inspect_cmd(args)
 
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "name"
         name = [test_names]
         report = None
@@ -91,7 +87,7 @@ def test_buildtest_inspect_name():
     ]
 
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "name"
         name = random_test
         report = None
@@ -101,7 +97,7 @@ def test_buildtest_inspect_name():
         inspect_cmd(args)
 
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "name"
         name = [r.builder_names()[0]]
         report = None
@@ -114,7 +110,7 @@ def test_buildspec_inspect_buildspec():
     tf = tempfile.NamedTemporaryFile(delete=True)
 
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "buildspec"
         buildspec = [tf.name]
         report = None
@@ -136,7 +132,7 @@ def test_buildspec_inspect_buildspec():
     ]
 
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "buildspec"
         buildspec = search_buildspec
         report = None
@@ -146,7 +142,7 @@ def test_buildspec_inspect_buildspec():
     inspect_cmd(args)
 
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "buildspec"
         buildspec = search_buildspec
         report = None
@@ -162,20 +158,19 @@ def test_buildtest_query():
     names = report.get_names()
 
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "query"
         name = names
-        report = None
         output = True
         error = True
         testpath = True
         buildscript = True
 
-    # check buildtest inspect query --output --error --testpath --buildscript -d last <name1> <name2> ...
+    # check buildtest inspect query --output --error --testpath --buildscript <name1> <name2> ...
     inspect_cmd(args)
 
     class args:
-        subcommands = "config"
+        subcommands = "inspect"
         inspect = "query"
         name = ["".join(random.choice(string.ascii_letters) for i in range(10))]
         report = None

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -13,7 +13,7 @@ from buildtest.exceptions import BuildTestError
 @pytest.mark.cli
 def test_report():
 
-    assert os.path.exists(BUILD_REPORT)
+    # assert os.path.exists(BUILD_REPORT)
 
     result = Report()
     print("Processing Report File:", result.reportfile())
@@ -170,7 +170,6 @@ def test_report_list():
         format = None
         oldest = False
         latest = False
-        report = BUILD_REPORT
         report_subcommand = "list"
         terse = None
 
@@ -178,7 +177,9 @@ def test_report_list():
 
     # now removing report summary it should print a message
     os.remove(BUILDTEST_REPORTS)
-    report_cmd(args)
+
+    with pytest.raises(SystemExit):
+        report_cmd(args)
 
 
 @pytest.mark.cli
@@ -190,7 +191,6 @@ def test_report_clear():
         format = None
         oldest = False
         latest = False
-        report = BUILD_REPORT
         report_subcommand = None
         terse = None
         no_header = None
@@ -208,11 +208,11 @@ def test_report_clear():
         format = None
         oldest = False
         latest = False
-        report = "".join(random.choice(string.ascii_letters) for i in range(10))
         report_subcommand = "clear"
         terse = None
         no_header = None
 
+    report_file = "".join(random.choice(string.ascii_letters) for i in range(10))
     # buildtest report clear <file> will raise an error since file doesn't exist
     with pytest.raises(SystemExit):
-        report_cmd(args)
+        report_cmd(args, report_file=report_file)

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -6,7 +6,7 @@ import tempfile
 
 import pytest
 from buildtest.cli.report import Report, report_cmd, report_summary
-from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORT_SUMMARY, BUILDTEST_ROOT
+from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORTS, BUILDTEST_ROOT
 from buildtest.exceptions import BuildTestError
 
 
@@ -177,7 +177,7 @@ def test_report_list():
     report_cmd(args)
 
     # now removing report summary it should print a message
-    os.remove(BUILDTEST_REPORT_SUMMARY)
+    os.remove(BUILDTEST_REPORTS)
     report_cmd(args)
 
 


### PR DESCRIPTION
This PR will remove the `--report` option from subcommands found in `buildtest build`, `buildtest inspect`, `buildtest report` and `buildtest cdash upload`. 
We remove `buildtest cdash view --url` option and also made improvement to `buildtest inspect list` and color code output. Fix regression test.