### PR TITLE
add support for specifying modules  and purge modules in command line

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -91,8 +91,8 @@ _buildtest ()
 
   case "$next" in
     build|bd)
-      local shortoption="-b -e -f -k -s -t -x"
-      local longoption="--buildspec --disable-executor-check --executor --exclude --filter --helpfilter --maxpendtime --nodes --pollinterval --procs --retry --stage --tags"
+      local shortoption="-b -e -f -k -m -s -t -x"
+      local longoption="--buildspec --disable-executor-check --executor --exclude --filter --helpfilter --maxpendtime --modules --module-purge --nodes --pollinterval --procs --retry --stage --tags"
       local allopts="${longoption} ${shortoption}"
 
       COMPREPLY=( $( compgen -W "$allopts" -- $cur ) )

--- a/buildtest/builders/base.py
+++ b/buildtest/builders/base.py
@@ -297,11 +297,18 @@ class BuilderBase(ABC):
         # self.duration += self.timer.stop()
         self.timer.stop()
 
-    def build(self):
+    def build(self, modules=None, modulepurge=None):
         """This method is responsible for invoking setup, creating test
         directory and writing test. This method is called from an instance
         object of this class that does ``builder.build()``.
+
+        args:
+            modules (str, optional): Specify a list of modules to load in the build script
+            modules (bool, optional): A boolean to control whether 'module purge' is run before running test
         """
+
+        self.modules = modules
+        self.modulepurge = modulepurge
 
         self._build_setup()
         self._write_test()
@@ -609,6 +616,15 @@ class BuilderBase(ABC):
 
         lines += self._default_test_variables()
         lines.append("# source executor startup script")
+
+        if self.modulepurge:
+            lines.append("module purge")
+
+        if self.modules:
+            lines.append("# Specify list of modules to load")
+            for module in self.modules.split(","):
+
+                lines.append(f"module load {module}")
 
         lines += [
             f"source {os.path.join(BUILDTEST_EXECUTOR_DIR, self.executor, 'before_script.sh')}"

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -383,7 +383,7 @@ def build_menu(subparsers):
     extra_group.add_argument(
         "-s",
         "--stage",
-        help="control behavior of buildtest build",
+        help="Control behavior of buildtest build to stop execution after 'parse' or 'build' stage",
         choices=["parse", "build"],
     )
 
@@ -396,6 +396,18 @@ def build_menu(subparsers):
         help="Specify number of processes to run tests (only applicable with batch jobs). Multiple values can be specified comma separated.",
         nargs="+",
         type=positive_number,
+    )
+    extra_group.add_argument(
+        "--module-purge",
+        action="store_true",
+        help="Run 'module purge' before running any test ",
+    )
+    extra_group.add_argument(
+        "-m",
+        "--modules",
+        type=str,
+        help="Specify a list of modules to load during test execution, to specify multiple modules each one must be comma"
+        "separated for instance if you want to load 'gcc' and 'python' module you can do '-m gcc,python' ",
     )
 
     extra_group.add_argument(

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -485,6 +485,8 @@ class BuildTest:
         helpfilter=None,
         numprocs=None,
         numnodes=None,
+        modules=None,
+        modulepurge=None,
     ):
         """The initializer method is responsible for checking input arguments for type
         check, if any argument fails type check we raise an error. If all arguments pass
@@ -510,6 +512,8 @@ class BuildTest:
             helpfilter (bool, optional): Display available filter fields for ``buildtest build --filter`` command. This argument is set to ``True`` if one specifies ``buildtest build --helpfilter``
             numprocs (str, optional): List of comma separated process values to run batch jobs specified via ``buildtest build --procs``
             numnodes (str, optional): List of comma separated nodes values to run batch jobs specified via ``buildtest build --nodes``
+            modules (str, optional): List of modules to load for every test specified via ``buildtest build --modules``.
+            modulepurge (bool, optional): Determine whether to run 'module purge' before running test. This is specified via ``buildtest build --modulepurge``.
         """
 
         if buildspecs and not isinstance(buildspecs, list):
@@ -556,6 +560,8 @@ class BuildTest:
         self.stage = stage
         self.filter_buildspecs = filter_buildspecs
         self.rebuild = rebuild
+        self.modules = modules
+        self.modulepurge = modulepurge
 
         # this variable contains the detected buildspecs that will be processed by buildtest.
         self.detected_buildspecs = None
@@ -850,7 +856,7 @@ class BuildTest:
             builder.builderdeps = self.builders
 
             try:
-                builder.build()
+                builder.build(modules=self.modules, modulepurge=self.modulepurge)
             except BuildTestError as err:
                 console.print(f"[red]{err}")
                 invalid_builders.append(builder)

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -132,6 +132,8 @@ def main():
                 helpfilter=args.helpfilter,
                 numprocs=args.procs,
                 numnodes=args.nodes,
+                modules=args.modules,
+                modulepurge=args.module_purge,
             )
             cmd.build()
 

--- a/docs/gettingstarted/buildingtest.rst
+++ b/docs/gettingstarted/buildingtest.rst
@@ -293,6 +293,18 @@ If you try to exceed this bound you will get an error such as
 .. command-output:: buildtest build -b tutorials/pass_returncode.yml --rebuild 51
     :returncode: 1
 
+Specify Modules in command line
+--------------------------------
+
+If your system supports ``modules`` such as environment-modules or Lmod you can specify a list
+of modules to load (``module load``) in the test via ``buildtest build --modules``. You can specify
+a comma separated list of modules to load, for example if you want to load `gcc` and `python` module in
+your test you can run ``buildtest build --modules gcc,python``. You may specify full name of module with
+version for instance you want test to load `gcc/9.3.0` and `python/3.7` you can run ``buildtest build --modules gcc/9.3.0,python/3.7``.
+
+If you want test to run ``module purge`` before running test you can specify ``buildtest build --module-purge`` option. If you specify
+``--module-purge`` and ``--modules`` then ``module purge`` will be run prior to loading any modules.
+
 Use Alternate Configuration file
 ---------------------------------
 


### PR DESCRIPTION
- Add new option ``buildtest build --modules``
- Add new option ``buildtest build --module-purge``
- Add options to bash completion script
- Add user documentation for these options