### PR TITLE
Add new command  buildtest buildspec edit

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -204,7 +204,7 @@ _buildtest ()
       ;;
 
     buildspec|bc)
-      local cmds="-h --help find show summary validate"
+      local cmds="-h --help edit find show summary validate"
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )
 
       # switch based on 2nd word 'buildtest buildspec <subcommand>'
@@ -224,7 +224,7 @@ _buildtest ()
            COMPREPLY=( $( compgen -W "${allopts}" -- $cur ) );;
          esac
         ;;
-      show)
+      show|edit)
         COMPREPLY=( $( compgen -W "$(_buildspec_cache_test_names)" -- $cur ) );;
       validate)
         local opts="--buildspec --exclude --executor --tag -b -e -t -x "

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -460,6 +460,15 @@ def buildspec_menu(subparsers):
         nargs="*",
     )
 
+    edit_buildspecs = subparsers_buildspec.add_parser(
+        "edit", help="Edit buildspec file based on test name"
+    )
+    edit_buildspecs.add_argument(
+        "name",
+        help="Show content of buildspec based on test name",
+        nargs="*",
+    )
+
     buildspec_validate = subparsers_buildspec.add_parser(
         "validate", help="Validate buildspecs with JSON Schema"
     )

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import subprocess
 import time
 
 from buildtest.buildsystem.parser import BuildspecParser
@@ -825,6 +826,31 @@ class BuildspecCache:
         """This method print buildspec paths, this implements command ``buildtest buildspec find --paths``"""
         for path in self.paths:
             print(path)
+
+
+def edit_buildspec_test(test_names, configuration):
+    """Open a list of test names in editor mode defined by ``EDITOR`` environment otherwise resort to ``vim``.
+    This method will search for buildspec cache and find path to buildspec file corresponding to test name and open
+    file in editor. If multiple test are specified via ``buildtest buildspec edit`` then each file will be open and
+    upon closing file, the next file will be open for edit until all files are written.
+
+    Args:
+        test_names (list): A list of test names to open in editor
+        configuration (buildtest.config.SiteConfiguration): An instance of SiteConfiguration class
+    """
+    cache = BuildspecCache(configuration=configuration)
+
+    for name in test_names:
+        if name not in cache.get_names():
+            console.print(f"[red]Unable to find test {name} in cache")
+            continue
+
+        buildspec = cache.lookup_buildspec_by_name(name)
+
+        EDITOR = os.environ.get("EDITOR", "vim")
+
+        subprocess.call([EDITOR, buildspec])
+        print(f"Writing file: {buildspec}")
 
 
 def show_buildspecs(test_names, configuration):

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -10,6 +10,7 @@ from buildtest.cli.buildspec import (
     BuildspecCache,
     buildspec_find,
     buildspec_validate,
+    edit_buildspec_test,
     show_buildspecs,
     summarize_buildspec_cache,
 )
@@ -157,6 +158,8 @@ def main():
             summarize_buildspec_cache(configuration)
         elif args.buildspecs_subcommand == "show":
             show_buildspecs(test_names=args.name, configuration=configuration)
+        elif args.buildspecs_subcommand == "edit":
+            edit_buildspec_test(test_names=args.name, configuration=configuration)
         elif args.buildspecs_subcommand == "validate":
             buildspec_validate(
                 buildspecs=args.buildspec,

--- a/docs/gettingstarted/buildspecs_interface.rst
+++ b/docs/gettingstarted/buildspecs_interface.rst
@@ -293,3 +293,55 @@ in the cache
 
 .. command-output:: buildtest buildspec show XYZ123!
    :returncode: 1
+
+Editing buildspecs by test ``buildtest buildspec edit``
+--------------------------------------------------------
+
+The ``buildtest buildspec edit`` allows one to specify a list of test as positional
+arguments to edit in your preferred editor. buildtest will provide tab completion for this
+command to show all test available in cache which works similar to ``buildtest buildspec show`` command.
+
+For instance, we can see the following test are available as part of command completion
+
+.. code-block:: console
+
+    $ buildtest buildspec edit _bin_bash_shell
+    _bin_bash_shell                 download_stream                 nodes_state_down                show_host_groups                string_tag
+    _bin_sh_shell                   executor_regex_script_schema    nodes_state_idle                show_jobs                       systemd_default_target
+    add_numbers                     executors_sbatch_declaration    nodes_state_reboot              show_lsf_configuration          tcsh_env_declaration
+    always_fail                     executors_vars_env_declaration  pullImage_dockerhub             show_lsf_models                 test_fail_returncode_match
+    always_pass                     exit1_fail                      pullImage_shub                  show_lsf_queues                 test_pass_returncode_mismatch
+    bash_env_variables              exit1_pass                      pullImage_sylabscloud           show_lsf_queues_current_user    timelimit_max
+    bash_login_shebang              foo_bar                         python_hello                    show_lsf_queues_formatted       timelimit_max_fail
+    bash_nonlogin_shebang           gcc_version                     qdel_version                    show_lsf_resources              timelimit_min
+    bash_shell                      get_partitions                  qmove_version                   show_lsf_user_groups            timelimit_min_fail
+    bhosts_version                  hello_world                     qselect_version                 show_partition                  timelimit_min_max
+    build_remoteimages              inspect_image                   qsub_version                    show_qos                        ulimit_cputime_unlimited
+    build_sandbox_image             jobA                            returncode_int_match            show_queues                     ulimit_filedescriptor_4096
+    build_sif_from_dockerimage      jobB                            returncode_list_mismatch        show_tres                       ulimit_filelock_unlimited
+    circle_area                     jobC                            root_disk_usage                 show_users                      ulimit_max_user_process_2048
+    cqsub_version                   kernel_swapusage                runImage                        sinfo_version                   ulimit_stacksize_unlimited
+    csh_env_declaration             list_of_strings_tags            run_stream                      skip                            ulimit_vmsize_unlimited
+    csh_shell                       lsf_version                     selinux_disable                 sleep                           unskipped
+    current_user_queue              metric_regex_example            sh_shell                        slurm_config                    variables_bash
+    dead_nodes                      node_down_fail_list_reason      shell_options                   status_regex_fail
+    display_hosts_format            nodes_state_allocated           show_accounts                   status_regex_pass
+    display_lsf_hosts               nodes_state_completing          show_all_jobs                   status_returncode_by_executors
+
+Let's take for instance we want to edit the following test, buildtest will search the buildspec cache and find the buildspec file, open
+in editor and once changes are written to disk, the next file will be processed until all files are written to disk.
+
+.. code-block:: console
+
+    $ buildtest buildspec edit sleep _bin_bash_shell add_numbers
+    Writing file: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/sleep.yml
+    Writing file: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/shell_examples.yml
+    Writing file: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/add_numbers.yml
+
+If you specify an invalid test, then buildtest will ignore the test and report a message and skip to next test as shown below
+
+.. code-block:: console
+
+    $ buildtest buildspec edit invalid_test sleep
+    Unable to find test invalid_test in cache
+    Writing file: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/sleep.yml


### PR DESCRIPTION
This command will edit buildspec files based on test names and one can specify multiple test names on command line.

This is similar to `buildtest edit` except that works on files