### PR TITLE
add paging output for buildtest report and buildtest report summary

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -142,9 +142,14 @@ _buildtest ()
       ;;
 
     report|rt)
-      local opts="--filter --format --help --helpfilter --helpformat --latest --no-header --oldest --terse  -h -n -t clear list summary"
-      COMPREPLY=( $( compgen -W "$opts" -- $cur ) );;
-
+      local opts="--filter --format --help --helpfilter --helpformat --latest --no-header --oldest --pager --terse  -h -n -t clear list summary"
+      COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
+      case "${COMP_WORDS[2]}" in summary)
+        local opts="-h --help --pager"
+        COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
+        ;;
+      esac
+      ;;
     config|cg)
       local cmds="-h --help compilers edit executors validate view systems"
 

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -693,7 +693,9 @@ def report_menu(subparsers):
     )
     subparsers.add_parser("clear", help="Remove all report file")
     subparsers.add_parser("list", help="List all report files")
-    subparsers.add_parser("summary", help="Summarize test report")
+    parser_report_summary = subparsers.add_parser(
+        "summary", help="Summarize test report"
+    )
 
     # buildtest report
     parser_report.add_argument(
@@ -736,6 +738,13 @@ def report_menu(subparsers):
         "--terse",
         action="store_true",
         help="Print output in machine readable format",
+    )
+    parser_report.add_argument(
+        "--pager", action="store_true", help="Enable PAGING when viewing result"
+    )
+
+    parser_report_summary.add_argument(
+        "--pager", action="store_true", help="Enable PAGING when viewing result"
     )
 
 

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -631,7 +631,10 @@ def report_cmd(args, report_file=None):
         reports = load_json(BUILDTEST_REPORTS)
         for report in reports:
             console.print(f"Removing report file: {report}")
-            os.remove(report)
+            try:
+                os.remove(report)
+            except OSError:
+                continue
 
         os.remove(BUILDTEST_REPORTS)
         return
@@ -672,18 +675,16 @@ def report_cmd(args, report_file=None):
     results.print_report(terse=args.terse, noheader=args.no_header)
 
 
-def report_summary(report, pager):
+def report_summary(report, pager=None):
     """This method will print summary for report file which can be retrieved via ``buildtest report summary`` command"""
 
     test_breakdown = report.breakdown_by_test_names()
 
-    table = Table(
-        title="Breakdown by test",
-    )
-    table.add_column("Name", style="cyan", header_style="blue")
-    table.add_column("Total Pass", style="green", header_style="blue")
-    table.add_column("Total Fail", style="red", header_style="blue")
-    table.add_column("Total Runs", style="blue", header_style="blue")
+    table = Table(title="Breakdown by test", header_style="blue")
+    table.add_column("Name", style="cyan")
+    table.add_column("Total Pass", style="green")
+    table.add_column("Total Fail", style="red")
+    table.add_column("Total Runs", style="blue")
     for k in test_breakdown.keys():
         table.add_row(
             k,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,7 @@ napoleon_include_init_with_doc = False
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "rich": ("https://rich.readthedocs.io/", None),
 }
 
 suppress_warnings = ["autoapi"]

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -1,7 +1,5 @@
 import os
-import random
 import shutil
-import string
 import tempfile
 
 import pytest
@@ -25,6 +23,9 @@ def test_report():
 
     # run 'buildtest report --format name,state,returncode,buildspec'
     result = Report(format_args="name,state,returncode,buildspec")
+    result.print_report()
+
+    result = Report(pager=True)
     result.print_report()
 
 
@@ -160,6 +161,9 @@ def test_report_summary():
     report = Report()
     report_summary(report)
 
+    report = Report(pager=True)
+    report_summary(report)
+
 
 @pytest.mark.cli
 def test_report_list():
@@ -191,28 +195,16 @@ def test_report_clear():
         format = None
         oldest = False
         latest = False
-        report_subcommand = None
+        report_subcommand = "clear"
         terse = None
         no_header = None
 
     backupfile = BUILD_REPORT + ".bak"
     shutil.copy2(BUILD_REPORT, backupfile)
-    report_cmd(args)
+
+    # buildtest report clear will raise an error since file doesn't exist
+    with pytest.raises(SystemExit):
+        report_cmd(args)
+
     shutil.move(backupfile, BUILD_REPORT)
     assert BUILD_REPORT
-
-    class args:
-        helpformat = False
-        helpfilter = False
-        filter = None
-        format = None
-        oldest = False
-        latest = False
-        report_subcommand = "clear"
-        terse = None
-        no_header = None
-
-    report_file = "".join(random.choice(string.ascii_letters) for i in range(10))
-    # buildtest report clear <file> will raise an error since file doesn't exist
-    with pytest.raises(SystemExit):
-        report_cmd(args, report_file=report_file)


### PR DESCRIPTION
This PR will add `--pager` option to **buildtest report** and **buildtest report summary** command.
this will fix some issues with regression test.
When removing report files via `buildtest report clear` we catch exception when file is invalid.