### PR TITLE
add option --buildenv

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -206,7 +206,7 @@ _buildtest ()
         query)
           COMPREPLY=( $( compgen -W "$(_builder_names)" -- $cur ) )
           if [[ $cur == -* ]] ; then
-            local opts="--buildscript --error --help --output --testpath -b -e -o -h -o -t"
+            local opts="--buildscript --buildenv --error --help --output --testpath -b -be -e -o -h -o -t"
             COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
           fi
           ;;

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -130,7 +130,7 @@ _buildtest ()
       COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
       ;;
     path)
-      local opts="-b -e -h -o -s -t --buildscript --errfile --help --outfile --stagedir --testpath"
+      local opts="-b -be -e -h -o -s -t --buildscript --buildenv --errfile --help --outfile --stagedir --testpath"
       COMPREPLY=( $( compgen -W "$(_builder_names)" -- $cur ) )
       if [[ $cur == -* ]] ; then
         COMPREPLY=( $( compgen -W "$opts" -- $cur ) )

--- a/buildtest/builders/base.py
+++ b/buildtest/builders/base.py
@@ -303,7 +303,8 @@ class BuilderBase(ABC):
         command = BuildTestCommand("env")
         command.execute()
         content = "".join(command.get_output())
-        write_file(os.path.join(self.test_root, "build-env.sh"), content)
+        self.metadata["buildenv"] = os.path.join(self.test_root, "build-env.txt")
+        write_file(self.metadata["buildenv"], content)
 
         console.print(f"[blue]{self}[/]: Running Test via command: [cyan]{cmd}[/cyan]")
 
@@ -752,9 +753,7 @@ class BuilderBase(ABC):
             fname,
             stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH,
         )
-        self.logger.debug(
-            f"Applying permission 755 to {fname} so that test can be executed"
-        )
+        self.logger.debug(f"Changing permission to 755 for script: {fname}")
 
     def _get_environment(self, env):
         """Retrieve a list of environment variables defined in buildspec and

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -832,7 +832,9 @@ def inspect_menu(subparsers):
     query_list.add_argument(
         "-b", "--buildscript", action="store_true", help="Print build script"
     )
-
+    query_list.add_argument(
+        "-be", "--buildenv", action="store_true", help="Print content of build env"
+    )
     query_list.add_argument(
         "-e", "--error", action="store_true", help="Print error file"
     )

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -147,7 +147,9 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
     )
     path = subparsers.add_parser("path", help="Show path attributes for a given test")
     path_group = path.add_mutually_exclusive_group()
-
+    path_group.add_argument(
+        "-be", "--buildenv", action="store_true", help="Show path to build environment"
+    )
     path_group.add_argument(
         "-t", "--testpath", action="store_true", help="Show path to test script"
     )

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import sys
 import tempfile
+import time
 from datetime import datetime
 
 from buildtest import BUILDTEST_VERSION
@@ -225,28 +226,25 @@ def print_discovered_buildspecs(buildspec_dict):
 
     console.rule("[bold red] Discovering Buildspecs")
 
-    console.print("Discovered Buildspecs: ", len(buildspec_dict["included"]))
-    console.print("Excluded Buildspecs: ", len(buildspec_dict["excluded"]))
-    console.print(
-        "Detected Buildspecs after exclusion: ", len(buildspec_dict["detected"])
-    )
-
     table = Table(
-        "[blue]Buildspecs", title="Discovered buildspecs", box=box.DOUBLE_EDGE
+        title="Discovered buildspecs", box=box.DOUBLE_EDGE, header_style="blue"
     )
+    table.add_column("buildspec", style="red")
 
     for i in buildspec_dict["included"]:
-        table.add_row(f"[red]{i}")
+        table.add_row(i)
     console.print(table)
 
     # if any buildspecs removed due to -x option we print them to screen
     if buildspec_dict["excluded"]:
 
         table = Table(
-            "[blue]Buildspecs", title="Excluded buildspecs", box=box.DOUBLE_EDGE
+            title="Excluded buildspecs", box=box.DOUBLE_EDGE, header_style="blue"
         )
+        table.add_column("buildspec", style="red")
+
         for i in buildspec_dict["excluded"]:
-            table.add_row(f"[red]{i}")
+            table.add_row(i)
         console.print(table)
 
     # print breakdown of buildspecs by tags
@@ -254,12 +252,13 @@ def print_discovered_buildspecs(buildspec_dict):
 
         for tagname in buildspec_dict["tags"].keys():
             table = Table(
-                "[blue]Buildspecs",
                 title=f"Buildspecs By Tag={tagname}",
                 box=box.DOUBLE_EDGE,
+                header_style="blue",
             )
+            table.add_column("buildspec", style="red")
             for row in buildspec_dict["tags"][tagname]:
-                table.add_row(f"[red] {row}")
+                table.add_row(row)
             console.print(table)
 
     # print breakdown of buildspecs by executors
@@ -267,14 +266,26 @@ def print_discovered_buildspecs(buildspec_dict):
 
         for executorname in buildspec_dict["executors"].keys():
             table = Table(
-                "[blue]Buildspecs",
                 title=f"Buildspecs by Executor={executorname}",
                 box=box.DOUBLE_EDGE,
+                header_style="blue",
             )
-
+            table.add_column("buildspecs")
             for row in buildspec_dict["executors"][executorname]:
                 table.add_row(f"[red]{row}")
             console.print(table)
+
+    print("\n")
+    console.print(
+        "[green bold]Total Discovered Buildspecs: ", len(buildspec_dict["included"])
+    )
+    console.print(
+        "[red bold]Total Excluded Buildspecs: ", len(buildspec_dict["excluded"])
+    )
+    console.print(
+        "[blue bold]Detected Buildspecs after exclusion: ",
+        len(buildspec_dict["detected"]),
+    )
 
 
 def discover_buildspecs_by_tags(tagnames):
@@ -834,7 +845,9 @@ class BuildTest:
 
         bc = BuildtestCompilers(configuration=self.configuration)
 
-        # for buildspec in track(self.detected_buildspecs, description="Parsing Buildspecs ..."):
+        console.print(
+            f"Buildtest will parse {len(self.detected_buildspecs)} buildspecs"
+        )
 
         for buildspec in self.detected_buildspecs:
             try:
@@ -867,8 +880,8 @@ class BuildTest:
 
             self.builders += builder.get_builders()
 
-        console.print(f"Valid Buildspecs: [green]{len(valid_buildspecs)}")
-        console.print(f"Invalid Buildspecs: [red]{len(self.invalid_buildspecs)}")
+        console.print(f"[green]Valid Buildspecs: {len(valid_buildspecs)}")
+        console.print(f"[red]Invalid Buildspecs: {len(self.invalid_buildspecs)}")
 
         for buildspec in valid_buildspecs:
 
@@ -883,7 +896,7 @@ class BuildTest:
                 console.print(msg)
 
         if filtered_buildspecs:
-            table = Table("[blue]Buildspecs", title="Buildspecs Filtered out")
+            table = Table("[blue]buildspecs", title="Buildspecs Filtered out")
 
             for test in filtered_buildspecs:
                 table.add_row(f"[red]{test}")
@@ -1008,13 +1021,13 @@ class BuildTest:
             builders (list): List of builders that ran to completion
         """
 
-        table = Table(title="Test Summary", show_lines=True)
-        table.add_column("[blue]Builder", overflow="fold")
-        table.add_column("[blue]executor")
-        table.add_column("[blue]status")
-        table.add_column("[blue]Checks (ReturnCode, Regex, Runtime)", overflow="fold")
-        table.add_column("[blue]ReturnCode")
-        table.add_column("[blue]Runtime")
+        table = Table(title="Test Summary", show_lines=True, header_style="blue")
+        table.add_column("builder", overflow="fold")
+        table.add_column("executor")
+        table.add_column("status")
+        table.add_column("checks (ReturnCode, Regex, Runtime)", overflow="fold")
+        table.add_column("returnCode")
+        table.add_column("runtime")
 
         passed_tests = 0
         failed_tests = 0
@@ -1164,25 +1177,51 @@ class BuildTest:
     def print_builders(
         self, compiler_builder, spack_builder, script_builder, batch_builder
     ):
+        from rich.table import Column
+
         """Print detected builders during build phase"""
 
+        script_table = Table(
+            Column(header="builder", style="blue"),
+            Column(header="executor", style="green"),
+            Column(header="compiler", style="red"),
+            Column(header="nodes", style="orange3"),
+            Column(header="procs", style="orange3"),
+            Column(header="description", style="magenta"),
+            Column(header="buildspecs", style="yellow"),
+            title="Script Builder Details",
+            show_lines=True,
+            header_style="blue",
+        )
+        compiler_table = Table(
+            Column(header="builder", style="blue"),
+            Column(header="executor", style="green"),
+            Column(header="compiler", style="red"),
+            Column(header="nodes", style="orange3"),
+            Column(header="procs", style="orange3"),
+            Column(header="description", style="magenta"),
+            Column(header="buildspecs", style="yellow"),
+            title="Compiler Builder Details",
+            show_lines=True,
+            header_style="blue",
+        )
+        spack_table = Table(
+            Column(header="builder", style="blue"),
+            Column(header="executor", style="green"),
+            Column(header="compiler", style="red"),
+            Column(header="nodes", style="orange3"),
+            Column(header="procs", style="orange3"),
+            Column(header="description", style="magenta"),
+            Column(header="buildspecs", style="yellow"),
+            title="Spack Builder Details",
+            show_lines=True,
+            header_style="blue",
+        )
         if script_builder:
-
-            table = Table(
-                title="Script Builder Details", show_lines=True, header_style="blue"
-            )
-            table.add_column("Builder", overflow="fold", style="blue")
-            table.add_column("Executor", overflow="fold", style="green")
-            table.add_column("Compiler", overflow="fold", style="red")
-            table.add_column("Nodes", overflow="fold", style="orange3")
-            table.add_column("Procs", overflow="fold", style="orange3")
-            table.add_column("Description", overflow="fold", style="magenta")
-            table.add_column("Buildspecs", overflow="fold", style="yellow")
-
             for builder in script_builder:
-                description = builder.recipe.get("description")
+                description = builder.recipe.get("description") or ""
                 # table entries must be rendered by rich and for purpose we need everything to be converted to string.
-                table.add_row(
+                script_table.add_row(
                     f"{builder}",
                     f"{builder.executor}",
                     f"{builder.compiler}",
@@ -1191,24 +1230,13 @@ class BuildTest:
                     f"{description}",
                     f"{builder.buildspec}",
                 )
-            console.print(table)
+            console.print(script_table)
 
         if spack_builder:
-
-            table = Table(
-                title="Spack Builder Details", show_lines=True, header_style="blue"
-            )
-            table.add_column("Builder", overflow="fold", style="blue")
-            table.add_column("Executor", overflow="fold", style="green")
-            table.add_column("Nodes", overflow="fold", style="orange3")
-            table.add_column("Procs", overflow="fold", style="orange3")
-            table.add_column("Description", overflow="fold", style="magenta")
-            table.add_column("Buildspecs", overflow="fold", style="yellow")
-
             for builder in spack_builder:
-                description = builder.recipe.get("description")
+                description = builder.recipe.get("description") or ""
 
-                table.add_row(
+                spack_table.add_row(
                     f"{builder}",
                     f"{builder.executor}",
                     f"{builder.numnodes}",
@@ -1217,24 +1245,13 @@ class BuildTest:
                     f"{builder.buildspec}",
                 )
 
-            console.print(table)
+            console.print(spack_table)
 
         if compiler_builder:
-            table = Table(
-                title="Compiler Builder Details", show_lines=True, style="blue"
-            )
-            table.add_column("Builder", overflow="fold", style="blue")
-            table.add_column("Executor", overflow="fold", style="green")
-            table.add_column("Compiler", overflow="fold", style="red")
-            table.add_column("Nodes", overflow="fold", style="orange3")
-            table.add_column("Procs", overflow="fold", style="orange3")
-            table.add_column("Description", overflow="fold", style="magenta")
-            table.add_column("Buildspecs", overflow="fold", style="yellow")
-
             for builder in compiler_builder:
-                description = builder.recipe.get("description")
+                description = builder.recipe.get("description") or ""
 
-                table.add_row(
+                compiler_table.add_row(
                     f"{builder}",
                     f"{builder.executor}",
                     f"{builder.compiler}",
@@ -1244,15 +1261,15 @@ class BuildTest:
                     f"{builder.buildspec}",
                 )
 
-            console.print(table)
+            console.print(compiler_table)
 
         if batch_builder:
             table = Table(
                 title="Batch Job Builders", show_lines=True, header_style="blue"
             )
-            table.add_column("Builder", overflow="fold", style="blue")
-            table.add_column("Executor", overflow="fold", style="green")
-            table.add_column("Buildspecs", overflow="fold", style="yellow")
+            table.add_column("builder", overflow="fold", style="blue")
+            table.add_column("executor", overflow="fold", style="green")
+            table.add_column("buildspecs", overflow="fold", style="yellow")
 
             for builder in batch_builder:
                 table.add_row(
@@ -1269,10 +1286,10 @@ class BuildTest:
                     show_lines=True,
                     header_style="blue",
                 )
-                table.add_column("Builder", overflow="fold", style="blue")
-                table.add_column("Executor", overflow="fold", style="green")
-                table.add_column("Procs", overflow="fold", style="orange3")
-                table.add_column("Buildspecs", overflow="fold", style="yellow")
+                table.add_column("builder", overflow="fold", style="blue")
+                table.add_column("executor", overflow="fold", style="green")
+                table.add_column("procs", overflow="fold", style="orange3")
+                table.add_column("buildspecs", overflow="fold", style="yellow")
 
                 for builder in batch_builder:
                     # skip builders that dont have attribute builder.numprocs which is set if buildtest build --procs is specified
@@ -1294,10 +1311,10 @@ class BuildTest:
                     show_lines=True,
                     header_style="blue",
                 )
-                table.add_column("Builder", overflow="fold", style="blue")
-                table.add_column("Executor", overflow="fold", style="green")
-                table.add_column("Nodes", overflow="fold", style="orange3")
-                table.add_column("Buildspecs", overflow="fold", style="yellow")
+                table.add_column("builder", overflow="fold", style="blue")
+                table.add_column("executor", overflow="fold", style="green")
+                table.add_column("nodes", overflow="fold", style="orange3")
+                table.add_column("buildspecs", overflow="fold", style="yellow")
 
                 for builder in batch_builder:
                     # skip builders that dont have attribute builder.numprocs which is set if buildtest build --procs is specified

--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -9,7 +9,7 @@ import re
 import shutil
 import sys
 import tempfile
-import time
+import traceback
 from datetime import datetime
 
 from buildtest import BUILDTEST_VERSION
@@ -47,13 +47,9 @@ from buildtest.utils.file import (
 from jsonschema.exceptions import ValidationError
 from rich import box
 from rich.panel import Panel
-from rich.table import Table
+from rich.table import Column, Table
 
 logger = logging.getLogger(__name__)
-
-
-import traceback
-
 
 # Context manager that copies stdout and any exceptions to a log file
 class Tee(object):
@@ -952,8 +948,8 @@ class BuildTest:
         console.rule("[bold red]Building Test")
 
         valid_builders = []
-        for builder in self.builders:
 
+        for builder in self.builders:
             try:
                 builder.build(
                     modules=self.modules,
@@ -1177,7 +1173,6 @@ class BuildTest:
     def print_builders(
         self, compiler_builder, spack_builder, script_builder, batch_builder
     ):
-        from rich.table import Column
 
         """Print detected builders during build phase"""
 
@@ -1375,6 +1370,7 @@ def update_report(valid_builders, report_file):
             "command",
             "outfile",
             "errfile",
+            "buildenv",
             "buildspec_content",
             "test_content",
             "buildscript_content",

--- a/buildtest/cli/cdash.py
+++ b/buildtest/cli/cdash.py
@@ -195,6 +195,7 @@ def upload_test_cdash(build_name, configuration, site=None, report_file=None):
                     test["endtime"] = test_data["endtime"]
                     test["build_script"] = test_data["build_script"]
                     test["logpath"] = test_data["logpath"]
+                    test["buildenv"] = test_data["buildenv"]
                     test["job"] = json.dumps(test_data["job"], indent=2, sort_keys=True)
 
                     # extra preformatted output fields
@@ -293,6 +294,7 @@ def upload_test_cdash(build_name, configuration, site=None, report_file=None):
             "testpath",
             "outfile",
             "errfile",
+            "buildenv",
             "starttime",
             "endtime",
             "logpath",

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -196,7 +196,7 @@ def inspect_query(report, args):
                     content = read_file(test["testpath"])
                     console.rule(f"Test File: {test['testpath']}")
 
-                    syntax = Syntax(content, "shell", line_numbers=True, theme="emacs")
+                    syntax = Syntax(content, "shell", theme="emacs")
                     console.print(syntax)
 
                 # print content of build script when 'buildtest inspect query --buildscript' is set
@@ -204,7 +204,14 @@ def inspect_query(report, args):
                     content = read_file(test["build_script"])
                     console.rule(f"Test File: {test['build_script']}")
 
-                    syntax = Syntax(content, "shell", line_numbers=True, theme="emacs")
+                    syntax = Syntax(content, lexer="shell", theme="emacs")
+                    console.print(syntax)
+
+                if args.buildenv:
+                    content = read_file(test["buildenv"])
+                    console.rule(f"Test File: {test['buildenv']}")
+
+                    syntax = Syntax(content, lexer="text", theme="emacs")
                     console.print(syntax)
 
 

--- a/buildtest/cli/path.py
+++ b/buildtest/cli/path.py
@@ -4,7 +4,13 @@ from buildtest.cli.report import Report
 
 
 def path_cmd(
-    name, testpath=None, outfile=None, errfile=None, buildscript=None, stagedir=None
+    name,
+    testpath=None,
+    outfile=None,
+    errfile=None,
+    buildscript=None,
+    stagedir=None,
+    buildenv=None,
 ):
     """This is the entry point for ``buildtest path`` command which will display path
     variables for a given test name. If no options are specified we retrieve the root
@@ -38,6 +44,7 @@ def path_cmd(
         errfile (bool): Retrieve path to error file for a given test
         buildscript (bool): Retrieve path to build script for a given test
         stagedir (bool): Retrieve path to stage directory for a given test
+        buildenv (bool): Retrieve path to buildenv for a given test
     """
     report = Report()
 
@@ -79,5 +86,8 @@ def path_cmd(
 
     if stagedir:
         path = record[tid]["stagedir"]
+
+    if buildenv:
+        path = record[tid]["buildenv"]
 
     print(path)

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -26,6 +26,7 @@ class Report:
     # list of format fields
     format_field_description = {
         "buildspec": "Buildspec File",
+        "buildenv": "Show build environment file for test",
         "command": "Command executed",
         "compiler": "Retrieve compiler used for test (applicable for compiler schema)",
         "endtime": "End Time for test",

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -196,6 +196,7 @@ def main():
             testpath=args.testpath,
             buildscript=args.buildscript,
             stagedir=args.stagedir,
+            buildenv=args.buildenv,
         )
     # running bnuildtest schema
     elif args.subcommands == "schema":

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -165,8 +165,9 @@ def test_buildtest_query():
         error = True
         testpath = True
         buildscript = True
+        buildenv = True
 
-    # check buildtest inspect query --output --error --testpath --buildscript <name1> <name2> ...
+    # check buildtest inspect query --output --error --testpath --buildscript --buildenv <name1> <name2> ...
     inspect_cmd(args)
 
     class args:
@@ -178,6 +179,7 @@ def test_buildtest_query():
         error = False
         testpath = False
         buildscript = False
+        buildenv = False
 
     # check invalid test name when querying result which will result in exception SystemExit
     with pytest.raises(SystemExit):

--- a/tests/cli/test_path.py
+++ b/tests/cli/test_path.py
@@ -19,6 +19,7 @@ def test_path():
     path_cmd(name, stagedir=True)
     path_cmd(name, testpath=True)
     path_cmd(name, buildscript=True)
+    path_cmd(name, buildenv=True)
 
     builders = report.builder_names()
     # specify name in format 'buildtest path <name>/<testid>


### PR DESCRIPTION
This PR will add the following:
1. Add metadata record `buildenv` in test that can be queried via `buildtest report` and uploaded to CDASH via `buildtest cdash upload`
2. Add option `--buildenv` for `buildtest path` and `buildtest inspect query` command and add regression test for each command
3. Slightly update the output of some commands related to rich tables