### PR TITLE
Rename commands to buildtest buildspec edit-test and buildtest buildspec edit-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ env.bak/
 
 # ignore .packages directory
 .packages/
+Pipfile

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -83,7 +83,7 @@ _buildtest ()
 
   COMPREPLY=()   # Array variable storing the possible completions.
 
-  local cmds="build buildspec cd cdash clean config debugreport docs edit help inspect history path report schema schemadocs stylecheck unittests"
+  local cmds="build buildspec cd cdash clean config debugreport docs edit-test help inspect history path report schema schemadocs stylecheck unittests"
   local alias_cmds="bd bc cg it et h hy rt style"
   local opts="--color --config --debug --editor --help --lastlog --report --version -c -d -h -r -V"
 
@@ -158,7 +158,7 @@ _buildtest ()
       esac
       ;;
     config|cg)
-      local cmds="-h --help compilers edit executors validate view systems"
+      local cmds="-h --help compilers edit-test executors validate view systems"
 
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )
       # handle completion logic for 'buildtest config <subcommand>' based on subcommands
@@ -216,7 +216,7 @@ _buildtest ()
       ;;
 
     buildspec|bc)
-      local cmds="-h --help edit edit-file find show summary validate"
+      local cmds="-h --help edit-test edit-file find show summary validate"
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )
 
       # switch based on 2nd word 'buildtest buildspec <subcommand>'
@@ -236,7 +236,7 @@ _buildtest ()
            COMPREPLY=( $( compgen -W "${allopts}" -- $cur ) );;
          esac
         ;;
-      show|edit)
+      show|edit-test)
         COMPREPLY=( $( compgen -W "$(_buildspec_cache_test_names)" -- $cur ) );;
       edit-file)
         COMPREPLY=( $( compgen -W "$(_avail_buildspecs)" -- $cur ) );;

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -83,7 +83,7 @@ _buildtest ()
 
   COMPREPLY=()   # Array variable storing the possible completions.
 
-  local cmds="build buildspec cd cdash clean config debugreport docs edit-test help inspect history path report schema schemadocs stylecheck unittests"
+  local cmds="build buildspec cd cdash clean config debugreport docs edit help inspect history path report schema schemadocs stylecheck unittests"
   local alias_cmds="bd bc cg it et h hy rt style"
   local opts="--color --config --debug --editor --help --lastlog --report --version -c -d -h -r -V"
 
@@ -158,7 +158,7 @@ _buildtest ()
       esac
       ;;
     config|cg)
-      local cmds="-h --help compilers edit-test executors validate view systems"
+      local cmds="-h --help compilers edit executors validate view systems"
 
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )
       # handle completion logic for 'buildtest config <subcommand>' based on subcommands

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -497,7 +497,7 @@ def buildspec_menu(subparsers):
     )
 
     edit_buildspecs = subparsers_buildspec.add_parser(
-        "edit", help="Edit buildspec file based on test name"
+        "edit-test", help="Edit buildspec file based on test name"
     )
     edit_buildspecs.add_argument(
         "name",
@@ -658,7 +658,7 @@ def config_menu(subparsers):
 
     compilers = subparsers_config.add_parser("compilers", help="Search compilers")
 
-    subparsers_config.add_parser("edit", help="Open configuration file in editor")
+    subparsers_config.add_parser("edit-test", help="Open configuration file in editor")
 
     executors = subparsers_config.add_parser(
         "executors", help="Query executors from buildtest configuration"

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -496,19 +496,19 @@ def buildspec_menu(subparsers):
         nargs="*",
     )
 
-    edit_buildspecs = subparsers_buildspec.add_parser(
+    edit_via_testname = subparsers_buildspec.add_parser(
         "edit-test", help="Edit buildspec file based on test name"
     )
-    edit_buildspecs.add_argument(
+    edit_via_testname.add_argument(
         "name",
         help="Show content of buildspec based on test name",
         nargs="*",
     )
 
-    edit_file = subparsers_buildspec.add_parser(
+    edit_via_filename = subparsers_buildspec.add_parser(
         "edit-file", help="Edit buildspec file based on filename"
     )
-    edit_file.add_argument(
+    edit_via_filename.add_argument(
         "file",
         help="Edit buildspec file in editor",
         nargs="*",
@@ -658,7 +658,7 @@ def config_menu(subparsers):
 
     compilers = subparsers_config.add_parser("compilers", help="Search compilers")
 
-    subparsers_config.add_parser("edit-test", help="Open configuration file in editor")
+    subparsers_config.add_parser("edit", help="Open configuration file in editor")
 
     executors = subparsers_config.add_parser(
         "executors", help="Query executors from buildtest configuration"

--- a/docs/gettingstarted/buildspecs_interface.rst
+++ b/docs/gettingstarted/buildspecs_interface.rst
@@ -358,21 +358,21 @@ Editing buildspecs in your preferred editor
 buildtest provides an interface to automatically open your buildspecs in editor and validate them after closing file.
 You are welcome to open your buildspec in your editor (`vim`, `emacs`, `nano`) but you won't be able to validate the buildspec
 unless you explicitly run the test or use **buildtest buildspec validate** to see if your buildspec is valid. buildtest comes
-with two commands to edit your buildspecs ``buildtest buildspec edit`` and ``buildtest buildspec edit-file`` which we will
+with two commands to edit your buildspecs ``buildtest buildspec edit-test`` and ``buildtest buildspec edit-file`` which we will
 discuss below.
 
-Editing by Test ``buildtest buildspec edit``
+Editing by Test ``buildtest buildspec edit-test``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``buildtest buildspec edit`` allows one to specify a list of test as positional
-arguments to edit in your preferred editor. buildtest will provide tab completion for this
+The ``buildtest buildspec edit-test`` allows one to specify a list of test as positional
+arguments to edit-test in your preferred editor. buildtest will provide tab completion for this
 command to show all test available in cache which works similar to ``buildtest buildspec show`` command.
 
 For instance, we can see the following test are available as part of command completion
 
 .. code-block:: console
 
-    $ buildtest buildspec edit
+    $ buildtest buildspec edit-test
     _bin_bash_shell                 download_stream                 nodes_state_down                show_host_groups                string_tag
     _bin_sh_shell                   executor_regex_script_schema    nodes_state_idle                show_jobs                       systemd_default_target
     add_numbers                     executors_sbatch_declaration    nodes_state_reboot              show_lsf_configuration          tcsh_env_declaration
@@ -400,7 +400,7 @@ in editor and once changes are written to disk, the next file will be processed 
 
 .. code-block:: console
 
-    $ buildtest buildspec edit sleep _bin_bash_shell add_numbers
+    $ buildtest buildspec edit-test sleep _bin_bash_shell add_numbers
     Writing file: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/sleep.yml
     /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/sleep.yml is valid
     Writing file: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/shell_examples.yml
@@ -412,7 +412,7 @@ If you specify an invalid test, then buildtest will ignore the test and report a
 
 .. code-block:: console
 
-    $ buildtest buildspec edit invalid_test sleep
+    $ buildtest buildspec edit-test invalid_test sleep
     Unable to find test invalid_test in cache
     Writing file: /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/sleep.yml
     /Users/siddiq90/Documents/GitHubDesktop/buildtest/tutorials/sleep.yml is valid
@@ -421,8 +421,8 @@ Edit buildspecs ``buildtest buildspec edit-file``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``buildtest buildspec edit-file`` command can be used to edit buildspec based on filename as pose to testname.
-This command works similar to ``buildtest buildspec edit`` where each file is open in editor and validated upon completion.
-You can use this command to create new buildspec whereas ``buildtest buildspec edit`` only works on existing buildspecs loaded
+This command works similar to ``buildtest buildspec edit-test`` where each file is open in editor and validated upon completion.
+You can use this command to create new buildspec whereas ``buildtest buildspec edit-test`` only works on existing buildspecs loaded
 in cache. You can pass multiple filenames as arguments if you want to edit several files.
 
 .. code-block:: console

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,1 @@
+import pytest

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,1 +1,0 @@
-import pytest


### PR DESCRIPTION
Changed the documentation to reflect the change to the ``buildtest buildspec edit-test`` command. The alias for the buildspec command that allowed you to edit tests based on a supplied test name has been changed from ``buildtest buildspec edit`` to ``buildtest buildspec edit-test``.  This was done in order to better match with the ``buildtest buildspec edit-file``.