### PR TITLE
add build stamp "-Experimental" in CDASH upload

### DIFF
--- a/buildtest/cli/cdash.py
+++ b/buildtest/cli/cdash.py
@@ -255,6 +255,7 @@ def upload_test_cdash(
     console.print(f"Uploading {len(tests)} tests")
 
     build_stamp = build_starttime.strftime(output_datetime_format)
+    build_stamp += "-Experimental"
 
     filename = "Test.xml"
     site_element = ET.Element(


### PR DESCRIPTION
@zackgalbreath

Adding the `-Experimental` and tried pushing a cdash test https://my.cdash.org//build/2181181. Let me know if this is the field, i dont understand what are the valid types for build stamp and how this impacts cdash upload. Is there user documentation that can help clarify this so we can make informed decision in the buildtest codebase.


![Screen Shot 2022-06-22 at 4 53 02 PM](https://user-images.githubusercontent.com/12942230/175134018-ab5d3d42-2bec-434c-89ae-7fe63f88d6a3.png)
 