### PR TITLE
add regression test for buildtest stats

### DIFF
--- a/buildtest/cli/stats.py
+++ b/buildtest/cli/stats.py
@@ -1,8 +1,7 @@
-from statistics import StatisticsError, mean, variance
+from statistics import mean, variance
 
 from buildtest.cli.report import Report
 from buildtest.defaults import console
-from buildtest.exceptions import BuildTestError
 
 
 def stats_cmd(name, report_file=None):

--- a/buildtest/cli/stats.py
+++ b/buildtest/cli/stats.py
@@ -40,14 +40,8 @@ def stats_cmd(name, report_file=None):
 
     # need to convert all items to float since each item is str
     runtimes = [float(runtime) for runtime in results.display_table["runtime"]]
+    test_variance = variance(runtimes) if len(runtimes) > 1 else 0
     console.print(f"Mean Runtime {mean(runtimes):.6f}")
-
-    # variance requires 2 input data otherwise it raises exception StatisticsError
-    try:
-        test_variance = variance(runtimes)
-    except StatisticsError:
-        raise BuildTestError("We need two test runs to calculate variance")
-
     console.print(f"Variance Runtime {test_variance:0.6f}")
 
     results.print_report()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,6 @@
+from buildtest.cli.stats import stats_cmd
+
+
+def test_stats():
+    name = "exit1_fail"
+    stats_cmd(name)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,6 +1,22 @@
+from buildtest.cli.build import BuildTest
+from buildtest.cli.buildspec import BuildspecCache
+from buildtest.cli.report import Report
 from buildtest.cli.stats import stats_cmd
+from buildtest.config import SiteConfiguration
+from buildtest.system import BuildTestSystem
 
 
 def test_stats():
-    name = "exit1_fail"
-    stats_cmd(name)
+    configuration = SiteConfiguration()
+    configuration.detect_system()
+    configuration.validate()
+    system = BuildTestSystem()
+
+    BuildspecCache(rebuild=True, configuration=configuration)
+
+    cmd = BuildTest(configuration=configuration, tags=["pass"], buildtest_system=system)
+    cmd.build()
+
+    report = Report()
+    name = report.get_random_tests()
+    stats_cmd(name[0])


### PR DESCRIPTION
Still need to pass **python $BUILDTEST_ROOT/buildtest/tools/unittests.py -c**

<img width="1264" alt="Screen Shot 2022-06-28 at 5 41 31 PM" src="https://user-images.githubusercontent.com/22202096/176304716-3b197e97-69a3-4a57-a048-25bc8d2d88f3.png">
