### PR TITLE
Changed report to print failures in red and passes in Red

### DIFF
--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -7,7 +7,7 @@ import sys
 from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORTS, console
 from buildtest.exceptions import BuildTestError
 from buildtest.utils.file import is_file, load_json, resolve_path
-from rich.color import Color
+from rich.color import Color, ColorParseError
 from rich.table import Table
 
 logger = logging.getLogger(__name__)
@@ -577,7 +577,7 @@ class Report:
         if color is not None:
             try:
                 consoleColor = Color.parse(color).name
-            except:
+            except ColorParseError:
                 consoleColor = Color.default().name
 
         for field in self.display_table.keys():

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -511,7 +511,7 @@ class Report:
         Args:
             terse (bool, optional): Print output int terse format
             noheader (bool, optional): Determine whether to print header in terse format
-
+            color (str, optional): An instance of a string class that tells print_report what color the output should be printed in.
 
         In this example, we display output in tabular format which works with ``--filter`` and ``--format`` option.
 
@@ -819,17 +819,16 @@ def report_summary(report, pager=None, color=None):
         table.add_column("Total Pass", style="green")
         table.add_column("Total Fail", style="red")
         table.add_column("Total Runs", style="blue")
-    elif color is not None:
+    else:
         try:
             consoleColor = Color.parse(color).name
         except ColorParseError:
             consoleColor = Color.default().name
-        finally:
-            table = Table(title="Breakdown by test", header_style=consoleColor)
-            table.add_column("Name", style=consoleColor)
-            table.add_column("Total Pass", style=consoleColor)
-            table.add_column("Total Fail", style=consoleColor)
-            table.add_column("Total Runs", style=consoleColor)
+        table = Table(title="Breakdown by test", header_style=consoleColor)
+        table.add_column("Name", style=consoleColor)
+        table.add_column("Total Pass", style=consoleColor)
+        table.add_column("Total Fail", style=consoleColor)
+        table.add_column("Total Runs", style=consoleColor)
 
     for k in test_breakdown.keys():
         table.add_row(
@@ -869,6 +868,7 @@ def print_report_summary_output(report, table, pass_results, fail_results, color
         table (rich.table.Table): An instance of Rich Table class
         pass_results (buildtest.cli.report.Report): An instance of Report class with filtered output by ``state=PASS``
         fail_results (buildtest.cli.report.Report): An instance of Report class with filtered output by ``state=FAIL``
+        color (str): An instance of a string class that tells print_report_summary what color the output should be printed in.
     """
     console.print("Report File: ", report.reportfile())
     console.print("Total Tests:", len(report.get_testids()))
@@ -878,6 +878,6 @@ def print_report_summary_output(report, table, pass_results, fail_results, color
     if color is None:
         pass_results.print_report(title="PASS Tests", color="green")
         fail_results.print_report(title="FAIL Tests", color="red")
-    elif color is not None:
+    else:
         pass_results.print_report(title="PASS Tests", color=color)
         fail_results.print_report(title="FAIL Tests", color=color)

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -501,7 +501,9 @@ class Report:
             )
         console.print(table)
 
-    def print_report(self, terse=None, noheader=None, title=None, count=None):
+    def print_report(
+        self, terse=None, noheader=None, title=None, count=None, color=None
+    ):
         """This method will print report table after processing report file. By default we print output in
         table format but this can be changed to terse format which will print output in parseable format.
 
@@ -571,7 +573,9 @@ class Report:
         title = title or f"Report File: {self.reportfile()}"
         table = Table(title=title, show_lines=True, expand=True)
         selectedStyle = "green"
-        if self.display_table["state"][0] == "FAIL":
+        if color is not None:
+            selectedStyle = color
+        if self.display_table["state"][0] == "FAIL" and color is None:
             selectedStyle = "red"
         for field in self.display_table.keys():
             table.add_column(f"[blue]{field}", overflow="fold", style=selectedStyle)

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -7,6 +7,7 @@ import sys
 from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORTS, console
 from buildtest.exceptions import BuildTestError
 from buildtest.utils.file import is_file, load_json, resolve_path
+from rich.color import Color
 from rich.table import Table
 
 logger = logging.getLogger(__name__)
@@ -572,13 +573,15 @@ class Report:
         join_list = []
         title = title or f"Report File: {self.reportfile()}"
         table = Table(title=title, show_lines=True, expand=True)
-        selectedStyle = "green"
+        consoleColor = Color.default().name
         if color is not None:
-            selectedStyle = color
-        if self.display_table["state"][0] == "FAIL" and color is None:
-            selectedStyle = "red"
+            try:
+                consoleColor = Color.parse(color).name
+            except:
+                consoleColor = Color.default().name
+
         for field in self.display_table.keys():
-            table.add_column(f"[blue]{field}", overflow="fold", style=selectedStyle)
+            table.add_column(f"[blue]{field}", overflow="fold", style=consoleColor)
             join_list.append(self.display_table[field])
 
         transpose_list = [list(i) for i in zip(*join_list)]
@@ -856,5 +859,5 @@ def print_report_summary_output(report, table, pass_results, fail_results):
     console.print("Total Tests by Names: ", len(report.get_names()))
     console.print("Number of buildspecs in report: ", len(report.get_buildspecs()))
     console.print(table)
-    pass_results.print_report(title="PASS Tests")
-    fail_results.print_report(title="FAIL Tests")
+    pass_results.print_report(title="PASS Tests", color="green")
+    fail_results.print_report(title="FAIL Tests", color="red")

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -570,8 +570,11 @@ class Report:
         join_list = []
         title = title or f"Report File: {self.reportfile()}"
         table = Table(title=title, show_lines=True, expand=True)
+        selectedStyle = "green"
+        if self.display_table["state"][0] == "FAIL":
+            selectedStyle = "red"
         for field in self.display_table.keys():
-            table.add_column(f"[blue]{field}", overflow="fold", style="red")
+            table.add_column(f"[blue]{field}", overflow="fold", style=selectedStyle)
             join_list.append(self.display_table[field])
 
         transpose_list = [list(i) for i in zip(*join_list)]

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -195,6 +195,12 @@ def test_report_summary():
     report = Report(pager=True)
     report_summary(report)
 
+    report = Report()
+    report_summary(report, color="light_pink1")
+
+    report = Report()
+    report_summary(report, color="BAD_COLOR")  # For system to use default color
+
 
 @pytest.mark.cli
 def test_report_list():


### PR DESCRIPTION
Added logic so that when ```buildtest report summary``` will show failed tests in red to help differentiate between passed tests and failed tests which will be in green