### PR TITLE
rename options for buildtest last log

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -95,7 +95,7 @@ _buildtest ()
 
   local cmds="build buildspec cd cdash clean config debugreport docs help info inspect history path report schema schemadocs stylecheck unittests"
   local alias_cmds="bd bc cg debug it h hy rt style test"
-  local opts="--color --config --debug --editor --help --lastlog-path --print-lastlog --report --version --view-lastlog -c -d -h -r -V"
+  local opts="--color --config --debug --editor --help --logpath --print-log --report --version --view-log -c -d -h -r -V"
 
   next=${COMP_WORDS[1]}
 

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -160,13 +160,13 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         choices=["vi", "vim", "emacs", "nano"],
     )
     parser.add_argument(
-        "--view-lastlog", action="store_true", help="Show content of last log"
+        "--view-log", action="store_true", help="Show content of last log"
     )
     parser.add_argument(
-        "--lastlog-path", action="store_true", help="Print full path to last log file"
+        "--logpath", action="store_true", help="Print full path to last log file"
     )
     parser.add_argument(
-        "--print-lastlog",
+        "--print-log",
         action="store_true",
         help="Print content of last log without pagination",
     )

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -75,21 +75,30 @@ def main():
 
     report_file = args.report
 
-    # print content of BUILDTEST_LOGFILE if buildtest --view-lastlog is specified which should contain last build log
-    if args.view_lastlog:
+    # print content of BUILDTEST_LOGFILE if buildtest --view-log or buildtest --print-log is specified which should contain output of last log
+    if args.view_log or args.print_log:
+
+        # if logfile is not present we should raise exception since this file is only created upon running 'buildtest build'
+        if not is_file(BUILDTEST_LOGFILE):
+            raise BuildTestError(
+                f"Unable to find logfile: {BUILDTEST_LOGFILE}, please run 'buildtest build'"
+            )
+
         content = read_file(BUILDTEST_LOGFILE)
-        with console.pager():
+
+        if args.view_log:
+            with console.pager():
+                console.print(content)
+        else:
             console.print(content)
+
         return
 
-    # print content of BUILDTEST_LOGFILE without paginated form if buildtest --print-lastlog is specified
-    if args.print_lastlog:
-        content = read_file(BUILDTEST_LOGFILE)
-        console.print(content)
-
-    # print full path to the lastlog file if buildtest --lastlog-path is specified
-    if args.lastlog_path:
+    # print full path to the lastlog file if buildtest --logpath is specified
+    if args.logpath:
         console.print(BUILDTEST_LOGFILE)
+        return
+
     if is_file(BUILDTEST_LOGFILE):
         remove_file(BUILDTEST_LOGFILE)
 


### PR DESCRIPTION
@Xiangs18 @prathmesh4321 please take a look. I renamed some of the options since it was bit too long we can presume these options will print last log we have in the help message.

I caught an exception when logfile is not found instead of reading the file.

Also i made sure we exit program by `return` which i noticed wasn't set in that case one could do something like `buildtest --view-log bd -t pass` and run some commands after viewing log.