### PR TITLE
Remove --pager option from buildtest report summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,5 @@ env.bak/
 # ignore .packages directory
 .packages/
 Pipfile
-
+Pipfile.lock
 coverage.json

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -159,15 +159,12 @@ _buildtest ()
       ;;
 
     report|rt)
-      local opts="--end --failure --filter --format --help --helpfilter --helpformat --latest --no-header --oldest --pager --passed --start --terse  -e -f -h -n -p -s -t clear list summary sm"
+      local opts="--end --failure --filter --format --help --helpfilter --helpformat --latest --no-header --oldest --pager --passed --start --terse  -e -f -h -n -p -s -t clear list summary"
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
-      case "${COMP_WORDS[2]}" in summary|sm)
+      case "${COMP_WORDS[2]}" in summary)
         local opt="-d -h --detailed --help"
-        COMPREPLY=( $( compgen -W "${opt}" -- $cur ) );;
-      esac
-      case "${COMP_WORDS[3]}" in summary|sm)
-        local opt="-d -h --detailed --help"
-        COMPREPLY=( $( compgen -W "${opt}" -- $cur ) );;
+        COMPREPLY=( $( compgen -W "${opt}" -- $cur ) )
+        ;;
       esac
       ;;
     config|cg)

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -162,8 +162,8 @@ _buildtest ()
       local opts="--end --failure --filter --format --help --helpfilter --helpformat --latest --no-header --oldest --pager --passed --start --terse  -e -f -h -n -p -s -t clear list summary"
       COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
       case "${COMP_WORDS[2]}" in summary)
-        local opt="-d -h --detailed --help"
-        COMPREPLY=( $( compgen -W "${opt}" -- $cur ) )
+        local opts="-d -h --detailed --help"
+        COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
         ;;
       esac
       ;;

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -160,7 +160,7 @@ _buildtest ()
 
     report|rt)
       local opts="--end --failure --filter --format --help --helpfilter --helpformat --latest --no-header --oldest --pager --passed --start --terse  -e -f -h -n -p -s -t clear list summary"
-      COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
+      COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
       case "${COMP_WORDS[2]}" in summary)
         local opt="-d -h --detailed --help"
         COMPREPLY=( $( compgen -W "${opt}" -- $cur ) )

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -159,12 +159,15 @@ _buildtest ()
       ;;
 
     report|rt)
-      local opts="--end --failure --filter --format --help --helpfilter --helpformat --latest --no-header --oldest --pager --passed --start --terse  -e -f -h -n -p -s -t clear list summary"
-      COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
-      case "${COMP_WORDS[2]}" in summary)
-        local opts="-d -h --detailed --help --pager"
-        COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
-        ;;
+      local opts="--end --failure --filter --format --help --helpfilter --helpformat --latest --no-header --oldest --pager --passed --start --terse  -e -f -h -n -p -s -t clear list summary sm"
+      COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
+      case "${COMP_WORDS[2]}" in summary|sm)
+        local opt="-d -h --detailed --help"
+        COMPREPLY=( $( compgen -W "${opt}" -- $cur ) );;
+      esac
+      case "${COMP_WORDS[3]}" in summary|sm)
+        local opt="-d -h --detailed --help"
+        COMPREPLY=( $( compgen -W "${opt}" -- $cur ) );;
       esac
       ;;
     config|cg)

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -9,6 +9,8 @@ from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import console
 from buildtest.schemas.defaults import schema_table
 
+# from ast import alias
+
 
 def handle_kv_string(val):
     """This method is used as type field in --filter argument in ``buildtest buildspec find``.
@@ -876,7 +878,7 @@ def report_menu(subparsers):
     subparsers.add_parser("clear", help="Remove all report file")
     subparsers.add_parser("list", help="List all report files")
     parser_report_summary = subparsers.add_parser(
-        "summary", help="Summarize test report"
+        "summary", aliases=["sm"], help="Summarize test report"
     )
 
     # buildtest report
@@ -954,10 +956,6 @@ def report_menu(subparsers):
         help="Print output in machine readable format",
     )
     parser_report.add_argument(
-        "--pager", action="store_true", help="Enable PAGING when viewing result"
-    )
-
-    parser_report_summary.add_argument(
         "--pager", action="store_true", help="Enable PAGING when viewing result"
     )
     parser_report_summary.add_argument(

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -876,7 +876,7 @@ def report_menu(subparsers):
     subparsers.add_parser("clear", help="Remove all report file")
     subparsers.add_parser("list", help="List all report files")
     parser_report_summary = subparsers.add_parser(
-        "summary", aliases=["sm"], help="Summarize test report"
+        "summary", help="Summarize test report"
     )
 
     # buildtest report

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -9,8 +9,6 @@ from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import console
 from buildtest.schemas.defaults import schema_table
 
-# from ast import alias
-
 
 def handle_kv_string(val):
     """This method is used as type field in --filter argument in ``buildtest buildspec find``.

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -89,7 +89,7 @@ class Report:
         latest=None,
         oldest=None,
         count=None,
-        pagerOpt=None,
+        pager=None,
         detailed=None,
     ):
         """
@@ -104,7 +104,7 @@ class Report:
             latest (bool, optional): Fetch latest run for all tests discovered. This is specified via ``buildtest report --latest``
             oldest (bool, optional): Fetch oldest run for all tests discovered. This is specified via ``buildtest report --oldest``
             count (int, optional): Fetch limited number of rows get printed for all tests discovered. This is specified via ``buildtest report --count``
-            pagerOpt (bool, optional): Enabling PAGING output for ``buildtest report``. This can be specified via ``buildtest report --pager``
+            pager (bool, optional): Enabling PAGING output for ``buildtest report``. This can be specified via ``buildtest report --pager``
         """
         self.start = start
         self.end = end
@@ -114,7 +114,7 @@ class Report:
         self.oldest = oldest
         self.filter = filter_args
         self.format = format_args
-        self.pager = pagerOpt
+        self.pager = pager
 
         self.input_report = report_file
 

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -512,6 +512,8 @@ class Report:
         Args:
             terse (bool, optional): Print output int terse format
             noheader (bool, optional): Determine whether to print header in terse format
+            title (str, optional): Table title to print out
+            count (int, optional): Number of rows to be printed in terse format
             color (str, optional): An instance of a string class that tells print_report what color the output should be printed in.
 
         In this example, we display output in tabular format which works with ``--filter`` and ``--format`` option.

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -195,20 +195,20 @@ def test_report_summary():
     report = Report(pager=True)
     report_summary(report)
 
-    report = Report(detailed=True)
-    report_summary(report)
+    report = Report()
+    report_summary(report, detailed=True)
 
-    report = Report(pager=True, detailed=True)
-    report_summary(report)
+    report = Report(pager=True)
+    report_summary(report, detailed=True)
 
     report = Report()
     report_summary(report, color="light_pink1")
 
-    report = Report(pager=True, detailed=True)
-    report_summary(report, color="light_pink1")
+    report = Report(pager=True)
+    report_summary(report, color="light_pink1", detailed=True)
 
-    report = Report(detailed=True)
-    report_summary(report, color="light_pink1")
+    report = Report()
+    report_summary(report, color="light_pink1", detailed=True)
 
     report = Report(pager=True)
     report_summary(report, color="light_pink1")
@@ -216,11 +216,11 @@ def test_report_summary():
     report = Report()
     report_summary(report, color="BAD_COLOR")
 
-    report = Report(pager=True, detailed=True)
-    report_summary(report, color="BAD_COLOR")
+    report = Report(pager=True)
+    report_summary(report, color="BAD_COLOR", detailed=True)
 
-    report = Report(detailed=True)
-    report_summary(report, color="BAD_COLOR")
+    report = Report()
+    report_summary(report, color="BAD_COLOR", detailed=True)
 
     report = Report(pager=True)
     report_summary(report, color="BAD_COLOR")


### PR DESCRIPTION
simplify the pagination option for report and its subcommand summary. Before there was two individual --page options, one for the report command and the for the summary subcommand now the --page command for report will also act as the option for summary. 