### PR TITLE
Fixed the case when there no invalid buildspecs at all

### DIFF
--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -882,7 +882,9 @@ class BuildspecCache:
                 print("buildspec")
             for buildspec in self.cache["invalids"].keys():
                 print(buildspec)
-            sys.exit(1)
+            if self.cache["invalids"]:
+                sys.exit(1)
+            return
 
         # if --error is not specified print list of invalid buildspecs in rich table
         if not error:
@@ -907,7 +909,9 @@ class BuildspecCache:
         for buildspec, value in self.cache["invalids"].items():
             console.rule(buildspec)
             pprint(value)
-        sys.exit(1)
+        if self.cache["invalids"]:
+            sys.exit(1)
+        return
 
     @staticmethod
     def print_filter_fields():

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -886,6 +886,7 @@ class BuildspecCache:
                 print("buildspec")
             for buildspec in self.cache["invalids"].keys():
                 print(buildspec)
+            sys.exit(1)
 
         # if --error is not specified print list of invalid buildspecs in rich table
         if not error:

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -876,15 +876,16 @@ class BuildspecCache:
             console.print("The --terse flag can not be used with the --error option")
             sys.exit(1)
 
+        if not self.get_invalid_buildspecs():
+            console.print("There are no invalid buildspecs in cache")
+            return
+
         # implementation for machine readable format specified via --terse
         if terse:
             if not header:
                 print("buildspec")
             for buildspec in self.cache["invalids"].keys():
                 print(buildspec)
-            if self.cache["invalids"]:
-                sys.exit(1)
-            return
 
         # if --error is not specified print list of invalid buildspecs in rich table
         if not error:
@@ -898,20 +899,14 @@ class BuildspecCache:
             )
             for buildspec in self.cache["invalids"].keys():
                 table.add_row(buildspec)
-
-            # return a non-zero returncode
-            if table.row_count > 0:
-                console.print(table)
-                sys.exit(1)
-            return
+            console.print(table)
+            sys.exit(1)
 
         # implementation for --error which displays buildspec file followed by error
         for buildspec, value in self.cache["invalids"].items():
             console.rule(buildspec)
             pprint(value)
-        if self.cache["invalids"]:
-            sys.exit(1)
-        return
+        sys.exit(1)
 
     @staticmethod
     def print_filter_fields():

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -146,23 +146,35 @@ def test_buildspec_find_invalid():
     cache = BuildspecCache(configuration=configuration)
 
     # testing buildtest buildspec find invalid. This will assert SystemExit exception raised by sys.exit
-    with pytest.raises(SystemExit):
+    try:
         cache.print_invalid_buildspecs(error=True)
+    except SystemExit:
+        assert True
 
-    with pytest.raises(SystemExit):
+    try:
         cache.print_invalid_buildspecs(error=False)
+    except SystemExit:
+        assert True
 
-    with pytest.raises(SystemExit):
+    try:
         cache.print_invalid_buildspecs(error=True, terse=True)
+    except SystemExit:
+        assert True
 
-    with pytest.raises(SystemExit):
+    try:
         cache.print_invalid_buildspecs(error=False, terse=True)
+    except SystemExit:
+        assert True
 
-    with pytest.raises(SystemExit):
+    try:
         cache.print_invalid_buildspecs(error=True, terse=True, header=True)
+    except SystemExit:
+        assert True
 
-    with pytest.raises(SystemExit):
+    try:
         cache.print_invalid_buildspecs(error=False, terse=True, header=True)
+    except SystemExit:
+        assert True
 
 
 @pytest.mark.cli

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -149,32 +149,32 @@ def test_buildspec_find_invalid():
     try:
         cache.print_invalid_buildspecs(error=True)
     except SystemExit:
-        assert True
+        pass
 
     try:
         cache.print_invalid_buildspecs(error=False)
     except SystemExit:
-        assert True
+        pass
 
     try:
         cache.print_invalid_buildspecs(error=True, terse=True)
     except SystemExit:
-        assert True
+        pass
 
     try:
         cache.print_invalid_buildspecs(error=False, terse=True)
     except SystemExit:
-        assert True
+        pass
 
     try:
         cache.print_invalid_buildspecs(error=True, terse=True, header=True)
     except SystemExit:
-        assert True
+        pass
 
     try:
         cache.print_invalid_buildspecs(error=False, terse=True, header=True)
     except SystemExit:
-        assert True
+        pass
 
 
 @pytest.mark.cli


### PR DESCRIPTION
**Case when there are no invalid buildspecs system exit is not raised.**

![Screen Shot 2022-08-15 at 12 15 26 PM](https://user-images.githubusercontent.com/35829130/184702999-55e68dc6-3167-40d8-b31d-43f890a7ca58.png)

**Case when there are invalid buildspecs** 

![Screen Shot 2022-08-15 at 12 14 20 PM](https://user-images.githubusercontent.com/35829130/184703013-95747c6a-586b-4508-a0bb-cb867c179203.png)

