### PR TITLE
Add support for color themes with 'buildtest bc show' and 'buildtest bc show-fail'

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -257,8 +257,9 @@ _buildtest ()
          esac
         ;;
 
-
-      show|edit-test)
+      edit-test)
+        COMPREPLY=( $( compgen -W "$(_buildspec_cache_test_names)" -- $cur ) );;
+      show)
         local opts="-h --help --theme"
         COMPREPLY=( $( compgen -W "$(_buildspec_cache_test_names)" -- $cur ) )
         if [[ $cur == -* ]] ; then

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -259,7 +259,17 @@ _buildtest ()
 
 
       show|edit-test)
-        COMPREPLY=( $( compgen -W "$(_buildspec_cache_test_names)" -- $cur ) );;
+        local opts="-h --help --theme"
+        COMPREPLY=( $( compgen -W "$(_buildspec_cache_test_names)" -- $cur ) )
+        if [[ $cur == -* ]] ; then
+          COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
+        fi
+        local themes=$(python -c "from pygments.styles import STYLE_MAP; print(' '.join(list(STYLE_MAP.keys())))")
+        case ${prev} in --theme)
+          COMPREPLY=( $( compgen -W "$themes" -- $cur ) )
+          return
+        esac
+        ;;
       show-fail)
         COMPREPLY=( $( compgen -W "$(_failed_tests)" -- $cur ) );;
       maintainers)

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -266,13 +266,23 @@ _buildtest ()
           COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
         fi
         local themes=$(python -c "from pygments.styles import STYLE_MAP; print(' '.join(list(STYLE_MAP.keys())))")
-        case ${prev} in --theme)
+        case ${prev} in --theme|-t)
           COMPREPLY=( $( compgen -W "$themes" -- $cur ) )
           return
         esac
         ;;
       show-fail)
-        COMPREPLY=( $( compgen -W "$(_failed_tests)" -- $cur ) );;
+        local opts="-h --help --theme"
+        COMPREPLY=( $( compgen -W "$(_failed_tests)" -- $cur ) )
+        if [[ $cur == -* ]] ; then
+          COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
+        fi
+        local themes=$(python -c "from pygments.styles import STYLE_MAP; print(' '.join(list(STYLE_MAP.keys())))")
+        case ${prev} in --theme|-t)
+          COMPREPLY=( $( compgen -W "$themes" -- $cur ) )
+          return
+        esac
+        ;;
       maintainers)
         local opts="--breakdown --list --help --terse --no-header -b -h -l -n find"
         COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -718,8 +718,10 @@ def buildspec_menu(subparsers):
         help="Show content of buildspec based on test name",
         nargs="*",
     )
-    show_buildspecs.add_argument("--theme",
-                                 help="Specify a color theme, Pygments style to use when displaying output.",
+    show_buildspecs.add_argument("-t",
+                                 "--theme",
+                                 metavar="Color Themes",
+                                 help="Specify a color theme, Pygments style to use when displaying output. See https://pygments.org/docs/styles/#getting-a-list-of-available-styles for available themese",
                                  choices=list(STYLE_MAP.keys())
     )
     # buildtest buildspec show-fail
@@ -730,6 +732,12 @@ def buildspec_menu(subparsers):
         "name",
         help="Show content of buildspec based on failed test name",
         nargs="*",
+    )
+    show_fail_buildspecs.add_argument("-t",
+                                 "--theme",
+                                 metavar="Color Themes",
+                                 help="Specify a color theme, Pygments style to use when displaying output. See https://pygments.org/docs/styles/#getting-a-list-of-available-styles for available themes",
+                                 choices=list(STYLE_MAP.keys())
     )
 
     # buildtest buildspec summary

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -4,6 +4,7 @@ interact with a global configuration for buildtest.
 """
 import argparse
 import datetime
+from pygments.styles import STYLE_MAP
 
 from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import console
@@ -717,7 +718,10 @@ def buildspec_menu(subparsers):
         help="Show content of buildspec based on test name",
         nargs="*",
     )
-
+    show_buildspecs.add_argument("--theme",
+                                 help="Specify a color theme, Pygments style to use when displaying output.",
+                                 choices=list(STYLE_MAP.keys())
+    )
     # buildtest buildspec show-fail
     show_fail_buildspecs = subparsers_buildspec.add_parser(
         "show-fail", help="Show content of buildspec file for all failed tests"

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -4,11 +4,11 @@ interact with a global configuration for buildtest.
 """
 import argparse
 import datetime
-from pygments.styles import STYLE_MAP
 
 from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import console
 from buildtest.schemas.defaults import schema_table
+from pygments.styles import STYLE_MAP
 
 
 def handle_kv_string(val):
@@ -718,11 +718,12 @@ def buildspec_menu(subparsers):
         help="Show content of buildspec based on test name",
         nargs="*",
     )
-    show_buildspecs.add_argument("-t",
-                                 "--theme",
-                                 metavar="Color Themes",
-                                 help="Specify a color theme, Pygments style to use when displaying output. See https://pygments.org/docs/styles/#getting-a-list-of-available-styles for available themese",
-                                 choices=list(STYLE_MAP.keys())
+    show_buildspecs.add_argument(
+        "-t",
+        "--theme",
+        metavar="Color Themes",
+        help="Specify a color theme, Pygments style to use when displaying output. See https://pygments.org/docs/styles/#getting-a-list-of-available-styles for available themese",
+        choices=list(STYLE_MAP.keys()),
     )
     # buildtest buildspec show-fail
     show_fail_buildspecs = subparsers_buildspec.add_parser(
@@ -733,11 +734,12 @@ def buildspec_menu(subparsers):
         help="Show content of buildspec based on failed test name",
         nargs="*",
     )
-    show_fail_buildspecs.add_argument("-t",
-                                 "--theme",
-                                 metavar="Color Themes",
-                                 help="Specify a color theme, Pygments style to use when displaying output. See https://pygments.org/docs/styles/#getting-a-list-of-available-styles for available themes",
-                                 choices=list(STYLE_MAP.keys())
+    show_fail_buildspecs.add_argument(
+        "-t",
+        "--theme",
+        metavar="Color Themes",
+        help="Specify a color theme, Pygments style to use when displaying output. See https://pygments.org/docs/styles/#getting-a-list-of-available-styles for available themes",
+        choices=list(STYLE_MAP.keys()),
     )
 
     # buildtest buildspec summary

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -1020,7 +1020,7 @@ def edit_buildspec_file(buildspecs, configuration, editor, test=None):
         console.print(f"[green]{buildspec} is valid")
 
 
-def show_buildspecs(test_names, configuration, theme="monokai"):
+def show_buildspecs(test_names, configuration, theme=None):
     """This is the entry point for ``buildtest buildspec show`` command which will print content of
     buildspec based on name of test.
 
@@ -1056,7 +1056,7 @@ def show_buildspecs(test_names, configuration, theme="monokai"):
         )
 
 
-def show_failed_buildspecs(configuration, test_names=None, report_file=None):
+def show_failed_buildspecs(configuration, test_names=None, report_file=None, theme=None):
     """This is the entry point for ``buildtest buildspec show-fail`` command which will print content of
     buildspec on name of all failed tests if a list of test names are not speficied
 
@@ -1077,7 +1077,7 @@ def show_failed_buildspecs(configuration, test_names=None, report_file=None):
         failed_tests = test_names
     else:
         failed_tests = all_failed_tests
-    show_buildspecs(failed_tests, configuration)
+    show_buildspecs(failed_tests, configuration, theme)
 
 
 def buildspec_validate(

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -30,7 +30,7 @@ from rich.layout import Layout
 from rich.panel import Panel
 from rich.pretty import pprint
 from rich.table import Column, Table
-
+from rich.syntax import Syntax
 logger = logging.getLogger(__name__)
 
 
@@ -1020,15 +1020,17 @@ def edit_buildspec_file(buildspecs, configuration, editor, test=None):
         console.print(f"[green]{buildspec} is valid")
 
 
-def show_buildspecs(test_names, configuration):
+def show_buildspecs(test_names, configuration, theme="monokai"):
     """This is the entry point for ``buildtest buildspec show`` command which will print content of
     buildspec based on name of test.
 
     Args:
         test_names (list): List of test names to show content of file
         configuration (buildtest.config.SiteConfiguration): Instance of SiteConfiguration class
+        theme (str): Color theme to chose. This is the Pygments style (https://pygments.org/docs/styles/#getting-a-list-of-available-styles) which is specified by ``--theme`` option
     """
     cache = BuildspecCache(configuration=configuration)
+    theme = theme or "monokai"
 
     error = False
     visited = set()
@@ -1042,9 +1044,11 @@ def show_buildspecs(test_names, configuration):
         buildspec = cache.lookup_buildspec_by_name(name)
         if buildspec not in visited:
             visited.add(buildspec)
-            content = read_file(buildspec)
+
             console.rule(buildspec)
-            console.print(Panel.fit(content))
+            with open(buildspec) as fd:
+                syntax = Syntax(fd.read(), "yaml", theme=theme)
+            console.print(syntax)
 
     if error:
         raise BuildTestError(

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import random
 import subprocess
 import sys
 import time
@@ -21,7 +22,6 @@ from buildtest.utils.file import (
     is_dir,
     is_file,
     load_json,
-    read_file,
     resolve_path,
     walk_tree,
 )
@@ -29,8 +29,9 @@ from jsonschema.exceptions import ValidationError
 from rich.layout import Layout
 from rich.panel import Panel
 from rich.pretty import pprint
-from rich.table import Column, Table
 from rich.syntax import Syntax
+from rich.table import Column, Table
+
 logger = logging.getLogger(__name__)
 
 
@@ -237,6 +238,15 @@ class BuildspecCache:
                 test_names.append(name)
 
         return test_names
+
+    def get_random_tests(self, num_items=1):
+        """Returns a list of random test names from the list of available test. The test are picked
+        using `random.sample <https://docs.python.org/3/library/random.html#random.sample>`_
+
+        Args:
+            num_items (int, optional): Number of test items to retrieve
+        """
+        return random.sample(self.get_names(), num_items)
 
     def lookup_buildspec_by_name(self, name):
         """Given an input test name, return corresponding buildspec file found in the cache.
@@ -1027,7 +1037,7 @@ def show_buildspecs(test_names, configuration, theme=None):
     Args:
         test_names (list): List of test names to show content of file
         configuration (buildtest.config.SiteConfiguration): Instance of SiteConfiguration class
-        theme (str): Color theme to chose. This is the Pygments style (https://pygments.org/docs/styles/#getting-a-list-of-available-styles) which is specified by ``--theme`` option
+        theme (str, optional): Color theme to choose. This is the Pygments style (https://pygments.org/docs/styles/#getting-a-list-of-available-styles) which is specified by ``--theme`` option
     """
     cache = BuildspecCache(configuration=configuration)
     theme = theme or "monokai"
@@ -1056,7 +1066,9 @@ def show_buildspecs(test_names, configuration, theme=None):
         )
 
 
-def show_failed_buildspecs(configuration, test_names=None, report_file=None, theme=None):
+def show_failed_buildspecs(
+    configuration, test_names=None, report_file=None, theme=None
+):
     """This is the entry point for ``buildtest buildspec show-fail`` command which will print content of
     buildspec on name of all failed tests if a list of test names are not speficied
 
@@ -1064,6 +1076,7 @@ def show_failed_buildspecs(configuration, test_names=None, report_file=None, the
         configuration (buildtest.config.SiteConfiguration): Instance of SiteConfiguration class
         test_names (list, optional): List of test names to show content of file
         report_file (str, optional): Full path to report file to read
+        theme (str, optional): Color theme to choose. This is the Pygments style (https://pygments.org/docs/styles/#getting-a-list-of-available-styles) which is specified by ``--theme`` option
     """
     results = Report(report_file=report_file)
     all_failed_tests = results.get_test_by_state(state="FAIL")

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -178,8 +178,10 @@ def print_buildspec_help():
         "buildtest buildspec show python_hello",
         "Show content of buildspec based on test name 'python_hello'",
     )
-    table.add_row("buildtest buildspec show python_hello --theme emacs",
-                  "Use color theme 'emacs' for showing content of test")
+    table.add_row(
+        "buildtest buildspec show python_hello --theme emacs",
+        "Use color theme 'emacs' for showing content of test",
+    )
     table.add_row(
         "buildtest buildspec show-fail",
         "Show content of buildspec on all failed tests",

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -178,9 +178,15 @@ def print_buildspec_help():
         "buildtest buildspec show python_hello",
         "Show content of buildspec based on test name 'python_hello'",
     )
+    table.add_row("buildtest buildspec show python_hello --theme emacs",
+                  "Use color theme 'emacs' for showing content of test")
     table.add_row(
         "buildtest buildspec show-fail",
         "Show content of buildspec on all failed tests",
+    )
+    table.add_row(
+        "buildtest buildspec show-fail exit1_fail",
+        "Show content of test 'exit1_fail'",
     )
     table.add_row(
         "buildtest buildspec edit-test python_hello",

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -184,7 +184,7 @@ def main():
         elif args.buildspecs_subcommand == "summary":
             summarize_buildspec_cache(pager=args.pager, configuration=configuration)
         elif args.buildspecs_subcommand == "show":
-            show_buildspecs(test_names=args.name, configuration=configuration)
+            show_buildspecs(test_names=args.name, configuration=configuration, theme=args.theme)
         elif args.buildspecs_subcommand == "show-fail":
             show_failed_buildspecs(
                 configuration=configuration,

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -184,13 +184,15 @@ def main():
         elif args.buildspecs_subcommand == "summary":
             summarize_buildspec_cache(pager=args.pager, configuration=configuration)
         elif args.buildspecs_subcommand == "show":
-            show_buildspecs(test_names=args.name, configuration=configuration, theme=args.theme)
+            show_buildspecs(
+                test_names=args.name, configuration=configuration, theme=args.theme
+            )
         elif args.buildspecs_subcommand == "show-fail":
             show_failed_buildspecs(
                 configuration=configuration,
                 test_names=args.name,
                 report_file=report_file,
-                theme=args.theme
+                theme=args.theme,
             )
         elif args.buildspecs_subcommand == "edit-test":
             edit_buildspec_test(

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -190,6 +190,7 @@ def main():
                 configuration=configuration,
                 test_names=args.name,
                 report_file=report_file,
+                theme=args.theme
             )
         elif args.buildspecs_subcommand == "edit-test":
             edit_buildspec_test(

--- a/docs/gettingstarted/buildspecs_interface.rst
+++ b/docs/gettingstarted/buildspecs_interface.rst
@@ -273,17 +273,16 @@ in the cache
 .. command-output:: buildtest buildspec show XYZ123!
    :returncode: 1
 
+You can use ``--theme`` option to define the color scheme used for printing content of buildspecs. The available comlor schemes can be found at
+https://pygments.org/docs/styles/#getting-a-list-of-available-styles. buildtest supports tab completion on the available themes which you can see below
 
-Let's assume you want to see content of all buildspec that failed test, you can use ``buildtest report`` to extract list of test names
-that failed as argument to ``buildtest buildspec show``, for instance we see below we have two tests that failed, using ``--filter state=FAIL`` will
-retrieve all failures, you will want to pipe output to **uniq** to get unique listing since output of ``buildtest report`` will show all test runs and
-duplicates can occur if same test is run multiple times.
+.. code-block::
 
-.. code-block:: console
-
-    $ buildtest report --filter state=FAIL --format name --terse --no-header | uniq
-    exit1_fail
-    returncode_list_mismatch
+    $  buildtest bc show --theme
+    abap                autumn              default             friendly_grayscale  igor                manni               native              pastie              sas                 stata-dark          vim
+    algol               borland             dracula             fruity              inkpot              material            one-dark            perldoc             solarized-dark      stata-light         vs
+    algol_nu            bw                  emacs               gruvbox-dark        lilypond            monokai             paraiso-dark        rainbow_dash        solarized-light     tango               xcode
+    arduino             colorful            friendly            gruvbox-light       lovelace            murphy              paraiso-light       rrt                 stata               trac                zenburn
 
 Show fail buildspec ``buildtest buildspec show-fail``
 ------------------------------------------------------

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -293,10 +293,14 @@ def test_buildspec_summary():
 @pytest.mark.cli
 def test_buildspec_show():
     cache = BuildspecCache(configuration=configuration)
-    # get first test in list
-    test_name = [cache.get_names()[0]]
+
+    test_name = cache.get_random_tests(num_items=1)
+
     # run buildtest buildspec show <test>
     show_buildspecs(test_name, configuration)
+
+    # run buildtest buildspec <test> show --theme monokai
+    show_buildspecs(test_name, configuration, theme="monokai")
 
     with pytest.raises(BuildTestError):
         random_testname = "".join(
@@ -322,3 +326,11 @@ def test_buildspec_show_fail():
         results = Report()
         pass_test = results.get_test_by_state(state="PASS")[0]
         show_failed_buildspecs(configuration=configuration, test_names=[pass_test])
+
+    report = Report()
+    # get a random failed test from report file to be used for showing content of buildspec file
+    fail_tests = random.sample(report.get_test_by_state(state="FAIL"), 1)
+    # running buildtest buildspec show-fail <test> --theme monokai
+    show_failed_buildspecs(
+        configuration=configuration, test_names=fail_tests, theme="monokai"
+    )


### PR DESCRIPTION
# default theme

![Screen Shot 2022-09-01 at 2 17 35 PM](https://user-images.githubusercontent.com/12942230/187984852-f23e77f5-943c-423b-a1b7-d0136ca2b0a1.png)


Now you can change theme such as `emacs`

![Screen Shot 2022-09-01 at 2 18 34 PM](https://user-images.githubusercontent.com/12942230/187985028-4317fb3f-22d2-4e44-b39c-083986f0cf4c.png)

This also works with `buildtest buildspec show-fail` 
![Screen Shot 2022-09-01 at 2 20 14 PM](https://user-images.githubusercontent.com/12942230/187985301-b7729ab3-5950-49f2-8885-20e133714465.png)
