### PR TITLE
Rename options for retrieving pass and failed test from report

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -84,7 +84,7 @@ _buildspec_cache_test_names()
 
 _failed_tests()
 {
-  buildtest rt --failure --format name --terse --no-header | uniq
+  buildtest rt --fail --format name --terse --no-header | uniq
 }
 
 _avail_maintainers()
@@ -165,7 +165,7 @@ _buildtest ()
       ;;
 
     report|rt)
-      local opts="--color --end --failure --filter --format --help --helpfilter --helpformat --latest --no-header --oldest --pager --passed --start --terse  -e -f -h -n -p -s -t c clear l list sm summary"
+      local opts="--color --end --fail --filter --format --help --helpfilter --helpformat --latest --no-header --oldest --pager --pass --start --terse  -e -f -h -n -p -s -t c clear l list sm summary"
       local copts=$(python -c "from rich.color import ANSI_COLOR_NAMES;print(' '.join(list(ANSI_COLOR_NAMES.keys())))")
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       case ${prev} in --color)

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -972,13 +972,14 @@ def report_menu(subparsers):
 
     pass_fail.add_argument(
         "-f",
-        "--failure",
+        "--fail",
         help="Retrieve all FAIL tests",
         action="store_true",
     )
     pass_fail.add_argument(
         "-p",
-        "--passed",
+        "--pass",
+        dest="passed",
         help="Retrieve all PASS tests",
         action="store_true",
     )

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -348,8 +348,8 @@ def print_report_help():
         "buildtest -r /tmp/result.json report",
         "Read report file /tmp/result.json and display result",
     )
-    table.add_row("buildtest report --failure", "Show all test failures")
-    table.add_row("buildtest report --passed", "Show all test passed")
+    table.add_row("buildtest report --fail", "Show all test failures")
+    table.add_row("buildtest report --pass", "Show all test passed")
     table.add_row(
         "buildtest report --start 2022-01-01 --end 2022-01-05",
         "Show all test records in the date range from [2022-01-01, 2022-01-05]",

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -115,8 +115,8 @@ class Report:
             format (str, optional): A comma separated list of format fields for altering report table. This is specified via ``buildtest report --format``
             start (datetime, optional): Fetch run for all tests discovered filered by starttime. This is specified via ``buildtest report --start``
             end (datetime, optional): Fetch run for all tests discovered filered by endtime. This is specified via ``buildtest report --end``
-            failure (bool, optional): Fetch failure run for all tests discovered. This is specified via ``buildtest report --failure``
-            passed (bool, optional): Fetch passed run for all tests discovered. This is specified via ``buildtest report --passed``
+            failure (bool, optional): Fetch failure run for all tests discovered. This is specified via ``buildtest report --fail``
+            passed (bool, optional): Fetch passed run for all tests discovered. This is specified via ``buildtest report --pass``
             latest (bool, optional): Fetch latest run for all tests discovered. This is specified via ``buildtest report --latest``
             oldest (bool, optional): Fetch oldest run for all tests discovered. This is specified via ``buildtest report --oldest``
             count (int, optional): Fetch limited number of rows get printed for all tests discovered. This is specified via ``buildtest report --count``
@@ -797,7 +797,7 @@ def report_cmd(args, report_file=None):
         format_args=args.format,
         start=args.start,
         end=args.end,
-        failure=args.failure,
+        failure=args.fail,
         passed=args.passed,
         latest=args.latest,
         oldest=args.oldest,

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -162,41 +162,36 @@ buildtest will retrieve the first and last record of every test.
 
 .. command-output:: buildtest report --filter name=exit1_pass --format name,id,starttime --oldest --latest
 
-Find all Failed Tests (``buildtest report --failure``)
+.. _buildtest_report_fail:
+
+Find all Failed Tests (``buildtest report --fail``)
 --------------------------------------------------------
 
-The ``buildtest report --failure`` command can be used to retrieve all failed tests which is equivalent to filtering tests
+The ``buildtest report --fail`` command can be used to retrieve all failed tests which is equivalent to filtering tests
 by **state=FAIL** since test state is determined by **state** property. This command can be useful to pin-point failures.
 
-Let's take a look at these two example, the first test queries report by filtering by tag name ``tutorials`` and the second command
-will run same example with ``--failure`` option. Take note of the **state** property in table, in second example buildtest will
-filter test and report all **FAIL** tests.
+Let's take a look at next two example, the first command will query report and limit output to 6 rows which can retrieve both pass
+and failed test. The second command will run same example with ``--fail`` and only retrieve failed tests.
+Take note of the **state** property in table, in second example buildtest will filter test and report all **FAIL** tests.
 
+.. command-output:: buildtest report --format name,id,state --count=6
 
-.. command-output:: buildtest report --filter tags=tutorials --format name,id,state
+.. command-output:: buildtest report --format name,id,state --fail --count=6
 
-.. command-output:: buildtest report --filter tags=tutorials --format name,id,state --failure
-
-Find all Passed Tests (``buildtest report --passed``)
+Find all Passed Tests (``buildtest report --pass``)
 --------------------------------------------------------
 
-The ``buildtest report --passed`` command can be used to retrieve all passed tests which is equivalent to filtering tests
-by **state=PASS** since the test state is determined by **state** property. This command can be useful to pin-point passed tests.
+The ``buildtest report --pass``, works similar to ``buildtest report --fail`` where it will filter test by **state=PASS** which can be used to find all passed tests.
 
-Let's take a look at these two example, the first test queries report by filtering by tag name ``tutorials`` and the second command
-will run same example with ``--passed`` option. Take note of the **state** property in table. In second example buildtest will
-filter test and report all **PASS** tests.
+We can see in example below, that buildtest will retrieve only PASS tests which can be determined by the ``state`` property
 
-
-.. command-output:: buildtest report --filter tags=tutorials --format name,id,state
-
-.. command-output:: buildtest report --filter tags=tutorials --format name,id,state --passed
+.. command-output:: buildtest report --format name,id,state --pass --count=6
 
 .. Note::
-    The ``--passed`` and ``--failure`` are mutually exclusive option which will query all PASS or FAIL test from report file, if you try to
+    The ``--pass`` and ``--fail`` are mutually exclusive option which will query all PASS or FAIL test from report file, if you try to
     specify both options on command line you will get an error
 
-    .. command-output:: buildtest report --passed --failure
+    .. command-output:: buildtest report --pass --fail
         :returncode: 2
 
 Find Tests by Start and End Date (``buildtest report --start --end``)


### PR DESCRIPTION
This PR will change the option names to `buildtest report --pass` and `buildtest report --fail` 