### PR TITLE
Added tab completion for buildtest report --format & --filter

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -107,6 +107,16 @@ _avail_buildspec_formatfields()
 {
   buildtest buildspec find --formatfields
 }
+
+_avail_report_filterfields()
+{
+  buildtest report --filterfields
+}
+
+_avail_report_formatfields()
+{
+  buildtest report --formatfields
+}
 #  entry point to buildtest bash completion function
 _buildtest ()
 {
@@ -185,6 +195,14 @@ _buildtest ()
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       case ${prev} in --color)
         COMPREPLY=( $( compgen -W "$(_supported_colors)" -- $cur ) )
+        return
+      esac
+      case "${prev}" in --filter)
+        COMPREPLY=( $( compgen -W "$(_avail_report_filterfields)" -- $cur ) )
+        return
+      esac
+      case "${prev}" in --format)
+        COMPREPLY=( $( compgen -W "$(_avail_report_formatfields)" -- $cur ) )
         return
       esac
       case "$prev" in summary)


### PR DESCRIPTION
Bash completion for buildtest report --format and --filter options

![image](https://user-images.githubusercontent.com/35829130/193343134-e708c077-12d2-46ed-8e26-b91bd7185cfb.png)

