### PR TITLE
Add subcommand "buildtest report path" to print path to the report file being used.

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -195,7 +195,7 @@ _buildtest ()
       ;;
 
     report|rt)
-      local opts="--color --end --fail --filter --filterfields --format --formatfields --help --helpfilter --helpformat --latest --no-header --oldest --pager --pass --row-count --start --terse  -e -f -h -n -p -s -t c clear l list sm summary"
+      local opts="--color --end --fail --filter --filterfields --format --formatfields --help --helpfilter --helpformat --latest --no-header --oldest --pager --pass --row-count --start --terse  -e -f -h -n -p -s -t c clear l list p path sm summary"
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       case ${prev} in --color)
         COMPREPLY=( $( compgen -W "$(_supported_colors)" -- $cur ) )

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -4,7 +4,6 @@ interact with a global configuration for buildtest.
 """
 import argparse
 import datetime
-from ast import alias
 
 from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import console

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -4,6 +4,7 @@ interact with a global configuration for buildtest.
 """
 import argparse
 import datetime
+from ast import alias
 
 from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import console
@@ -973,6 +974,9 @@ def report_menu(subparsers):
     )
     subparsers.add_parser("clear", aliases=["c"], help="Remove all report file")
     subparsers.add_parser("list", aliases=["l"], help="List all report files")
+    subparsers.add_parser(
+        "path", aliases=["p"], help="Print full path to the report file being used"
+    )
     parser_report_summary = subparsers.add_parser(
         "summary", aliases=["sm"], help="Summarize test report"
     )

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -368,6 +368,9 @@ def print_report_help():
     )
     table.add_row("buildtest report list", "List all report files")
     table.add_row("buildtest report clear", "Remove content of default report file")
+    table.add_roe(
+        "buildtest report path", "Print full path to the report file being used"
+    )
     table.add_row("buildtest report summary", "Show summary of test report")
     table.add_row(
         "buildtest report summary --detailed", "Show detailed summary of test report"

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -368,7 +368,7 @@ def print_report_help():
     )
     table.add_row("buildtest report list", "List all report files")
     table.add_row("buildtest report clear", "Remove content of default report file")
-    table.add_roe(
+    table.add_row(
         "buildtest report path", "Print full path to the report file being used"
     )
     table.add_row("buildtest report summary", "Show summary of test report")

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -809,6 +809,11 @@ def report_cmd(args, report_file=None):
         report_file=report_file,
         count=args.count,
     )
+
+    if args.report_subcommand in ["path", "p"]:
+        console.print(results.reportfile())
+        return
+
     if args.report_subcommand in ["summary", "sm"]:
         if args.pager:
             with console.pager():

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -20,6 +20,13 @@ with default format fields. To see a list of all format fields, click :ref:`here
     .. command-output:: buildtest report
        :ellipsis: 20
 
+You can run ``buildtest report path`` command to get the full path to the report file being used. This is helpful when the report file
+is not known in that case one can print the file by doing ``cat $(buildtest report path)``.
+
+.. dropdown:: ``buildtest report path``
+
+    .. command-output:: buildtest report path
+
 The ``buildtest report`` command will fetch all records and display them in a table format, if you want to know how many records are displayed in the table you can use ``buildtest report --row-count`` which will display   
 a raw count of records in the table. In the example below we will run ``buildtest report --row-count`` which will show number of tests in the report.
 

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -316,8 +316,3 @@ def test_report_path():
         color = None
 
     report_cmd(args)
-
-    os.remove(BUILD_REPORT)
-
-    with pytest.raises(SystemExit):
-        report_cmd(args)

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -293,6 +293,14 @@ def test_report_clear():
 
 
 @pytest.mark.cli
+def test_report_limited_rows():
+
+    report = Report()
+    report.print_report(count=5)
+    report.print_report(terse=True, count=5)
+
+
+@pytest.mark.cli
 def test_report_path():
     class args:
         filter = None
@@ -313,11 +321,3 @@ def test_report_path():
 
     with pytest.raises(SystemExit):
         report_cmd(args)
-
-
-@pytest.mark.cli
-def test_report_limited_rows():
-
-    report = Report()
-    report.print_report(count=5)
-    report.print_report(terse=True, count=5)

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -268,6 +268,27 @@ def test_report_list():
 
 
 @pytest.mark.cli
+def test_report_path():
+    class args:
+        helpformat = False
+        helpfilter = False
+        filter = None
+        format = None
+        oldest = False
+        latest = False
+        report_subcommand = "path"
+        terse = None
+        color = None
+
+    report_cmd(args)
+
+    os.remove(BUILD_REPORT)
+
+    with pytest.raises(SystemExit):
+        report_cmd(args)
+
+
+@pytest.mark.cli
 def test_report_clear():
     class args:
         helpformat = False

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -268,29 +268,6 @@ def test_report_list():
 
 
 @pytest.mark.cli
-def test_report_path():
-    class args:
-        filter = None
-        format = None
-        start = None
-        end = None
-        fail = None
-        passed = None
-        oldest = False
-        latest = False
-        report_subcommand = "path"
-        count = None
-        color = None
-
-    report_cmd(args)
-
-    os.remove(BUILD_REPORT)
-
-    with pytest.raises(SystemExit):
-        report_cmd(args)
-
-
-@pytest.mark.cli
 def test_report_clear():
     class args:
         helpformat = False
@@ -313,6 +290,29 @@ def test_report_clear():
 
     shutil.move(backupfile, BUILD_REPORT)
     assert BUILD_REPORT
+
+
+@pytest.mark.cli
+def test_report_path():
+    class args:
+        filter = None
+        format = None
+        start = None
+        end = None
+        fail = None
+        passed = None
+        oldest = False
+        latest = False
+        report_subcommand = "path"
+        count = None
+        color = None
+
+    report_cmd(args)
+
+    os.remove(BUILD_REPORT)
+
+    with pytest.raises(SystemExit):
+        report_cmd(args)
 
 
 @pytest.mark.cli

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -270,14 +270,16 @@ def test_report_list():
 @pytest.mark.cli
 def test_report_path():
     class args:
-        helpformat = False
-        helpfilter = False
         filter = None
         format = None
+        start = None
+        end = None
+        fail = None
+        passed = None
         oldest = False
         latest = False
         report_subcommand = "path"
-        terse = None
+        count = None
         color = None
 
     report_cmd(args)


### PR DESCRIPTION
**buildtest rt path**

![buildtest_report](https://user-images.githubusercontent.com/35829130/193952431-dd148bb7-0ef8-4940-9fd8-b7b6f26eeb40.png)

**buildtest -r <path> rt path**

![builtest_report_try](https://user-images.githubusercontent.com/35829130/193952499-2d3abe93-5604-4618-aef6-15e2ceaa9315.png)

**"buildtest rt path" raising exception when there is no report file**

![buildtes report clear](https://user-images.githubusercontent.com/35829130/193952629-ade21a02-0a5a-4a68-a83a-65f703b96625.png)
