### PR TITLE
Colorize output for all terse formats

### DIFF
--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -807,21 +807,15 @@ class BuildspecCache:
         """Return a list of maintainers"""
         return self.cache["maintainers"]
 
-    def print_maintainer(self, color=None):
-        """This method prints maintainers from buildspec cache file which implements ``buildtest buildspec maintainers --list`` command.
-
-        Args:
-            color (bool, optional): Print table output of ``buildtest buildspec maintainers --list`` with selected color
-        """
-
-        consoleColor = checkColor(color)
+    def print_maintainer(self):
+        """This method prints maintainers from buildspec cache file which implements ``buildtest buildspec maintainers --list`` command."""
 
         if self.terse:
             if not self.header:
-                print("maintainers")
+                console.print("maintainers", style=self.color)
 
             for maintainer in self.cache["maintainers"]:
-                print(maintainer)
+                console.print(f"[{self.color}]{maintainer}")
 
             return
 
@@ -829,7 +823,7 @@ class BuildspecCache:
             Column("Maintainers", overflow="fold"),
             header_style="blue",
             title_style="red",
-            row_styles=[consoleColor],
+            row_styles=[self.color],
         )
 
         for maintainer in self.cache["maintainers"].keys():
@@ -855,21 +849,15 @@ class BuildspecCache:
             for file in self.cache["maintainers"][name]:
                 console.print(file)
 
-    def print_maintainers_by_buildspecs(self, color=None):
-        """This method prints maintainers breakdown by buildspecs. This method implements ``buildtest buildspec maintainers --breakdown``
-
-        Args:
-            color (bool, optional): Print table output of ``buildtest buildspec maintainers --breakdown`` with selected color
-        """
-
-        consoleColor = checkColor(color)
+    def print_maintainers_by_buildspecs(self):
+        """This method prints maintainers breakdown by buildspecs. This method implements ``buildtest buildspec maintainers --breakdown``."""
 
         if self.terse:
             if not self.header:
-                print("maintainers|buildspec")
+                console.print("maintainers|buildspec", style=self.color)
 
             for maintainer, buildspecs in self.cache["maintainers"].items():
-                print(f"{maintainer}|{':'.join(buildspecs)}")
+                console.print(f"[{self.color}]{maintainer}|{':'.join(buildspecs)}")
             return
 
         table = Table(
@@ -879,7 +867,7 @@ class BuildspecCache:
             header_style="blue",
             style="cyan",
             title_style="red",
-            row_styles=[consoleColor],
+            row_styles=[self.color],
             show_lines=True,
         )
 
@@ -1301,15 +1289,15 @@ def buildspec_maintainers(
         name (str, optional): List all buildspecs corresponding to maintainer name. This command is specified via ``buildtest buildspec maintainers find <name>``
     """
 
-    consoleColor = checkColor(color)
-
-    cache = BuildspecCache(configuration=configuration, terse=terse, header=header)
+    cache = BuildspecCache(
+        configuration=configuration, terse=terse, header=header, color=color
+    )
 
     if list_maintainers:
-        cache.print_maintainer(color=consoleColor)
+        cache.print_maintainer()
 
     if breakdown:
-        cache.print_maintainers_by_buildspecs(color=consoleColor)
+        cache.print_maintainers_by_buildspecs()
 
     if name:
         cache.print_maintainers_find(name=name)

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -687,7 +687,9 @@ class BuildspecCache:
                 for test_name, description in self.cache["executor"][
                     executor_name
                 ].items():
-                    console.print(f"[{self.color}]{executor_name}|{test_name}|{description}")
+                    console.print(
+                        f"[{self.color}]{executor_name}|{test_name}|{description}"
+                    )
             return
 
         table = Table(title="Tests by Executors", header_style="blue", show_lines=True)

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -592,10 +592,10 @@ class BuildspecCache:
         if self.terse:
 
             if not self.header:
-                print("buildspec")
+                console.print("buildspec", style=self.color)
 
             for buildspec in self.cache["buildspecs"].keys():
-                print(buildspec)
+                console.print(f"[{self.color}]{buildspec}")
 
             return
 
@@ -623,10 +623,10 @@ class BuildspecCache:
         # if --terse option specified print list of all tags in machine readable format
         if self.terse:
             if not self.header:
-                print("tag")
+                console.print("tag", style=self.color)
 
             for tag in self.cache["unique_tags"]:
-                print(tag)
+                console.print(f"[{self.color}]{tag}")
 
             return
 
@@ -652,10 +652,10 @@ class BuildspecCache:
         if self.terse:
 
             if not self.header:
-                print("executor")
+                console.print("executor", style=self.color)
 
             for executor in self.cache["unique_executors"]:
-                print(executor)
+                console.print(f"[{self.color}]{executor}")
 
             return
 
@@ -681,13 +681,13 @@ class BuildspecCache:
         if self.terse:
 
             if not self.header:
-                print("executor|name|description")
+                console.print("executor|name|description", style=self.color)
 
             for executor_name in self.cache["executor"].keys():
                 for test_name, description in self.cache["executor"][
                     executor_name
                 ].items():
-                    print(f"{executor_name}|{test_name}|{description}")
+                    console.print(f"[{self.color}]{executor_name}|{test_name}|{description}")
             return
 
         table = Table(title="Tests by Executors", header_style="blue", show_lines=True)
@@ -712,12 +712,11 @@ class BuildspecCache:
         if self.terse:
 
             if not self.header:
-                print("tags|name|description")
+                console.print("tags|name|description", style=self.color)
 
             for tagname in self.cache["tags"].keys():
                 for test_name, description in self.cache["tags"][tagname].items():
-
-                    print(f"{tagname}|{test_name}|{description}")
+                    console.print(f"[{self.color}]{tagname}|{test_name}|{description}")
             return
 
         table = Table(title="Tests by Tags", header_style="blue", show_lines=True)
@@ -781,7 +780,7 @@ class BuildspecCache:
             # print terse output
 
             if not self.header:
-                print("|".join(self.table.keys()))
+                console.print("|".join(self.table.keys()), style=self.color)
 
             for row in t:
 
@@ -790,7 +789,8 @@ class BuildspecCache:
 
                 # if any entry contains None type we convert to empty string
                 row = ["" if item is None else item for item in row]
-                console.print("|".join(row))
+                join_string = "|".join(row)
+                console.print(f"[{self.color}]{join_string}")
 
             return
 

--- a/buildtest/cli/history.py
+++ b/buildtest/cli/history.py
@@ -102,20 +102,20 @@ def list_build_history(no_header=None, terse=None, pager=None, color=None):
 
     if terse:
 
-        join_list = []
+        row_entry = []
 
         for key in table.keys():
-            join_list.append(table[key])
+            row_entry.append(table[key])
 
-        t = [list(i) for i in zip(*join_list)]
+        transpose_list = [list(i) for i in zip(*row_entry)]
 
         # We print the table columns if --no-header is not specified
         if not no_header:
             console.print("|".join(table.keys()), style=consoleColor)
 
-        for i in t:
-            join_string = "|".join(i)
-            console.print(f"[{consoleColor}]{join_string}")
+        for row in transpose_list:
+            line = "|".join(row)
+            console.print(f"[{consoleColor}]{line}")
         return
 
     history_table = Table(

--- a/buildtest/cli/history.py
+++ b/buildtest/cli/history.py
@@ -102,38 +102,20 @@ def list_build_history(no_header=None, terse=None, pager=None, color=None):
 
     if terse:
 
+        join_list = []
+
+        for key in table.keys():
+            join_list.append(table[key])
+
+        t = [list(i) for i in zip(*join_list)]
+
         # We print the table columns if --no-header is not specified
         if not no_header:
-            console.print("|".join(table.keys()))
+            console.print("|".join(table.keys()), style=consoleColor)
 
-        for (
-            build_id,
-            hostname,
-            user,
-            system,
-            date,
-            pass_test,
-            fail_tests,
-            total_tests,
-            pass_rate,
-            fail_rate,
-            command,
-        ) in zip(
-            table["id"],
-            table["hostname"],
-            table["user"],
-            table["system"],
-            table["date"],
-            table["pass_tests"],
-            table["fail_tests"],
-            table["total_tests"],
-            table["pass_rate"],
-            table["fail_rate"],
-            table["command"],
-        ):
-            console.print(
-                f"{build_id}|{hostname}|{user}|{date}|{pass_test}|{fail_tests}|{total_tests}|{pass_rate}|{fail_rate}|{command}"
-            )
+        for i in t:
+            join_string = "|".join(i)
+            console.print(f"[{consoleColor}]{join_string}")
         return
 
     history_table = Table(

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -584,17 +584,18 @@ class Report:
                 join_list.append(self.display_table[key])
 
             t = [list(i) for i in zip(*join_list)]
-
+            
             # limited number of rows to be printed in terse mode
             if count:
                 t = t[:count]
 
             if not noheader:
-                print("|".join(self.display_table.keys()))
+                console.print("|".join(self.display_table.keys()), style=consoleColor)
 
             for i in t:
-                print("|".join(i))
-
+                join_string = "|".join(i)
+                console.print(f"[{consoleColor}]{join_string}")
+                    
             return
 
         join_list = []

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -584,7 +584,7 @@ class Report:
                 join_list.append(self.display_table[key])
 
             t = [list(i) for i in zip(*join_list)]
-            
+
             # limited number of rows to be printed in terse mode
             if count:
                 t = t[:count]
@@ -595,7 +595,7 @@ class Report:
             for i in t:
                 join_string = "|".join(i)
                 console.print(f"[{consoleColor}]{join_string}")
-                    
+
             return
 
         join_list = []

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -578,33 +578,33 @@ class Report:
         """
         consoleColor = checkColor(color)
         if terse:
-            join_list = []
+            row_entry = []
 
             for key in self.display_table.keys():
-                join_list.append(self.display_table[key])
+                row_entry.append(self.display_table[key])
 
-            t = [list(i) for i in zip(*join_list)]
+            transpose_list = [list(i) for i in zip(*row_entry)]
 
             # limited number of rows to be printed in terse mode
             if count:
-                t = t[:count]
+                transpose_list = transpose_list[:count]
 
             if not noheader:
                 console.print("|".join(self.display_table.keys()), style=consoleColor)
 
-            for i in t:
-                join_string = "|".join(i)
-                console.print(f"[{consoleColor}]{join_string}")
+            for row in transpose_list:
+                line = "|".join(row)
+                console.print(f"[{consoleColor}]{line}")
 
             return
 
-        join_list = []
+        row_entry = []
         title = title or f"Report File: {self.reportfile()}"
         table = Table(title=title, show_lines=True, expand=True)
         for field in self.display_table.keys():
             table.add_column(field, overflow="fold", style=consoleColor)
-            join_list.append(self.display_table[field])
-        transpose_list = [list(i) for i in zip(*join_list)]
+            row_entry.append(self.display_table[field])
+        transpose_list = [list(i) for i in zip(*row_entry)]
 
         # limited number of rows to be printed
         if count:

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -136,7 +136,12 @@ def test_func_buildspec_find():
 @pytest.mark.cli
 def test_buildspec_find_terse():
 
-    cache = BuildspecCache(configuration=configuration, terse=True, header=False)
+    cache = BuildspecCache(
+        configuration=configuration,
+        terse=True,
+        header=False,
+        color=Color.default().name,
+    )
     cache.print_buildspecs()
     cache.print_tags()
     cache.print_executors()

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -23,7 +23,9 @@ def test_build_history_list():
     list_build_history(terse=False, no_header=False, pager=True)
 
     # test with terse mode and with color: buildtest --color <Color> history list --terse
-    list_build_history(terse=True, no_header=False, pager=False, color=Color.default().name)
+    list_build_history(
+        terse=True, no_header=False, pager=False, color=Color.default().name
+    )
 
     # test with terse and no header: buildtest history list --terse --no-header
     list_build_history(terse=True, no_header=True, pager=False)

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -22,8 +22,8 @@ def test_build_history_list():
     # test with pager support: buildtest history list --pager
     list_build_history(terse=False, no_header=False, pager=True)
 
-    # test with terse mode: buildtest history list --terse
-    list_build_history(terse=True, no_header=False, pager=False)
+    # test with terse mode and with color: buildtest --color <Color> history list --terse
+    list_build_history(terse=True, no_header=False, pager=False, color=Color.default().name)
 
     # test with terse and no header: buildtest history list --terse --no-header
     list_build_history(terse=True, no_header=True, pager=False)

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -7,6 +7,7 @@ import pytest
 from buildtest.cli.report import Report, report_cmd, report_summary
 from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORTS, BUILDTEST_ROOT
 from buildtest.exceptions import BuildTestError
+from rich.color import Color
 
 
 @pytest.mark.cli
@@ -19,8 +20,8 @@ def test_report():
 
     result.print_report()
 
-    # run 'buildtest report --format name,state,returncode,buildspec --terse'
-    result.print_report(terse=True)
+    # run 'buildtest --color <Color> report --format name,state,returncode,buildspec --terse'
+    result.print_report(terse=True, color=Color.default().name)
 
     result.print_report(row_count=True)
 


### PR DESCRIPTION
Added color for terse option of  **buildtest buildspec maintainers --list** **buildtest buildspec maintainers --breakdown** along with **buildtest rt --terse** , **buildtest buildspec find --terse**, **buildtest history list --terse** 

![image](https://user-images.githubusercontent.com/35829130/199876898-4d2a7925-a83c-409d-a50c-989f306bdf6c.png)

![image](https://user-images.githubusercontent.com/35829130/199877036-38cb670c-daf8-43cf-988d-248d7b2b969e.png)

![image](https://user-images.githubusercontent.com/35829130/199877163-243095a8-daf8-49ca-b299-702b169cb638.png)

![image](https://user-images.githubusercontent.com/35829130/199877271-fafca453-36a9-4254-b78b-39df24d7a067.png)

![image](https://user-images.githubusercontent.com/35829130/199877364-13eae747-fca8-412e-8433-8cac77efa9ae.png)

![image](https://user-images.githubusercontent.com/35829130/199877499-5833325f-bfaa-49b8-b6e5-1fcf391a9fea.png)