### PR TITLE
Add option "buildtest tutorial-examples" to auto-generate documentation examples for Buildtest Tutorial

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -440,7 +440,7 @@ _buildtest ()
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )
       ;;
     *)
-      local cmds="build buildspec cd cdash clean config debugreport docs help info inspect history path report schema schemadocs stats stylecheck unittests"
+      local cmds="build buildspec cd cdash clean config debugreport docs help info inspect history path report schema schemadocs stats stylecheck tutorial-examples unittests"
       local alias_cmds="bd bc cg debug it h hy rt style test"
       local opts="--color --config --debug --editor --help --helpcolor --logpath --print-log --no-color --report --version --view-log -c -d -h -r -V"
 

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -428,8 +428,13 @@ _buildtest ()
 
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       ;;
+    tutorial-examples)
+      local opts=""
+
+      COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
+      ;;
     help|h)
-      local subcommands="build buildspec cdash config history inspect path report schema stylecheck unittests"
+      local subcommands="build buildspec cdash config history inspect path report schema stylecheck tutorial-examples unittests"
       local alias_cmds="bd bc cg hy it rt style test"
       local cmds="$subcommands $alias_cmds"
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -429,12 +429,12 @@ _buildtest ()
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       ;;
     tutorial-examples)
-      local opts=""
+      local opts="-h --help"
 
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       ;;
     help|h)
-      local subcommands="build buildspec cdash config history inspect path report schema stylecheck tutorial-examples unittests"
+      local subcommands="build buildspec cdash config history inspect path report schema stylecheck unittests"
       local alias_cmds="bd bc cg hy it rt style test"
       local cmds="$subcommands $alias_cmds"
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -296,7 +296,6 @@ def misc_menu(subparsers):
             "style",
             "stylecheck",
             "test",
-            "tutorial-examples",
             "unittests",
         ],
         help="Show help message for command",

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -231,6 +231,7 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
     unittest_menu(subparsers)
     stylecheck_menu(subparsers)
     misc_menu(subparsers)
+    tutorial_examples_menu(subparsers)
 
     return parser
 
@@ -295,6 +296,7 @@ def misc_menu(subparsers):
             "style",
             "stylecheck",
             "test",
+            "tutorial-examples",
             "unittests",
         ],
         help="Show help message for command",
@@ -343,6 +345,15 @@ def unittest_menu(subparsers):
         type=str,
         help="Specify path to file or directory when running regression test",
         action="append",
+    )
+
+
+def tutorial_examples_menu(subparsers):
+    """This method builds the command line menu for ``buildtest tutorial-examples`` command"""
+
+    subparsers.add_parser(
+        "tutorial-examples",
+        help="Generate documentation examples for Buildtest Tutorial",
     )
 
 

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -492,20 +492,6 @@ def print_unittests_help():
     console.print(table)
 
 
-def print_tutorialexamples_help():
-    """This method will print help message for command ``buildtest help tutorial-examples``"""
-
-    table = Table(title="Generate tuotial examples", show_lines=False)
-    table.add_column("Command", justify="left", style="cyan")
-    table.add_column("Description", justify="left", style="magenta")
-
-    table.add_row(
-        "buildtest tutorial-examples",
-        "Generate documentation examples for Buildtest Tutorial",
-    )
-    console.print(table)
-
-
 def print_path_help():
     """This method will print help message for command ``buildtest help schema``"""
 
@@ -568,5 +554,3 @@ def buildtest_help(command):
         print_stylecheck_help()
     elif command in ["unittests", "test"]:
         print_unittests_help()
-    elif command == "tutorial-examples":
-        print_tutorialexamples_help()

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -463,7 +463,7 @@ def print_stylecheck_help():
 
 
 def print_unittests_help():
-    """This method will print help message for command ``buildtest help stylecheck``"""
+    """This method will print help message for command ``buildtest help unittests``"""
 
     table = Table(title="Buildtest unittests", show_lines=False)
     table.add_column("Command", justify="left", style="cyan")
@@ -489,6 +489,20 @@ def print_unittests_help():
         "Specify a list of files to run unittests instead of running all tests",
     )
 
+    console.print(table)
+
+
+def print_tutorialexamples_help():
+    """This method will print help message for command ``buildtest help tutorial-examples``"""
+
+    table = Table(title="Generate tuotial examples", show_lines=False)
+    table.add_column("Command", justify="left", style="cyan")
+    table.add_column("Description", justify="left", style="magenta")
+
+    table.add_row(
+        "buildtest tutorial-examples",
+        "Generate documentation examples for Buildtest Tutorial",
+    )
     console.print(table)
 
 
@@ -554,3 +568,5 @@ def buildtest_help(command):
         print_stylecheck_help()
     elif command in ["unittests", "test"]:
         print_unittests_help()
+    elif command == "tutorial-examples":
+        print_tutorialexamples_help()

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -47,6 +47,7 @@ from buildtest.log import init_logfile
 from buildtest.system import BuildTestSystem
 from buildtest.tools.editor import set_editor
 from buildtest.tools.stylecheck import run_style_checks
+from buildtest.tools.tutorialexamples import generate_tutorial_examples
 from buildtest.tools.unittests import run_unit_tests
 from buildtest.utils.file import (
     create_dir,
@@ -320,6 +321,9 @@ def main():
             sourcefiles=args.sourcefiles,
             enable_coverage=args.coverage,
         )
+
+    elif args.subcommands == "tutorial-examples":
+        generate_tutorial_examples()
 
     elif args.subcommands in ["stylecheck", "style"]:
         run_style_checks(

--- a/buildtest/tools/tutorialexamples.py
+++ b/buildtest/tools/tutorialexamples.py
@@ -1,0 +1,46 @@
+import getpass
+import os
+import shutil
+import sys
+
+from buildtest.cli.clean import clean
+from buildtest.config import SiteConfiguration
+from buildtest.defaults import BUILDTEST_ROOT, TUTORIALS_SETTINGS_FILE
+from buildtest.tools.docs import build_compiler_examples, build_spack_examples
+from buildtest.utils.file import create_dir, is_dir, is_file
+
+
+def generate_tutorial_examples():
+    """This method is the entry point for "buildtest tutorial-examples" command which generates
+    documentation examples for Buildtest Tutorial.
+    """
+
+    if getpass.getuser() != "spack" or os.getenv("HOME") != "/home/spack":
+        sys.exit(
+            "This script can only be run inside container: ghcr.io/buildtesters/buildtest_spack:latest"
+        )
+
+    autogen_examples_dir = os.path.join(
+        BUILDTEST_ROOT, "docs", "buildtest_tutorial_examples"
+    )
+
+    config = SiteConfiguration(settings_file=TUTORIALS_SETTINGS_FILE)
+    config.detect_system()
+    config.validate(validate_executors=True)
+
+    if is_file(autogen_examples_dir):
+        os.remove(autogen_examples_dir)
+
+    if is_dir(autogen_examples_dir):
+        shutil.rmtree(autogen_examples_dir)
+
+    create_dir(autogen_examples_dir)
+
+    clean(config, yes=True)
+    build_spack_examples(autogen_examples_dir)
+    build_compiler_examples(autogen_examples_dir)
+
+
+if __name__ == "__main__":
+
+    generate_tutorial_examples()

--- a/docs/contributing/build_documentation.rst
+++ b/docs/contributing/build_documentation.rst
@@ -104,7 +104,7 @@ following commands.
 You will need to volume mount **$BUILDTEST_ROOT** into `/home/spack/buildtest` in-order to get buildtest code-base accessible inside
 the container.
 
-Once your setup is complete, you can auto-generate documentation examples by running the folllowing ::
+Once your setup is complete, you can auto-generate documentation examples by running the following ::
 
         buildtest tutorial-examples
 

--- a/docs/contributing/build_documentation.rst
+++ b/docs/contributing/build_documentation.rst
@@ -88,7 +88,7 @@ Generating Documentation Examples for Buildtest Tutorial
 The documentation examples for the buildtest tutorial are run inside the container image
 ghcr.io/buildtesters/buildtest_spack:latest which means that some of the example output needs to be generated manually. There
 is a script `doc-examples.py <https://github.com/buildtesters/buildtest/blob/devel/scripts/spack_container/doc-examples.py>`_ that
-is responsible for auto-generating the documentation examples inside the container. To get started you will need to run the
+is responsible for auto-generating the documentation examples inside the container. To get the container running along with the buildtest codebase you will need to run the
 following commands.
 
 .. Note::
@@ -101,14 +101,16 @@ following commands.
     cd /home/spack/buildtest
     source scripts/spack_container/setup.sh
 
-You will need to volume mount **$BUILDTEST_ROOT** into `/home/spack/buildtest` in-order to get  buildtest code-base accessible inside
+You will need to volume mount **$BUILDTEST_ROOT** into `/home/spack/buildtest` in-order to get buildtest code-base accessible inside
 the container.
 
-Once you setup is complete, please run the python script and it will auto-generate the documentation examples::
+Once you setup is complete, the python script that will auto-generate the documentation examples can be invoked by using the folllowing buildtest command ::
+
+        buildtest tutorial-examples
+
+Alternatively, the script can also be invoked via python as shown below :: 
 
         python scripts/spack_container/doc-examples.py
 
 Please verify all the auto-generated examples that will be used in the documentation. Once you are content with all the changes please add all
 the changes via ``git add``.
-The script `doc-examples.py <https://github.com/buildtesters/buildtest/blob/devel/scripts/spack_container/doc-examples.py>`_ can also be invoked via the 
-command **buildtest tutorial-examples**.

--- a/docs/contributing/build_documentation.rst
+++ b/docs/contributing/build_documentation.rst
@@ -110,4 +110,9 @@ Once you setup is complete, please run the python script and it will auto-genera
 
 Please verify all the auto-generated examples that will be used in the documentation. Once you are content with all the changes please add all
 the changes via ``git add``.
+The script `doc-examples.py <https://github.com/buildtesters/buildtest/blob/devel/scripts/spack_container/doc-examples.py>`_ can also be invoked via the 
+command **buildtest tutorial-examples**.
+.. dropdown:: ``buildtest tutorial-examples``
+
+    .. command-output:: buildtest tutorial-examples
 

--- a/docs/contributing/build_documentation.rst
+++ b/docs/contributing/build_documentation.rst
@@ -112,7 +112,3 @@ Please verify all the auto-generated examples that will be used in the documenta
 the changes via ``git add``.
 The script `doc-examples.py <https://github.com/buildtesters/buildtest/blob/devel/scripts/spack_container/doc-examples.py>`_ can also be invoked via the 
 command **buildtest tutorial-examples**.
-.. dropdown:: ``buildtest tutorial-examples``
-
-    .. command-output:: buildtest tutorial-examples
-

--- a/docs/contributing/build_documentation.rst
+++ b/docs/contributing/build_documentation.rst
@@ -104,7 +104,7 @@ following commands.
 You will need to volume mount **$BUILDTEST_ROOT** into `/home/spack/buildtest` in-order to get buildtest code-base accessible inside
 the container.
 
-Once you setup is complete, the python script that will auto-generate the documentation examples can be invoked by using the folllowing buildtest command ::
+Once your setup is complete, you can auto-generate documentation examples by running the folllowing ::
 
         buildtest tutorial-examples
 

--- a/tests/tools/test_tutorialexamples.py
+++ b/tests/tools/test_tutorialexamples.py
@@ -1,0 +1,7 @@
+import pytest
+from buildtest.tools.tutorialexamples import generate_tutorial_examples
+
+
+def test_buildtest_tutorial_examples():
+    with pytest.raises(SystemExit):
+        generate_tutorial_examples()


### PR DESCRIPTION
buildtest tutorial-examples

<img width="633" alt="Screen Shot 2022-12-04 at 4 08 41 PM" src="https://user-images.githubusercontent.com/35829130/205521268-5f50938f-893a-42ad-842b-4180860193f6.png">

Hi @shahzebsiddiqui  I still need to add tab completion for "buildtest tutorial-examples". I might need help with that.
