### PR TITLE
add support for assert greater equal. Update metrics property

### DIFF
--- a/buildtest/builders/base.py
+++ b/buildtest/builders/base.py
@@ -1052,7 +1052,6 @@ class BuilderBase(ABC):
         # iterate over each metric in buildspec and determine reference check for each metric
         for metric in self.status["assert_ge"]:
             name = metric["name"]
-            ref_value = metric["ref"]
 
             # if metric is not valid, then mark as False
             if name not in metric_names:
@@ -1062,6 +1061,10 @@ class BuilderBase(ABC):
                 assert_check.append(False)
                 continue
 
+            metric_value = self.metadata["metrics"][name]
+            ref_value = metric["ref"]
+            conv_value = None
+
             # if metrics is empty string mark as False since we can't convert item to int or float
             if self.metadata["metrics"][name] == "":
                 assert_check.append(False)
@@ -1070,18 +1073,22 @@ class BuilderBase(ABC):
             # convert metric value and reference value to int
             if self.metrics[name]["type"] == "int":
                 try:
-                    conv_value = int(self.metadata["metrics"][name])
+                    conv_value = int(metric_value)
                 except ValueError:
                     console.print_exception(show_locals=True)
                     assert_check.append(False)
+                    continue
+
                 ref_value = int(ref_value)
+
             # convert metric value and reference value to float
             elif self.metrics[metric["name"]]["type"] == "float":
                 try:
-                    conv_value = float(self.metadata["metrics"][name])
+                    conv_value = float(metric_value)
                 except ValueError:
                     console.print_exception(show_locals=True)
                     assert_check.append(False)
+                    continue
 
                 ref_value = float(ref_value)
             elif self.metrics[name]["type"] == "str":
@@ -1089,6 +1096,7 @@ class BuilderBase(ABC):
                 console.print(msg)
                 self.logger.warning(msg)
                 assert_check.append(False)
+                continue
 
             console.print(
                 f"[blue]{self}[/]: testing metric: {name} if {conv_value} >= {ref_value}"

--- a/buildtest/schemas/definitions.schema.json
+++ b/buildtest/schemas/definitions.schema.json
@@ -60,6 +60,10 @@
         "exp": {
           "type": "string",
           "description": "Specify a regular expression to run with input stream specified by ``stream`` field. buildtest uses re.search when performing regex"
+        },
+        "item": {
+          "type": "integer",
+          "description": "Specify the item number used to index element in `match.group() <https://docs.python.org/3/library/re.html#match-objects>`_"
         }
       }
     },
@@ -123,6 +127,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "type": {
+          "type": "string",
+          "description": "Specify python data-type (str, int, float) to convert metric. ",
+          "enum": ["str", "int", "float"]
+        },
         "regex": {
           "$ref": "#/definitions/regex"
         }
@@ -202,6 +211,26 @@
               "type": "number",
               "minimum": 0,
               "description": "Specify a maximum runtime in seconds. The test will PASS if actual runtime is less than max time"
+            }
+          }
+        },
+        "assert_ge": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "ref"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of metric to use for comparison"
+              },
+              "ref": {
+                "type": "number"
+              }
             }
           }
         },

--- a/buildtest/schemas/definitions.schema.json
+++ b/buildtest/schemas/definitions.schema.json
@@ -63,6 +63,7 @@
         },
         "item": {
           "type": "integer",
+          "minimum": 0,
           "description": "Specify the item number used to index element in `match.group() <https://docs.python.org/3/library/re.html#match-objects>`_"
         }
       }
@@ -216,6 +217,7 @@
         },
         "assert_ge": {
           "type": "array",
+          "description": "Perform assertion of greater and equal (>=) with reference value",
           "items": {
             "type": "object",
             "additionalProperties": false,
@@ -229,7 +231,8 @@
                 "description": "Name of metric to use for comparison"
               },
               "ref": {
-                "type": "number"
+                "type": "number",
+                "description": "Specify reference value (int,float) for comparison"
               }
             }
           }

--- a/docs/buildspecs/buildspec_overview.rst
+++ b/docs/buildspecs/buildspec_overview.rst
@@ -342,21 +342,27 @@ Performance Checks
 ~~~~~~~~~~~~~~~~~~~~
 
 buildtest can determine status check based on performance check. In this next example, we will run the
-`STREAM <https://www.cs.virginia.edu/stream/>` memory benchmark and capture metrics named `copy`, `scale`
-`add` and `triad` from the output and perform an Assertion Greater Equal (``assert_ge``) with a reference value.
+`STREAM <https://www.cs.virginia.edu/stream/>`_ memory benchmark and capture :ref:`metrics <metrics>` named ``copy``, ``scale``
+``add`` and ``triad`` from the output and perform an Assertion Greater Equal (``assert_ge``) with a reference value.
+
+The ``assert_ge`` contains a list of assertions where each metric name is
+referenced via ``name`` that is compared with the reference value defined by ``ref`` property. The comparison
+is ``metric_value >= ref``, where **metric_value** is the value assigned to the metric name captured by the regular
+expression. The ``type`` field in the metric section is used for the type conversion which can be **float**, **int**, or **string**.
+The ``item`` is a numeric field used in `match.group <https://docs.python.org/3/library/re.html#re.Match.group>`_ to retrieve the output
+from the regular expression search. The item must be non-negative number.
 
 .. literalinclude:: ../tutorials/stream.yml
     :language: yaml
     :emphasize-lines: 12-46
+    :linenos:
 
 
-In this test, we define :ref:`metrics <metrics>` that will capture key performance metrics from the STREAM test and
-define them in the metric name. The ``assert_ge`` is comprised of list of assertions where each metric name referenced via ``name`` is compared (**>=**)
-with reference value `ref`.
+buildtest will evaluate each assertion in the list and use a logical AND to determine the final
+status of ``assert_ge``.
 
-buildtest will evaluate each operation as a logical AND when determining status for ``assert_ge``.
-
-Let's build this test
+Let's build this test and run ``buildtest inspect query -o stream_test``. Take a close look at the output
+of ``buildtest build`` and output of test.
 
 .. dropdown:: ``buildtest build -b tutorials/stream.yml``
 

--- a/docs/buildspecs/buildspec_overview.rst
+++ b/docs/buildspecs/buildspec_overview.rst
@@ -361,12 +361,17 @@ from the regular expression search. The item must be non-negative number.
 buildtest will evaluate each assertion in the list and use a logical AND to determine the final
 status of ``assert_ge``.
 
-Let's build this test and run ``buildtest inspect query -o stream_test``. Take a close look at the output
-of ``buildtest build`` and output of test.
+Let's build this test, take a close look at the output of ``buildtest build`` and take note of the assertion
+statement.
+
 
 .. dropdown:: ``buildtest build -b tutorials/stream.yml``
 
     .. command-output:: buildtest build -b tutorials/stream.yml
+
+Let's run ``buildtest inspect query -o stream_test`` to retrieve the test details and output of STREAM test.
+
+.. dropdown:: ``buildtest inspect query -o stream_test``
 
     .. command-output:: buildtest inspect query -o stream_test
 

--- a/docs/buildspecs/buildspec_overview.rst
+++ b/docs/buildspecs/buildspec_overview.rst
@@ -338,6 +338,32 @@ If we build this test, we expect buildtest to honor the value of ``state`` prope
 
    .. command-output:: buildtest build -b tutorials/test_status/explicit_state.yml
 
+Performance Checks
+~~~~~~~~~~~~~~~~~~~~
+
+buildtest can determine status check based on performance check. In this next example, we will run the
+`STREAM <https://www.cs.virginia.edu/stream/>` memory benchmark and capture metrics named `copy`, `scale`
+`add` and `triad` from the output and perform an Assertion Greater Equal (``assert_ge``) with a reference value.
+
+.. literalinclude:: ../tutorials/stream.yml
+    :language: yaml
+    :emphasize-lines: 12-46
+
+
+In this test, we define :ref:`metrics <metrics>` that will capture key performance metrics from the STREAM test and
+define them in the metric name. The ``assert_ge`` is comprised of list of assertions where each metric name referenced via ``name`` is compared (**>=**)
+with reference value `ref`.
+
+buildtest will evaluate each operation as a logical AND when determining status for ``assert_ge``.
+
+Let's build this test
+
+.. dropdown:: ``buildtest build -b tutorials/stream.yml``
+
+    .. command-output:: buildtest build -b tutorials/stream.yml
+
+    .. command-output:: buildtest inspect query -o stream_test
+
 .. _define_tags:
 
 Defining Tags

--- a/tests/builders/assert_ge.yml
+++ b/tests/builders/assert_ge.yml
@@ -1,0 +1,60 @@
+buildspecs:
+  stream_test:
+    type: script
+    executor: generic.local.bash
+    description: Run stream test with metrics example using assert greater equal
+    env:
+      OMP_NUM_THREADS: 4
+    run: |
+      wget https://raw.githubusercontent.com/jeffhammond/STREAM/master/stream.c
+      gcc -openmp -o stream stream.c
+      ./stream
+    metrics:
+      copy:
+        type: float
+        regex:
+          exp: 'Copy:\s+(\S+)\s+.*'
+          stream: stdout
+          item: 1
+      scale:
+        type: float
+        regex:
+          exp: 'Scale:\s+(\S+)\s+.*'
+          stream: stdout
+          item: 1
+      add:
+        type: float
+        regex:
+          exp: 'Add:\s+(\S+)\s+.*'
+          stream: stdout
+          item: 1
+      triad:
+        type: float
+        regex:
+          exp: 'Triad:\s+(\S+)\s+.*'
+          stream: stdout
+          item: 1
+      int_metric:
+        type: int
+        regex:
+          exp: 'Triad:\s+(\S+)\s+.*'
+          stream: stdout
+          item: 1
+      string_metric:
+        type: str
+        regex:
+          exp: 'Triad:\s+(\S+)\s+.*'
+          stream: stdout
+          item: 1
+    status:
+      assert_ge:
+        - name: copy
+          ref: 5000
+        - name: scale
+          ref: 5500
+        - name: add
+          ref: 6000
+        - name: triad
+          ref: 6500
+        - name: invalid_metric
+          ref: 128

--- a/tests/builders/test_builders.py
+++ b/tests/builders/test_builders.py
@@ -1,0 +1,37 @@
+import os
+
+import pytest
+from buildtest.buildsystem.builders import Builder
+from buildtest.buildsystem.parser import BuildspecParser
+from buildtest.cli.compilers import BuildtestCompilers
+from buildtest.config import SiteConfiguration
+from buildtest.defaults import DEFAULT_SETTINGS_FILE
+from buildtest.executors.setup import BuildExecutor
+from buildtest.system import BuildTestSystem
+
+here = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_assert_ge(tmp_path):
+    config = SiteConfiguration(DEFAULT_SETTINGS_FILE)
+    config.detect_system()
+    config.validate()
+    executors = BuildExecutor(config)
+    system = BuildTestSystem()
+
+    bp = BuildspecParser(
+        buildspec=os.path.join(here, "assert_ge.yml"), buildexecutor=executors
+    )
+    bc = BuildtestCompilers(configuration=config)
+    builder = Builder(
+        bp=bp,
+        buildtest_compilers=bc,
+        buildexecutor=executors,
+        configuration=config,
+        filters=[],
+        testdir=tmp_path,
+        buildtest_system=system,
+    )
+    builders = builder.get_builders()
+    for test in builders:
+        test.build()

--- a/tutorials/stream.yml
+++ b/tutorials/stream.yml
@@ -22,9 +22,25 @@ buildspecs:
           exp: 'Scale:\s+(\S+)\s+.*'
           stream: stdout
           item: 1
+      add:
+        type: float
+        regex:
+          exp: 'Add:\s+(\S+)\s+.*'
+          stream: stdout
+          item: 1
+      triad:
+        type: float
+        regex:
+          exp: 'Triad:\s+(\S+)\s+.*'
+          stream: stdout
+          item: 1
     status:
       assert_ge:
         - name: copy
           ref: 5000
         - name: scale
-          ref: 5000
+          ref: 5500
+        - name: add
+          ref: 6000
+        - name: triad
+          ref: 6500

--- a/tutorials/stream.yml
+++ b/tutorials/stream.yml
@@ -1,0 +1,30 @@
+buildspecs:
+  stream_test:
+    type: script
+    executor: generic.local.bash
+    description: Run stream test with metrics example using assert greater equal
+    env:
+      OMP_NUM_THREADS: 4
+    run: |
+      wget https://raw.githubusercontent.com/jeffhammond/STREAM/master/stream.c
+      gcc -openmp -o stream stream.c
+      ./stream
+    metrics:
+      copy:
+        type: float
+        regex:
+          exp: 'Copy:\s+(\S+)\s+.*'
+          stream: stdout
+          item: 1
+      scale:
+        type: float
+        regex:
+          exp: 'Scale:\s+(\S+)\s+.*'
+          stream: stdout
+          item: 1
+    status:
+      assert_ge:
+        - name: copy
+          ref: 5000
+        - name: scale
+          ref: 5000


### PR DESCRIPTION
Here is the stream benchmark take note of the output lines

**stream_test/7305fc15: testing metric: copy if 7981.3 >= 5000.0**
**stream_test/7305fc15: testing metric: scale if 9484.8 >= 5000.0**


```
(buildtest)  ~/Documents/github/buildtest/ [perf_status] buildtest bd -b tutorials/stream.yml
╭─────────────────────────────────────────── buildtest summary ───────────────────────────────────────────╮                                                                                                                                
│                                                                                                         │                                                                                                                                
│ User:               siddiq90                                                                            │                                                                                                                                
│ Hostname:           DOE-7086392.vpn-dhcp.lbl.gov                                                        │                                                                                                                                
│ Platform:           Darwin                                                                              │                                                                                                                                
│ Current Time:       2022/12/16 12:41:03                                                                 │                                                                                                                                
│ buildtest path:     /Users/siddiq90/Documents/github/buildtest/bin/buildtest                            │                                                                                                                                
│ buildtest version:  1.0                                                                                 │                                                                                                                                
│ python path:        /Users/siddiq90/.local/share/virtualenvs/buildtest-Ir4AdrfC/bin/python3             │                                                                                                                                
│ python version:     3.7.3                                                                               │                                                                                                                                
│ Configuration File: /Users/siddiq90/Documents/github/buildtest/buildtest/settings/config.yml            │                                                                                                                                
│ Test Directory:     /Users/siddiq90/Documents/github/buildtest/var/tests                                │                                                                                                                                
│ Report File:        /Users/siddiq90/Documents/github/buildtest/var/report.json                          │                                                                                                                                
│ Command:            /Users/siddiq90/Documents/github/buildtest/bin/buildtest bd -b tutorials/stream.yml │                                                                                                                                
│                                                                                                         │                                                                                                                                
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────╯                                                                                                                                
─────────────────────────────────────────────────────────────────────────────────────────────────────────  Discovering Buildspecs ─────────────────────────────────────────────────────────────────────────────────────────────────────────
                       Discovered buildspecs                       
╔═════════════════════════════════════════════════════════════════╗
║ buildspec                                                       ║
╟─────────────────────────────────────────────────────────────────╢
║ /Users/siddiq90/Documents/github/buildtest/tutorials/stream.yml ║
╚═════════════════════════════════════════════════════════════════╝


Total Discovered Buildspecs:  1
Total Excluded Buildspecs:  0
Detected Buildspecs after exclusion:  1
─────────────────────────────────────────────────────────────────────────────────────────────────────────── Parsing Buildspecs ────────────────────────────────────────────────────────────────────────────────────────────────────────────
Valid Buildspecs: 1
Invalid Buildspecs: 0
/Users/siddiq90/Documents/github/buildtest/tutorials/stream.yml: VALID
Total builder objects created: 1
                                                                                               Builders by type=script                                                                                               
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ builder              ┃ type   ┃ executor           ┃ compiler ┃ nodes ┃ procs ┃ description                                                     ┃ buildspecs                                                      ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ stream_test/7305fc15 │ script │ generic.local.bash │ None     │ None  │ None  │ Run stream test with metrics example using assert greater equal │ /Users/siddiq90/Documents/github/buildtest/tutorials/stream.yml │
└──────────────────────┴────────┴────────────────────┴──────────┴───────┴───────┴─────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────┘
────────────────────────────────────────────────────────────────────────────────────────────────────────────── Building Test ──────────────────────────────────────────────────────────────────────────────────────────────────────────────
stream_test/7305fc15: Creating test directory: /Users/siddiq90/Documents/github/buildtest/var/tests/generic.local.bash/stream/stream_test/7305fc15
stream_test/7305fc15: Creating the stage directory: /Users/siddiq90/Documents/github/buildtest/var/tests/generic.local.bash/stream/stream_test/7305fc15/stage
stream_test/7305fc15: Writing build script: /Users/siddiq90/Documents/github/buildtest/var/tests/generic.local.bash/stream/stream_test/7305fc15/stream_test_build.sh
────────────────────────────────────────────────────────────────────────────────────────────────────────────── Running Tests ──────────────────────────────────────────────────────────────────────────────────────────────────────────────
Spawning 1 processes for processing builders
─────────────────────────────────────────────────────────────────────────────────────────────────────────────── Iteration 1 ───────────────────────────────────────────────────────────────────────────────────────────────────────────────
stream_test/7305fc15 does not have any dependencies adding test to queue
In this iteration we are going to run the following tests: [stream_test/7305fc15]
stream_test/7305fc15: Running Test via command: bash --norc --noprofile -eo pipefail stream_test_build.sh
stream_test/7305fc15: Test completed in 2.67788 seconds
stream_test/7305fc15: Test completed with returncode: 0
stream_test/7305fc15: Writing output file -  /Users/siddiq90/Documents/github/buildtest/var/tests/generic.local.bash/stream/stream_test/7305fc15/stream_test.out
stream_test/7305fc15: Writing error file - /Users/siddiq90/Documents/github/buildtest/var/tests/generic.local.bash/stream/stream_test/7305fc15/stream_test.err
stream_test/7305fc15: testing metric: copy if 7981.3 >= 5000.0
stream_test/7305fc15: testing metric: scale if 9484.8 >= 5000.0
                                                   Test Summary                                                    
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━┓
┃ builder              ┃ executor           ┃ status ┃ checks (ReturnCode, Regex, Runtime) ┃ returncode ┃ runtime ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━┩
│ stream_test/7305fc15 │ generic.local.bash │ PASS   │ False False False                   │ 0          │ 2.67788 │
└──────────────────────┴────────────────────┴────────┴─────────────────────────────────────┴────────────┴─────────┘



Passed Tests: 1/1 Percentage: 100.000%
Failed Tests: 0/1 Percentage: 0.000%


Adding 1 test results to /Users/siddiq90/Documents/github/buildtest/var/report.json
Writing Logfile to: /Users/siddiq90/Documents/github/buildtest/var/logs/buildtest_jfnd4nfo.log

```

The metrics are captured based on regular expession and they are converted to `int`, `float`, or `str`. In this example we are capturing the 1st item from the list

```
(buildtest)  ~/Documents/github/buildtest/ [perf_status] buildtest inspect query -o stream_test 
──────────────────────────────────────────────────────────────────────────────────────────── stream_test/7305fc15-dceb-4c4e-b094-fadf4ed6a7b9 ─────────────────────────────────────────────────────────────────────────────────────────────
Executor: generic.local.bash
Description: Run stream test with metrics example using assert greater equal
State: PASS
Returncode: 0
Runtime: 2.67788 sec
Starttime: 2022/12/16 12:41:03
Endtime: 2022/12/16 12:41:06
Command: bash --norc --noprofile -eo pipefail stream_test_build.sh
Test Script: /Users/siddiq90/Documents/github/buildtest/var/tests/generic.local.bash/stream/stream_test/7305fc15/stream_test.sh
Build Script: /Users/siddiq90/Documents/github/buildtest/var/tests/generic.local.bash/stream/stream_test/7305fc15/stream_test_build.sh
Output File: /Users/siddiq90/Documents/github/buildtest/var/tests/generic.local.bash/stream/stream_test/7305fc15/stream_test.out
Error File: /Users/siddiq90/Documents/github/buildtest/var/tests/generic.local.bash/stream/stream_test/7305fc15/stream_test.err
Log File: /Users/siddiq90/Documents/github/buildtest/var/logs/buildtest_jfnd4nfo.log
     Metrics      
┏━━━━━━━┳━━━━━━━━┓
┃ Name  ┃ Value  ┃
┡━━━━━━━╇━━━━━━━━┩
│ copy  │ 7981.3 │
│ scale │ 9484.8 │
└───────┴────────┘
──────────────────────────────────────────────────── Output File: /Users/siddiq90/Documents/github/buildtest/var/tests/generic.local.bash/stream/stream_test/7305fc15/stream_test.out ─────────────────────────────────────────────────────
-------------------------------------------------------------                                                                                                                                                                              
STREAM version $Revision: 5.10 $                                                                                                                                                                                                           
-------------------------------------------------------------                                                                                                                                                                              
This system uses 8 bytes per array element.                                                                                                                                                                                                
-------------------------------------------------------------                                                                                                                                                                              
Array size = 10000000 (elements), Offset = 0 (elements)                                                                                                                                                                                    
Memory per array = 76.3 MiB (= 0.1 GiB).                                                                                                                                                                                                   
Total memory required = 228.9 MiB (= 0.2 GiB).                                                                                                                                                                                             
Each kernel will be executed 10 times.                                                                                                                                                                                                     
 The *best* time for each kernel (excluding the first iteration)                                                                                                                                                                           
 will be used to compute the reported bandwidth.                                                                                                                                                                                           
-------------------------------------------------------------                                                                                                                                                                              
Your clock granularity/precision appears to be 1 microseconds.                                                                                                                                                                             
Each test below will take on the order of 25614 microseconds.                                                                                                                                                                              
   (= 25614 clock ticks)                                                                                                                                                                                                                   
Increase the size of the arrays if this shows that                                                                                                                                                                                         
you are not getting at least 20 clock ticks per test.                                                                                                                                                                                      
-------------------------------------------------------------                                                                                                                                                                              
WARNING -- The above is only a rough guideline.                                                                                                                                                                                            
For best results, please be sure you know the                                                                                                                                                                                              
precision of your system timer.                                                                                                                                                                                                            
-------------------------------------------------------------                                                                                                                                                                              
Function    Best Rate MB/s  Avg time     Min time     Max time                                                                                                                                                                             
Copy:            7981.3     0.020670     0.020047     0.022545                                                                                                                                                                             
Scale:           9484.8     0.018009     0.016869     0.021216                                                                                                                                                                             
Add:            10859.3     0.022774     0.022101     0.024963                                                                                                                                                                             
Triad:          11370.7     0.022250     0.021107     0.024320                                                                                                                                                                             
-------------------------------------------------------------                                                                                                                                                                              
Solution Validates: avg error less than 1.000000e-13 on all three arrays                                                                                                                                                                   
-------------------------------------------------------------                                                                                                                                                                              
                                                                                
```