### PR TITLE
fix bug with file check with slurm jobs

### DIFF
--- a/buildtest/builders/base.py
+++ b/buildtest/builders/base.py
@@ -244,10 +244,7 @@ class BuilderBase(ABC):
         # import issue when putting this at top of file
         from buildtest.executors.local import LocalExecutor
 
-        if isinstance(self.buildexecutor.executors[self.executor], LocalExecutor):
-            return True
-
-        return False
+        return isinstance(self.buildexecutor.executors[self.executor], LocalExecutor)
 
     def is_slurm_executor(self):
         """Return True if current builder executor type is LocalExecutor otherwise returns False.
@@ -258,22 +255,16 @@ class BuilderBase(ABC):
         """
 
         # import issue when putting this at top of file
-        from buildtest.executors.local import SlurmExecutor
+        from buildtest.executors.slurm import SlurmExecutor
 
-        if isinstance(self.buildexecutor.executors[self.executor], SlurmExecutor):
-            return True
-
-        return False
+        return isinstance(self.buildexecutor.executors[self.executor], SlurmExecutor)
 
     def is_batch_job(self):
         """Return True/False if builder.job attribute is of type Job instance if not returns False.
         This method indicates if builder has a job submitted to queue
         """
 
-        if isinstance(self.job, Job):
-            return True
-
-        return False
+        return isinstance(self.job, Job)
 
     def start(self):
         """Keep internal timer for test using class :class:`buildtest.utils.timer.Timer`. This method will start the timer for builder which is invoked upon running test."""

--- a/buildtest/builders/base.py
+++ b/buildtest/builders/base.py
@@ -897,10 +897,10 @@ class BuilderBase(ABC):
         such as output, error and test script. We will check state of test and mark job is complete.
         """
 
-        if self.is_slurm_executor():
-            print(f"{self} workdir: ", os.getcwd())
-            os.chdir(os.getenv("SLURM_SUBMIT_DIR"))
-            print(f"{self} Changing directory to ", os.getcwd())
+        # ensure we are back in stage directory before processing. For batch jobs like Slurm the
+        # current working directory is changed to the submit line which can cause issues for file checks
+        os.chdir(self.stage_dir)
+
         self._output = read_file(self.metadata["outfile"])
         self._error = read_file(self.metadata["errfile"])
 

--- a/buildtest/builders/base.py
+++ b/buildtest/builders/base.py
@@ -249,6 +249,22 @@ class BuilderBase(ABC):
 
         return False
 
+    def is_slurm_executor(self):
+        """Return True if current builder executor type is LocalExecutor otherwise returns False.
+
+        Returns:
+            bool: returns True if builder is using executor type LocalExecutor otherwise returns False
+
+        """
+
+        # import issue when putting this at top of file
+        from buildtest.executors.local import SlurmExecutor
+
+        if isinstance(self.buildexecutor.executors[self.executor], SlurmExecutor):
+            return True
+
+        return False
+
     def is_batch_job(self):
         """Return True/False if builder.job attribute is of type Job instance if not returns False.
         This method indicates if builder has a job submitted to queue
@@ -890,6 +906,10 @@ class BuilderBase(ABC):
         such as output, error and test script. We will check state of test and mark job is complete.
         """
 
+        if self.is_slurm_executor():
+            print(f"{self} workdir: ", os.getcwd())
+            os.chdir(os.getenv("SLURM_SUBMIT_DIR"))
+            print(f"{self} Changing directory to ", os.getcwd())
         self._output = read_file(self.metadata["outfile"])
         self._error = read_file(self.metadata["errfile"])
 

--- a/buildtest/builders/base.py
+++ b/buildtest/builders/base.py
@@ -301,6 +301,7 @@ class BuilderBase(ABC):
 
         self.metadata["command"] = cmd
 
+        console.print(f"[blue]{self}[/]: Current Working Directory : {os.getcwd()}")
         # capture output of 'env' and write to file 'build-env.sh' prior to running test
         command = BuildTestCommand("env")
         command.execute()

--- a/buildtest/buildsystem/checks.py
+++ b/buildtest/buildsystem/checks.py
@@ -1,3 +1,5 @@
+import os
+
 from buildtest.defaults import console
 from buildtest.utils.file import is_dir, is_file, resolve_path
 
@@ -12,6 +14,8 @@ def exists_check(builder, status):
     Returns:
         bool: A boolean for exists status check
     """
+    console.print(f"{self} working directory is {os.getcwd()}")
+
     assert_exists = all(resolve_path(file, exist=True) for file in status["exists"])
     console.print(
         f"[blue]{builder}[/]: Test all files:  {status['exists']}  existences "

--- a/buildtest/buildsystem/checks.py
+++ b/buildtest/buildsystem/checks.py
@@ -14,8 +14,6 @@ def exists_check(builder, status):
     Returns:
         bool: A boolean for exists status check
     """
-    console.print(f"{self} working directory is {os.getcwd()}")
-
     assert_exists = all(resolve_path(file, exist=True) for file in status["exists"])
     console.print(
         f"[blue]{builder}[/]: Test all files:  {status['exists']}  existences "

--- a/buildtest/buildsystem/checks.py
+++ b/buildtest/buildsystem/checks.py
@@ -17,7 +17,7 @@ def exists_check(builder, status):
         f"[blue]{builder}[/]: Test all files:  {status['exists']}  existences "
     )
     for fname in status["exists"]:
-        resolved_fname = resolve_path(fname, exist=True)
+        resolved_fname = resolve_path(fname)
         if resolved_fname:
             console.print(f"[blue]{builder}[/]: file: {resolved_fname} exists")
         else:
@@ -71,7 +71,7 @@ def is_dir_check(builder, status):
         f"[blue]{builder}[/]: Test all files:  {status['is_dir']}  existences "
     )
     for dirname in status["is_dir"]:
-        resolved_dirname = resolve_path(dirname, exist=True)
+        resolved_dirname = resolve_path(dirname)
         if is_dir(resolved_dirname):
             console.print(
                 f"[blue]{builder}[/]: file: {resolved_dirname} is a directory "

--- a/buildtest/buildsystem/checks.py
+++ b/buildtest/buildsystem/checks.py
@@ -1,5 +1,3 @@
-import os
-
 from buildtest.defaults import console
 from buildtest.utils.file import is_dir, is_file, resolve_path
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -13,13 +13,16 @@ from buildtest.defaults import DEFAULT_SETTINGS_SCHEMA, SCHEMA_ROOT
 from buildtest.executors.setup import BuildExecutor
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema
+from buildtest.system import BuildTestSystem
 from buildtest.utils.file import walk_tree
 
 pytest_root = os.path.dirname(os.path.dirname(__file__))
 
+system = BuildTestSystem()
+
 configuration = SiteConfiguration()
 configuration.detect_system()
-configuration.validate()
+configuration.validate(moduletool=system.system["moduletool"])
 
 
 @pytest.mark.cli
@@ -56,7 +59,7 @@ def test_valid_config_schemas():
 
 @pytest.mark.cli
 def test_config_validate():
-    validate_config(configuration)
+    validate_config(configuration=configuration, moduletool=system.system["moduletool"])
 
 
 @pytest.mark.cli

--- a/tests/examples/cori/exists.yml
+++ b/tests/examples/cori/exists.yml
@@ -1,0 +1,17 @@
+buildspecs:
+  status_exists_slurm:
+   type: script
+   executor: cori.slurm.knl_debug
+   description: status check based for file and directory
+   sbatch: ['-n 1', '-t 5', '-C knl']
+   run: |
+     mkdir -p a/b/c
+     touch foo
+   status:
+     exists:
+       - a/b/c
+       - foo
+     is_dir:
+       - a/b/c
+     is_file:
+       - foo

--- a/tests/test_cori.py
+++ b/tests/test_cori.py
@@ -94,6 +94,31 @@ def test_cori_slurm_max_pend():
         cmd.build()
 
 
+def test_cori_slurm_file_exists():
+
+    if not hostname.startswith("cori"):
+        pytest.skip("This test runs on Cori Login nodes ('cori*')")
+
+    bc = SiteConfiguration(settings_file)
+    bc.detect_system()
+    bc.validate(moduletool="environment-modules")
+
+    system = BuildTestSystem()
+
+    cmd = BuildTest(
+        configuration=bc,
+        buildspecs=[
+            os.path.join(
+                os.getenv("BUILDTEST_ROOT"), "tests", "examples", "cori", "exists.yml"
+            )
+        ],
+        buildtest_system=system,
+        poll_interval=5,
+        maxpendtime=120,
+    )
+    cmd.build()
+
+
 def test_compiler_find_cori():
 
     if not hostname.startswith("cori"):


### PR DESCRIPTION
Thanks to @wyphan we have found an issue where Slurm jobs will cause current working directory to be changed and it doesn't preserve the stage directory this causes issues where file checks are not done correctly since relative path is not stage directory.

An initial prototype of this was done to ensure test was working with file checks with slurm job

Here is an example buildspec

```yaml
(buildtest)  ~/gitrepos/buildtest/ [debug_file_checks] cat examples/pm.yml
buildspecs:
  status_exists_pm_slurm:
   type: script
   executor: perlmutter.slurm.debug
   description: status check based for file and directory
   sbatch: ['-n 1', '-t 5', '-C cpu']
   run: |
     mkdir -p cuda_vecadd/test
     env | grep SLURM_*
   status:
     exists:
       - cuda_vecadd
       - cuda_vecadd/test
```

I was able to build this successfully 
```
(buildtest)  ~/gitrepos/buildtest/examples/ [debug_file_checks*] buildtest bd -b pm.yml
╭──────────────────────────────────────── buildtest summary ────────────────────────────────────────╮
│                                                                                                   │
│ User:               siddiq90                                                                      │
│ Hostname:           login20                                                                       │
│ Platform:           Linux                                                                         │
│ Current Time:       2023/01/05 13:44:33                                                           │
│ buildtest path:     /global/homes/s/siddiq90/gitrepos/buildtest/bin/buildtest                     │
│ buildtest version:  1.0                                                                           │
│ python path:        /global/u1/s/siddiq90/.local/share/virtualenvs/buildtest-WqshQcL1/bin/python3 │
│ python version:     3.9.7                                                                         │
│ Configuration File: /global/u1/s/siddiq90/gitrepos/buildtest-nersc/config.yml                     │
│ Test Directory:     /global/u1/s/siddiq90/gitrepos/buildtest/var/tests                            │
│ Report File:        /global/u1/s/siddiq90/gitrepos/buildtest/var/report.json                      │
│ Command:            /global/homes/s/siddiq90/gitrepos/buildtest/bin/buildtest bd -b pm.yml        │
│                                                                                                   │
╰───────────────────────────────────────────────────────────────────────────────────────────────────╯
───────────────────────────────────────────────────────────────────────────────────────────────  Discovering Buildspecs ────────────────────────────────────────────────────────────────────────────────────────────────
                   Discovered buildspecs
╔══════════════════════════════════════════════════════════╗
║ buildspec                                                ║
╟──────────────────────────────────────────────────────────╢
║ /global/u1/s/siddiq90/gitrepos/buildtest/examples/pm.yml ║
╚══════════════════════════════════════════════════════════╝


Total Discovered Buildspecs:  1
Total Excluded Buildspecs:  0
Detected Buildspecs after exclusion:  1
────────────────────────────────────────────────────────────────────────────────────────────────── Parsing Buildspecs ──────────────────────────────────────────────────────────────────────────────────────────────────
Valid Buildspecs: 1
Invalid Buildspecs: 0
/global/u1/s/siddiq90/gitrepos/buildtest/examples/pm.yml: VALID
Total builder objects created: 1
                                                                                        Builders by type=script
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ builder                         ┃ type   ┃ executor               ┃ compiler ┃ nodes ┃ procs ┃ description                               ┃ buildspecs                                               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ status_exists_pm_slurm/db3e1760 │ script │ perlmutter.slurm.debug │ None     │ None  │ None  │ status check based for file and directory │ /global/u1/s/siddiq90/gitrepos/buildtest/examples/pm.yml │
└─────────────────────────────────┴────────┴────────────────────────┴──────────┴───────┴───────┴───────────────────────────────────────────┴──────────────────────────────────────────────────────────┘
                                                  Batch Job Builders
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ builder                         ┃ executor               ┃ buildspecs                                               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ status_exists_pm_slurm/db3e1760 │ perlmutter.slurm.debug │ /global/u1/s/siddiq90/gitrepos/buildtest/examples/pm.yml │
└─────────────────────────────────┴────────────────────────┴──────────────────────────────────────────────────────────┘
──────────────────────────────────────────────────────────────────────────────────────────────────── Building Test ─────────────────────────────────────────────────────────────────────────────────────────────────────
status_exists_pm_slurm/db3e1760: Creating test directory: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760
status_exists_pm_slurm/db3e1760: Creating the stage directory: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760/stage
status_exists_pm_slurm/db3e1760: Writing build script: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760/status_exists_pm_slurm_build.sh
──────────────────────────────────────────────────────────────────────────────────────────────────── Running Tests ─────────────────────────────────────────────────────────────────────────────────────────────────────
Spawning 256 processes for processing builders
───────────────────────────────────────────────────────────────────────────────────────────────────── Iteration 1 ──────────────────────────────────────────────────────────────────────────────────────────────────────
status_exists_pm_slurm/db3e1760 does not have any dependencies adding test to queue
In this iteration we are going to run the following tests: [status_exists_pm_slurm/db3e1760]
status_exists_pm_slurm/db3e1760: Current Working Directory : /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760/stage
status_exists_pm_slurm/db3e1760: Running Test via command: bash --norc --noprofile -eo pipefail status_exists_pm_slurm_build.sh
status_exists_pm_slurm/db3e1760: JobID 4344691 dispatched to scheduler
Polling Jobs in 30 seconds
status_exists_pm_slurm/db3e1760: Job 4344691 is complete!
status_exists_pm_slurm/db3e1760 workdir:  /global/u1/s/siddiq90/gitrepos/buildtest/examples
status_exists_pm_slurm/db3e1760 Changing directory to  /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760/stage
status_exists_pm_slurm/db3e1760: Test completed in 30.175633 seconds
status_exists_pm_slurm/db3e1760: Test completed with returncode: 0
status_exists_pm_slurm/db3e1760: Writing output file -  /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760/status_exists_pm_slurm.out
status_exists_pm_slurm/db3e1760: Writing error file - /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760/status_exists_pm_slurm.err
status_exists_pm_slurm/db3e1760 working directory is /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760/stage
status_exists_pm_slurm/db3e1760: Test all files:  ['cuda_vecadd', 'cuda_vecadd/test']  existences
status_exists_pm_slurm/db3e1760: file: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760/stage/cuda_vecadd exists
status_exists_pm_slurm/db3e1760: file: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760/stage/cuda_vecadd/test exists
status_exists_pm_slurm/db3e1760: Exist Check: True
                                        Completed Jobs
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ builder                         ┃ executor               ┃ jobid   ┃ jobstate  ┃ runtime   ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
│ status_exists_pm_slurm/db3e1760 │ perlmutter.slurm.debug │ 4344691 │ COMPLETED │ 30.175633 │
└─────────────────────────────────┴────────────────────────┴─────────┴───────────┴───────────┘
                                                            Test Summary
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ builder                         ┃ executor               ┃ status ┃ checks (ReturnCode, Regex, Runtime) ┃ returncode ┃ runtime   ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ status_exists_pm_slurm/db3e1760 │ perlmutter.slurm.debug │ PASS   │ False False False                   │ 0          │ 30.175633 │
└─────────────────────────────────┴────────────────────────┴────────┴─────────────────────────────────────┴────────────┴───────────┘



Passed Tests: 1/1 Percentage: 100.000%
Failed Tests: 0/1 Percentage: 0.000%


Adding 1 test results to /global/u1/s/siddiq90/gitrepos/buildtest/var/report.json
Writing Logfile to: /global/u1/s/siddiq90/gitrepos/buildtest/var/logs/buildtest_3qswtgx5.log
```

I can confirm the directory is created in stage directory 

```
(buildtest)  ~/gitrepos/buildtest/ [debug_file_checks] ls -ld $(buildtest path status_exists_pm_slurm)/stage/cuda_vecadd/test
drwxrwx--- 2 siddiq90 siddiq90 512 Jan  5 13:44 /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/pm/status_exists_pm_slurm/db3e1760/stage/cuda_vecadd/test
```