### PR TITLE
change executor match from equality check to regex (re.fullmatch) 

### DIFF
--- a/buildtest/buildsystem/parser.py
+++ b/buildtest/buildsystem/parser.py
@@ -7,6 +7,7 @@ expose functions to run builds.
 
 import logging
 import os
+import re
 
 from buildtest.exceptions import (
     ExecutorError,
@@ -137,7 +138,7 @@ class BuildspecParser:
 
         match = any(
             [
-                True if name == executor else False
+                True if re.fullmatch(executor, name) else False
                 for name in self.buildexecutors.names()
             ]
         )


### PR DESCRIPTION
There was an issue with validating test when `executor` property was using a regex. Current behavior was equality check with the executors defined in configuration file. This caused tests like https://github.com/buildtesters/buildtest-nersc/blob/devel/buildspecs/apps/hpctoolkit/hpctoolkit_cuda_vecadd_pc_perlmutter.yml to fail where we had the following for executor - `executor: '(perlmutter|muller).slurm.regular'`

With this change i was able to confirm validation and tags was picking up executors. 

```
(buildtest)  ~/gitrepos/buildtest-nersc/ [devel] buildtest bc find --filter buildspec=/global/u1/s/siddiq90/gitrepos/buildtest-nersc/buildspecs/apps/hpctoolkit/hpctoolkit_cuda_vecadd_perlmutter.yml
          Buildspec Cache: /global/u1/s/siddiq90/gitrepos/buildtest/var/buildspecs/cache.json
 name            ┃ type   ┃ executor                          ┃ tags ┃ description
━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 hpctoolkit_cuda │ script │ (perlmutter|muller).slurm.regular │ e4s  │ HPCToolkit vector add CUDA test
```

@wyphan with this change i expect hpctoolkit test will run now that we change executor check to `re.fullmatch`