### PR TITLE
relocate pages for buildtest tutorial in 'References' 

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,12 +1,11 @@
 .. _getting_started:
 
 
-Buildtest Tutorial
-===================
+Buildtest Command Line Reference
+=================================
 
 .. toctree::
    :maxdepth: 2
-   :caption: buildtest command line tutorial
 
    gettingstarted/buildingtest
    gettingstarted/buildspecs_interface

--- a/docs/gettingstarted/buildingtest.rst
+++ b/docs/gettingstarted/buildingtest.rst
@@ -1,9 +1,9 @@
 .. _building_test:
 
-Building Test via buildtest (``buildtest build``)
-=================================================
+Building Test  (``buildtest build``)
+======================================
 
-This guide will get you familiar with buildtest command line interface. Once
+This reference guide will get you familiar with buildtest command line interface. Once
 you complete this section, you can proceed to :ref:`writing buildspecs <buildspec_tutorial>`
 section where we will cover how to write buildspecs.
 

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -321,7 +321,7 @@ filter test and only report tests in the range of [start, end] dates.
         └────────────────────────────────────────────────────────┴──────────────┴──────────────────────────────────────────┴─────────────────────────────────────────┘
 
 Limit number of test records (``buildtest report --count``)
---------------------------------------------------------
+-------------------------------------------------------------
 
 The ``buildtest report`` command will show all test results from the report file and the output can be quite long. 
 If you want to limit the number of records that get printed then you can use ``buildtest report --count`` 

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -320,18 +320,22 @@ filter test and only report tests in the range of [start, end] dates.
         │ exit1_fail                                             │ FAIL         │ 2022/06/11 17:51:59                      │ 2022/06/11 17:51:59                     │
         └────────────────────────────────────────────────────────┴──────────────┴──────────────────────────────────────────┴─────────────────────────────────────────┘
 
-Find limited Tests (``buildtest report --count``)
+Limit number of test records (``buildtest report --count``)
 --------------------------------------------------------
 
 The ``buildtest report`` command will show all test results from the report file and the output can be quite long. 
 If you want to limit the number of records that get printed then you can use ``buildtest report --count`` 
 where ``--count`` is number of rows that that get printed. Shown below is the output of 2 records in table format
 
-.. command-output:: buildtest report --count 2
+.. dropdown:: ``buildtest report --count 2``
+
+    .. command-output:: buildtest report --count 2
 
 The ``--count`` option also works with terse mode ``--terse``, shown below is the same output 
 
-.. command-output:: buildtest report --terse --count 2
+.. dropdown:: ``buildtest report --terse --count 2``
+
+    .. command-output:: buildtest report --terse --count 2
 
 Terse Output
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,7 +82,6 @@ automate module load testing. For more details on lmodule see https://github.com
    :maxdepth: 2
    :caption: Tutorial
 
-
    getting_started
    buildspec_tutorial
    buildtest_perlmutter
@@ -106,6 +105,7 @@ automate module load testing. For more details on lmodule see https://github.com
    :maxdepth: 2
    :caption: Reference
 
+   getting_started
    writing_buildspecs
    features
    schema_examples

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,7 +82,6 @@ automate module load testing. For more details on lmodule see https://github.com
    :maxdepth: 2
    :caption: Tutorial
 
-   getting_started
    buildspec_tutorial
    buildtest_perlmutter
 


### PR DESCRIPTION
@prathmesh4321 i know we discussed about rewriting the "Buildtest Tutorial" page so for now i was thinking of moving the entire page tree into `References` and then later create a new page that is hands-on 