### PR TITLE
Add feature buildtest buildspec find --row-count

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -301,7 +301,7 @@ _buildtest ()
            COMPREPLY=( $( compgen -W "${opts}" -- $cur ) );;
          # completion for rest of arguments
          *)
-           local longopts="--buildspec --count --executors --filter --filterfields --format --formatfields --group-by-executor --group-by-tags --help --helpfilter --helpformat --no-header --pager --paths --quiet --rebuild --tags --root --terse"
+           local longopts="--buildspec --count --executors --filter --filterfields --format --formatfields --group-by-executor --group-by-tags --help --helpfilter --helpformat --no-header --pager --paths --quiet --rebuild --row-count --tags --root --terse"
            local shortopts="-b -e -h -n -p -q -r -t"
            local subcmds="invalid"
            local allopts="${longopts} ${shortopts} ${subcmds}"

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -759,6 +759,11 @@ def buildspec_menu(subparsers):
         help="Limit number of entries queried in output",
     )
     buildspec_find.add_argument(
+        "--row-count",
+        action="store_true",
+        help="Print total count of records from the table.",
+    )
+    buildspec_find.add_argument(
         "--pager", action="store_true", help="Enable PAGING when viewing result"
     )
     buildspec_find.add_argument(

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -751,7 +751,7 @@ class BuildspecCache:
 
         console.print(table)
 
-    def print_buildspecs(self, terse=None, header=None, quiet=None):
+    def print_buildspecs(self, terse=None, header=None, quiet=None, row_count=None):
         """Print buildspec table. This method is typically called when running ``buildtest buildspec find`` or options
         with ``--filter`` and ``--format``.
 
@@ -759,6 +759,7 @@ class BuildspecCache:
             terse (bool, optional): This argument will print output in terse format if ``--terse`` option is specified otherwise will print output in table format
             header (bool, optional): This argument controls whether header will be printed in terse format. If ``--terse`` option is not specified this argument has no effect. This argument holds the value of ``--no-header`` option
             quiet (bool, optional): If this option is set we return immediately and don't anything. This is specified via ``buildtest buildspec find --quiet`` which can be useful when rebuilding cache without displaying output
+            row_count (bool, optional): Print total number of records from the table
         """
 
         # Don't print anything if --quiet is set
@@ -813,6 +814,10 @@ class BuildspecCache:
         if self.pager:
             with console.pager():
                 console.print(table)
+            return
+
+        if row_count:
+            console.print(table.row_count)
             return
 
         console.print(table)
@@ -1403,4 +1408,4 @@ def buildspec_find(args, configuration):
         cache.print_raw_format_fields()
         return
 
-    cache.print_buildspecs(quiet=args.quiet)
+    cache.print_buildspecs(quiet=args.quiet, row_count=args.row_count)

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -593,12 +593,13 @@ class BuildspecCache:
 
         return buildspec_summary
 
-    def print_buildspecfiles(self, terse=None, header=None):
+    def print_buildspecfiles(self, terse=None, header=None, row_count=None):
         """This method implements ``buildtest buildspec find --buildspec`` which reports all buildspec files in cache.
 
         Args:
             terse (bool, optional): This argument will print output in terse format if ``--terse`` option is specified otherwise will print output in table format
             header (bool, optional): This argument controls whether header will be printed in terse format. If ``--terse`` option is not specified this argument has no effect. This argument holds the value of ``--no-header`` option
+            row_count (bool, optional): Print total number of records from the table
         """
 
         self.terse = terse or self.terse
@@ -627,11 +628,18 @@ class BuildspecCache:
                 console.print(table)
             return
 
+        if row_count:
+            print(table.row_count)
+            return
+
         console.print(table)
 
-    def print_tags(self):
+    def print_tags(self, row_count=None):
         """This method implements ``buildtest buildspec find --tags`` which
         reports a list of unique tags from all buildspecs in cache file.
+
+        Args:
+            row_count (bool, optional): Print total number of records from the table
         """
 
         # if --terse option specified print list of all tags in machine readable format
@@ -658,10 +666,18 @@ class BuildspecCache:
                 console.print(table)
             return
 
+        if row_count:
+            print(table.row_count)
+            return
+
         console.print(table)
 
-    def print_executors(self):
-        """This method implements ``buildtest buildspec find --executors`` which reports all executors from cache."""
+    def print_executors(self, row_count=None):
+        """This method implements ``buildtest buildspec find --executors`` which reports all executors from cache.
+
+        Args:
+            row_count (bool, optional): Print total number of records from the table
+        """
 
         if self.terse:
 
@@ -685,6 +701,10 @@ class BuildspecCache:
         if self.pager:
             with console.pager():
                 console.print(table)
+            return
+
+        if row_count:
+            print(table.row_count)
             return
 
         console.print(table)
@@ -1360,12 +1380,12 @@ def buildspec_find(args, configuration):
 
     # buildtest buildspec find --tags
     if args.tags:
-        cache.print_tags()
+        cache.print_tags(row_count=args.row_count)
         return
 
     # buildtest buildspec find --buildspec
     if args.buildspec:
-        cache.print_buildspecfiles()
+        cache.print_buildspecfiles(row_count=args.row_count)
         return
 
     # buildtest buildspec find --paths
@@ -1375,7 +1395,7 @@ def buildspec_find(args, configuration):
 
     # buildtest buildspec find --executors
     if args.executors:
-        cache.print_executors()
+        cache.print_executors(row_count=args.row_count)
         return
 
     # buildtest buildspec find --group-by-executors

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -137,6 +137,10 @@ def print_buildspec_help():
     table.add_row("buildtest buildspec find --helpformat", "Show all format fields")
     table.add_row("buildtest buildspec find --terse", "Display output in terse format")
     table.add_row(
+        "buildtest buildspec find --row-count",
+        "Print total count of records from the table",
+    )
+    table.add_row(
         "buildtest buildspec find --count=5",
         "Limit output of buildspec cache to 5 elements",
     )

--- a/docs/gettingstarted/buildspecs_interface.rst
+++ b/docs/gettingstarted/buildspecs_interface.rst
@@ -53,8 +53,8 @@ let's limit output to 5 entries, we can run the following
 
     .. command-output:: buildtest buildspec find --count=5
 
-The ``buildtest buildspec find`` command will fetch all buildspecs and display them in a table format, if you want to know how many records are displayed in the table you can use ``buildtest buildspec find --row-count`` which will display   
-a raw count of records in the table. In the example below we will run ``buildtest buildspec find --row-count`` which will show number of buildspecs from buildspec cache.
+You can use the ``--row-count`` option to retrieve total number of records from the ``buildtest buildspec find`` query. In the next example, we show retrieve number of 
+tests available in the buildspec cache by running the following.
 
 .. dropdown:: ``buildtest buildspec find --row-count``
 

--- a/docs/gettingstarted/buildspecs_interface.rst
+++ b/docs/gettingstarted/buildspecs_interface.rst
@@ -53,6 +53,20 @@ let's limit output to 5 entries, we can run the following
 
     .. command-output:: buildtest buildspec find --count=5
 
+The ``buildtest buildspec find`` command will fetch all buildspecs and display them in a table format, if you want to know how many records are displayed in the table you can use ``buildtest buildspec find --row-count`` which will display   
+a raw count of records in the table. In the example below we will run ``buildtest buildspec find --row-count`` which will show number of buildspecs from buildspec cache.
+
+.. dropdown:: ``buildtest buildspec find --row-count``
+
+    .. command-output:: buildtest buildspec find --row-count
+
+You may find it useful to use the ``--row-count`` feature while filtering the buildspec cache. For instance, you can get the number of buildspecs in the cache with
+the script schema type, this can be done by running ``buildtest bc find --filter type=script --row-count`` as shown below.
+
+.. dropdown:: ``buildtest buildspec find --filter type=script --row-count``
+
+    .. command-output:: buildtest buildspec find --filter type=script --row-count
+
 Finding buildspec files
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/gettingstarted/buildspecs_interface.rst
+++ b/docs/gettingstarted/buildspecs_interface.rst
@@ -53,7 +53,7 @@ let's limit output to 5 entries, we can run the following
 
     .. command-output:: buildtest buildspec find --count=5
 
-You can use the ``--row-count`` option to retrieve total number of records from the ``buildtest buildspec find`` query. In the next example, we show retrieve number of 
+You can use the ``--row-count`` option to retrieve total number of records from the ``buildtest buildspec find`` query. In the next example, we show retrieved number of 
 tests available in the buildspec cache by running the following.
 
 .. dropdown:: ``buildtest buildspec find --row-count``

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -124,7 +124,17 @@ def test_func_buildspec_find():
     cache.print_buildspecs(quiet=True)
 
     # buildtest buildspec find --row-count
+    cache = BuildspecCache(configuration=configuration)
     cache.print_buildspecs(row_count=True)
+
+    # buildtest buildspec find --row-count --buildspec
+    cache.print_buildspecfiles(row_count=True)
+
+    # buildtest buildspec find --row-count --tags
+    cache.print_tags(row_count=True)
+
+    # buildtest buildspec find --row-count --executors
+    cache.print_executors(row_count=True)
 
     # test buildspec cache with color 'blue'
     cache = BuildspecCache(rebuild=True, configuration=configuration, color="blue")

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -123,6 +123,9 @@ def test_func_buildspec_find():
     # buildtest buildspec find --quiet
     cache.print_buildspecs(quiet=True)
 
+    # buildtest buildspec find --row-count
+    cache.print_buildspecs(row_count=True)
+
     # test buildspec cache with color 'blue'
     cache = BuildspecCache(rebuild=True, configuration=configuration, color="blue")
     cache.print_buildspecs()


### PR DESCRIPTION
Hi @shahzebsiddiqui. I have added the "--row-count" feature for "buildtest buildspec find". Please review the PR.

<img width="532" alt="Screen Shot 2023-02-07 at 7 45 08 PM" src="https://user-images.githubusercontent.com/35829130/217415948-75a33b29-c6c8-4121-a64f-5614435ce06f.png">

<img width="1669" alt="Screen Shot 2023-02-07 at 7 45 49 PM" src="https://user-images.githubusercontent.com/35829130/217416030-58c5117a-b589-42e5-b3f2-899e038988ab.png">
