### PR TITLE
create parent parser for --pager option used in subcommands

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -195,12 +195,8 @@ _buildtest ()
       ;;
 
     report|rt)
-      local opts="--end --fail --filter --filterfields --format --formatfields --help --helpfilter --helpformat --latest --no-header --oldest --pass --row-count --start --terse  -e -f -h -n -p -s -t c clear l list p path sm summary"
+      local opts="--end --fail --filter --filterfields --format --formatfields --help --helpfilter --helpformat --latest --no-header --oldest --pager --pass --row-count --start --terse  -e -f -h -n -p -s -t c clear l list p path sm summary"
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
-      case ${prev} in --color)
-        COMPREPLY=( $( compgen -W "$(_supported_colors)" -- $cur ) )
-        return
-      esac
       case "${prev}" in --filter)
         COMPREPLY=( $( compgen -W "$(_avail_report_filterfields)" -- $cur ) )
         return
@@ -241,7 +237,7 @@ _buildtest ()
           local opts="-h --help"
           COMPREPLY=( $( compgen -W "${opts}" -- $cur ) );;
         view|v)
-          local opts="--help --theme -h -p -t"
+          local opts="--help --pager --theme -h -t"
           COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
 
           case "${prev}" in --theme|-t)
@@ -259,13 +255,13 @@ _buildtest ()
       # case statement to handle completion for buildtest inspect [name|id|list] command
       case "${COMP_WORDS[2]}" in
         list|l)
-          local opts="--builder --help --no-header --terse -b -h -n -t"
+          local opts="--builder --help --no-header --pager --terse -b -h -n -t"
           COMPREPLY=( $( compgen -W "${opts}" -- $cur ) );;
         name|n)
           COMPREPLY=( $( compgen -W "$(_builder_names)" -- $cur ) )
 
           if [[ $cur == -* ]] ; then
-            local opts="--all --help -a -h"
+            local opts="--all --help --pager -a -h"
             COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
           fi
           ;;
@@ -273,7 +269,7 @@ _buildtest ()
           COMPREPLY=( $( compgen -W "$(_test_buildspec)" -- $cur ) )
 
           if [[ $cur == -* ]] ; then
-            local opts="--all --help -a -h"
+            local opts="--all --help --pager -a -h"
             COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
           fi
           ;;
@@ -305,7 +301,7 @@ _buildtest ()
            COMPREPLY=( $( compgen -W "${opts}" -- $cur ) );;
          # completion for rest of arguments
          *)
-           local longopts="--buildspec --count --executors --filter --filterfields --format --formatfields --group-by-executor --group-by-tags --help --helpfilter --helpformat --no-header --paths --quiet --rebuild --row-count --tags --root --terse"
+           local longopts="--buildspec --count --executors --filter --filterfields --format --formatfields --group-by-executor --group-by-tags --help --helpfilter --helpformat --no-header --pager --paths --quiet --rebuild --row-count --tags --root --terse"
            local shortopts="-b -e -h -n -p -q -r -t"
            local subcmds="invalid"
            local allopts="${longopts} ${shortopts} ${subcmds}"
@@ -318,10 +314,6 @@ _buildtest ()
              COMPREPLY=( $( compgen -W "$(_avail_buildspec_formatfields)" -- $cur ) )
              return
            esac
-           case ${prev} in --color)
-            COMPREPLY=( $( compgen -W "$(_supported_colors)" -- $cur ) )
-            return
-           esac
            ;;
          esac
         ;;
@@ -329,7 +321,7 @@ _buildtest ()
          case ${COMP_WORDS[3]} in
          # completion for rest of arguments
          *)
-           local longopts="--help"
+           local longopts="--help --pager"
            local shortopts="-h"
            local allopts="${longopts} ${shortopts}"
            COMPREPLY=( $( compgen -W "${allopts}" -- $cur ) );;
@@ -388,17 +380,13 @@ _buildtest ()
       ;;
 
     history|hy)
-      local cmds="--help -h list query"
+      local cmds="--help --pager -h list query"
       COMPREPLY=( $( compgen -W "${cmds}" -- $cur ) )
 
       case ${COMP_WORDS[2]} in
       list)
         local opts="--help --no-header --terse -h -n -t"
         COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
-
-        if [[ "${prev}" == "--color" ]]; then
-          COMPREPLY=( $( compgen -W "$(_supported_colors)" -- $cur ) )
-        fi
         ;;
       query)
         local opts="--help --log --output -h -l -o"
@@ -446,7 +434,7 @@ _buildtest ()
     *)
       local cmds="build buildspec cd cdash clean config debugreport docs help info inspect history path report schema schemadocs stats stylecheck tutorial-examples unittests"
       local alias_cmds="bd bc cg debug it h hy rt style test"
-      local opts="--color --config --debug --editor --help --helpcolor --logpath --loglevel --print-log --no-color --pager --report --version --view-log -c -d -h -l -p -r -V"
+      local opts="--color --config --debug --editor --help --helpcolor --logpath --loglevel --print-log --no-color --report --version --view-log -c -d -h -l -p -r -V"
 
       case "${cur}" in
       # print main options to buildtest

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -221,20 +221,21 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         action="store_true",
         help="Print available color options in a table format.",
     )
-    parser.add_argument(
-        "-p", "--pager", action="store_true", help="Enable PAGING when viewing result"
-    )
     parser.add_argument("-r", "--report", help="Specify path to test report file")
 
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser.add_argument(
+        "--pager", action="store_true", help="Enable PAGING when viewing result"
+    )
     subparsers = parser.add_subparsers(title="COMMANDS", dest="subcommands", metavar="")
 
     build_menu(subparsers)
-    buildspec_menu(subparsers)
-    config_menu(subparsers)
-    report_menu(subparsers)
-    inspect_menu(subparsers)
+    buildspec_menu(subparsers, parent_parser)
+    config_menu(subparsers, parent_parser)
+    report_menu(subparsers, parent_parser)
+    inspect_menu(subparsers, parent_parser)
     path_menu(subparsers)
-    history_menu(subparsers)
+    history_menu(subparsers, parent_parser)
     schema_menu(subparsers)
     cdash_menu(subparsers)
     unittest_menu(subparsers)
@@ -246,7 +247,11 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
 
 
 def misc_menu(subparsers):
-    """Build the command line menu for some miscellaneous commands"""
+    """Build the command line menu for some miscellaneous commands
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object to add subparser
+    """
 
     cd_parser = subparsers.add_parser(
         "cd", help="change directory to root of test given a test name"
@@ -312,7 +317,11 @@ def misc_menu(subparsers):
 
 
 def stylecheck_menu(subparsers):
-    """This method will create command options for ``buildtest stylecheck``"""
+    """This method will create command options for ``buildtest stylecheck``
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object to add subparser
+    """
 
     stylecheck_parser = subparsers.add_parser(
         "stylecheck", aliases=["style"], help="Run buildtest style checks"
@@ -333,7 +342,11 @@ def stylecheck_menu(subparsers):
 
 
 def unittest_menu(subparsers):
-    """This method builds the command line menu for ``buildtest unittests`` command"""
+    """This method builds the command line menu for ``buildtest unittests`` command
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object to add subparser
+    """
 
     unittests_parser = subparsers.add_parser(
         "unittests", help="Run buildtest unit tests", aliases=["test"]
@@ -357,7 +370,11 @@ def unittest_menu(subparsers):
 
 
 def tutorial_examples_menu(subparsers):
-    """This method builds the command line menu for ``buildtest tutorial-examples`` command"""
+    """This method builds the command line menu for ``buildtest tutorial-examples`` command
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object to add subparser
+    """
 
     subparsers.add_parser(
         "tutorial-examples",
@@ -366,7 +383,11 @@ def tutorial_examples_menu(subparsers):
 
 
 def path_menu(subparsers):
-    """This method builds the command line menu for ``buildtest path`` command"""
+    """This method builds the command line menu for ``buildtest path`` command
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object to add subparser
+    """
 
     path = subparsers.add_parser("path", help="Show path attributes for a given test")
     path_group = path.add_mutually_exclusive_group()
@@ -392,8 +413,13 @@ def path_menu(subparsers):
     path.add_argument("name", help="Name of test")
 
 
-def history_menu(subparsers):
-    """This method builds the command line menu for ``buildtest history`` command"""
+def history_menu(subparsers, parent_parser):
+    """This method builds the command line menu for ``buildtest history`` command
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object to add subparser
+        parent_parser (argparse.ArgumentParser): Parent parser object to add to subparser
+    """
 
     history_subcmd = subparsers.add_parser(
         "history", aliases=["hy"], help="Query build history"
@@ -404,7 +430,7 @@ def history_menu(subparsers):
     )
 
     list_parser = history_subparser.add_parser(
-        "list", help="List a summary of all builds"
+        "list", help="List a summary of all builds", parents=[parent_parser]
     )
     list_parser.add_argument(
         "-n",
@@ -438,7 +464,11 @@ def history_menu(subparsers):
 
 
 def build_menu(subparsers):
-    """This method implements command line menu for ``buildtest build`` command."""
+    """This method implements command line menu for ``buildtest build`` command.
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object to add subparser
+    """
 
     parser_build = subparsers.add_parser(
         "build", aliases=["bd"], help="Build and Run test"
@@ -594,8 +624,13 @@ def build_menu(subparsers):
     )
 
 
-def buildspec_menu(subparsers):
-    """This method implements ``buildtest buildspec`` command"""
+def buildspec_menu(subparsers, parent_parser):
+    """This method implements ``buildtest buildspec`` command
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object
+        parent_parser (argparse.ArgumentParser): Parent parser object
+    """
 
     parser_buildspec = subparsers.add_parser(
         "buildspec", aliases=["bc"], help="Buildspec Interface"
@@ -630,7 +665,10 @@ def buildspec_menu(subparsers):
     # buildtest buildspec find
 
     buildspec_find = subparsers_buildspec.add_parser(
-        "find", aliases=["f"], help="Query information from buildspecs cache"
+        "find",
+        aliases=["f"],
+        help="Query information from buildspecs cache",
+        parents=[parent_parser],
     )
 
     # buildtest buildspec maintainers
@@ -823,7 +861,10 @@ def buildspec_menu(subparsers):
 
     # buildtest buildspec summary
     subparsers_buildspec.add_parser(
-        "summary", aliases=["sm"], help="Print summary of buildspec cache"
+        "summary",
+        aliases=["sm"],
+        help="Print summary of buildspec cache",
+        parents=[parent_parser],
     )
     # buildtest buildspec validate
     buildspec_validate = subparsers_buildspec.add_parser(
@@ -862,11 +903,18 @@ def buildspec_menu(subparsers):
     )
 
 
-def config_menu(subparsers):
-    """This method adds argparse argument for ``buildtest config``"""
+def config_menu(subparsers, parent_parser):
+    """This method adds argparse argument for ``buildtest config``
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object
+        parent_parser (argparse.ArgumentParser): Parent parser object
+    """
 
     parser_config = subparsers.add_parser(
-        "config", aliases=["cg"], help="Query buildtest configuration"
+        "config",
+        aliases=["cg"],
+        help="Query buildtest configuration",
     )
 
     subparsers_config = parser_config.add_subparsers(
@@ -897,7 +945,7 @@ def config_menu(subparsers):
         "validate", help="Validate buildtest settings file with schema."
     )
     view_parser = subparsers_config.add_parser(
-        "view", aliases=["v"], help="View configuration file"
+        "view", aliases=["v"], help="View configuration file", parents=[parent_parser]
     )
     view_parser.add_argument(
         "-t",
@@ -975,11 +1023,16 @@ def config_menu(subparsers):
     )
 
 
-def report_menu(subparsers):
-    """This method implements the ``buildtest report`` command options"""
+def report_menu(subparsers, parent_parser):
+    """This method implements the ``buildtest report`` command options
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object
+        parent_parser (argparse.ArgumentParser): Parent parser object
+    """
 
     parser_report = subparsers.add_parser(
-        "report", aliases=["rt"], help="Query test report"
+        "report", aliases=["rt"], help="Query test report", parents=[parent_parser]
     )
     subparsers = parser_report.add_subparsers(
         description="Fetch test results from report file and print them in table format",
@@ -992,7 +1045,7 @@ def report_menu(subparsers):
         "path", aliases=["p"], help="Print full path to the report file being used"
     )
     parser_report_summary = subparsers.add_parser(
-        "summary", aliases=["sm"], help="Summarize test report"
+        "summary", aliases=["sm"], help="Summarize test report", parents=[parent_parser]
     )
 
     # buildtest report
@@ -1090,8 +1143,13 @@ def report_menu(subparsers):
     )
 
 
-def inspect_menu(subparsers):
-    """This method builds argument for ``buildtest inspect`` command"""
+def inspect_menu(subparsers, parent_parser):
+    """This method builds argument for ``buildtest inspect`` command
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object
+        parent_parser (argparse.ArgumentParser): Parent parser object
+    """
 
     parser_inspect = subparsers.add_parser(
         "inspect", aliases=["it"], help="Inspect a test based on NAME or ID "
@@ -1103,9 +1161,14 @@ def inspect_menu(subparsers):
         metavar="",
     )
     inspect_buildspec = subparser.add_parser(
-        "buildspec", aliases=["b"], help="Inspect a test based on buildspec"
+        "buildspec",
+        aliases=["b"],
+        help="Inspect a test based on buildspec",
+        parents=[parent_parser],
     )
-    name = subparser.add_parser("name", aliases=["n"], help="Specify name of test")
+    name = subparser.add_parser(
+        "name", aliases=["n"], help="Specify name of test", parents=[parent_parser]
+    )
     query_list = subparser.add_parser(
         "query", aliases=["q"], help="Query fields from record"
     )
@@ -1125,6 +1188,7 @@ def inspect_menu(subparsers):
         "list",
         aliases=["l"],
         help="List all test names, ids, and corresponding buildspecs",
+        parents=[parent_parser],
     )
     inspect_list.add_argument(
         "-n",
@@ -1168,7 +1232,11 @@ def inspect_menu(subparsers):
 
 
 def schema_menu(subparsers):
-    """This method builds menu for ``buildtest schema``"""
+    """This method builds menu for ``buildtest schema``
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object
+    """
 
     parser_schema = subparsers.add_parser(
         "schema", help="List schema contents and examples"
@@ -1192,7 +1260,11 @@ def schema_menu(subparsers):
 
 
 def cdash_menu(subparsers):
-    """This method builds arguments for ``buildtest cdash`` command."""
+    """This method builds arguments for ``buildtest cdash`` command.
+
+    Args:
+        subparsers (argparse._SubParsersAction): Subparser object
+    """
 
     parser_cdash = subparsers.add_parser("cdash", help="Upload test to CDASH server")
 

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -103,7 +103,7 @@ def print_buildspec_help():
     )
     table.add_row("buildtest buildspec find --rebuild", "Rebuild cache file")
     table.add_row(
-        "buildtest --pager buildspec find", "Paginate output of buildspec cache"
+        "buildtest buildspec find --pager", "Paginate output of buildspec cache"
     )
     table.add_row(
         "buildtest buildspec find --root /tmp --rebuild",
@@ -186,7 +186,7 @@ def print_buildspec_help():
 
     table.add_row("buildtest buildspec summary", "Show summary of buildspec cache file")
     table.add_row(
-        "buildtest --pager buildspec summary",
+        "buildtest buildspec summary --pager",
         "Paginate the output of summary for buildspec cache",
     )
     table.add_row(
@@ -242,7 +242,7 @@ def print_config_help():
 
     table.add_row("buildtest config view", "View content of configuration file")
     table.add_row(
-        "buildtest --pager config view", "Paginate output of configuration file"
+        "buildtest config view --pager", "Paginate output of configuration file"
     )
     table.add_row(
         "buildtest config validate", "Validate configuration file with JSON schema"
@@ -343,7 +343,7 @@ def print_report_help():
     table.add_column("Description", justify="left", style="magenta")
 
     table.add_row("buildtest report", "Display all test results")
-    table.add_row("buildtest --pager report", "Paginate output of test results")
+    table.add_row("buildtest report --pager", "Paginate output of test results")
     table.add_row(
         "buildtest report --filter returncode=0", "Filter test results by returncode=0"
     )
@@ -387,7 +387,7 @@ def print_report_help():
         "buildtest report summary --detailed", "Show detailed summary of test report"
     )
     table.add_row(
-        "buildtest --pager report summary", "Paginate output of report summary"
+        "buildtest report summary --pager", "Paginate output of report summary"
     )
     console.print(table)
 

--- a/docs/command_line_tutorial.rst
+++ b/docs/command_line_tutorial.rst
@@ -95,7 +95,7 @@ The ``buildtest rt summary`` can be useful if you want to summary of report file
 Buildtest supports paging support with ``buildtest rt`` which can be useful when you
 have lots of tests. To enable pagination you can run::
 
-    buildtest --pager rt
+    buildtest rt --pager
 
 Finally we can filter test records and format table columns via ``--filter`` and ``--format`` option. Let's try
 running the following command

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -107,7 +107,7 @@ def test_func_buildspec_find():
     # buildtest buildspec find --formatfields
     cache.print_raw_format_fields()
 
-    # buildtest --pager buildspec find
+    # buildtest buildspec find --pager
     cache = BuildspecCache(configuration=configuration, pager=True)
     cache.print_tags()
     cache.print_buildspecfiles()
@@ -340,7 +340,7 @@ def test_buildspec_summary():
     summarize_buildspec_cache(
         configuration=configuration, pager=False, color=Color.default().name
     )
-    # buildtest --pager buildspec summary
+    # buildtest buildspec summary --pager
     summarize_buildspec_cache(configuration=configuration, pager=True)
 
 

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -43,7 +43,7 @@ def test_view_configuration():
     # buildtest config view --theme emacs
     view_configuration(configuration, theme="emacs")
 
-    # buildtest --pager config view
+    # buildtest config view --pager
     view_configuration(configuration, pager=True)
 
 

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -201,7 +201,7 @@ def test_report_summary():
     report = Report()
     report_summary(report)
 
-    # buildtest --pager rt summary
+    # buildtest rt summary --pager
     report = Report(pager=True)
     report_summary(report)
 
@@ -209,7 +209,7 @@ def test_report_summary():
     report = Report()
     report_summary(report, detailed=True)
 
-    # buildtest --pager rt summary --detailed
+    # buildtest rt summary --detailed --pager
     report = Report(pager=True)
     report_summary(report, detailed=True)
 
@@ -226,7 +226,7 @@ def test_report_summary():
     report = Report(color="light_pink1")
     report_summary(report, detailed=True)
 
-    # buildtest --pager rt sm --detailed
+    # buildtest rt sm --detailed --pager
     report = Report(pager=True)
     report_summary(report, detailed=True)
 


### PR DESCRIPTION
```
(buildtest)  ~/Documents/github/buildtest/ [parent_parser_declaration_for_pager_option*] buildtest cg view -h | grep pager
usage: buildtest [options] [COMMANDS] config view [-h] [--pager]
  --pager               Enable PAGING when viewing result

(buildtest)  ~/Documents/github/buildtest/ [parent_parser_declaration_for_pager_option*] buildtest rt -h | grep pager
usage: buildtest [options] [COMMANDS] report [-h] [--pager] [--filter FILTER]
  --pager               Enable PAGING when viewing result

(buildtest)  ~/Documents/github/buildtest/ [parent_parser_declaration_for_pager_option*] buildtest bc find -h | grep pager
usage: buildtest [options] [COMMANDS] buildspec find [-h] [--pager] [-b] [-e]
  --pager              Enable PAGING when viewing result

(buildtest)  ~/Documents/github/buildtest/ [parent_parser_declaration_for_pager_option*] buildtest bc sm -h | grep pager
usage: buildtest [options] [COMMANDS] buildspec summary [-h] [--pager]
  --pager     Enable PAGING when viewing result

(buildtest)  ~/Documents/github/buildtest/ [parent_parser_declaration_for_pager_option*] buildtest rt -h | grep pager
usage: buildtest [options] [COMMANDS] report [-h] [--pager] [--filter FILTER]
  --pager               Enable PAGING when viewing result
(buildtest)  ~/Documents/github/buildtest/ [parent_parser_declaration_for_pager_option*] buildtest rt sm -h | grep pager
usage: buildtest [options] [COMMANDS] report summary [-h] [--pager]
  --pager         Enable PAGING when viewing result
(buildtest)  ~/Documents/github/buildtest/ [parent_parser_declaration_for_pager_option*] buildtest it l -h | grep pager 
usage: buildtest [options] [COMMANDS] inspect list [-h] [--pager] [-n] [-t]
  --pager          Enable PAGING when viewing result

```

there are still several more ...