### PR TITLE
Add code coverage for subprocesses

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,9 @@
 [run]
 branch = True
+parallel = True
+concurrency = multiprocessing
 source = buildtest
+
 omit =
     buildtest/main.py
     buildtest/defaults.py

--- a/buildtest/tools/unittests.py
+++ b/buildtest/tools/unittests.py
@@ -72,6 +72,7 @@ def run_unit_tests(pytestopts=None, sourcefiles=None, enable_coverage=False):
 
     if enable_coverage:
         cov.stop()
+        cov.combine()
         cov.html_report(title="buildtest unittests coverage report", directory=html_dir)
         cov.json_report(outfile=os.path.join(BUILDTEST_ROOT, "coverage.json"))
         cov.report(ignore_errors=True, skip_empty=True, sort="-cover", precision=2)

--- a/setup.sh
+++ b/setup.sh
@@ -48,6 +48,7 @@ if [ $returncode -ne 0 ]; then
 fi
 
 export BUILDTEST_ROOT=$buildtest_root
+export COVERAGE_PROCESS_START=$buildtest_root/.coveragerc
 export PATH=${buildtest_root}/bin:$PATH
 
 # for ZSH shell need to run autoload see https://stackoverflow.com/questions/3249432/can-a-bash-tab-completion-script-be-used-in-zsh

--- a/tests/sitecustomize.py
+++ b/tests/sitecustomize.py
@@ -1,0 +1,3 @@
+import coverage
+
+coverage.process_startup()


### PR DESCRIPTION
@shahzebsiddiqui Looks like code coverage works now. Check this - https://app.codecov.io/gh/buildtesters/buildtest/blob/coverage_subprocesses/buildtest/buildsystem/checks.py