### PR TITLE
Add pagination support for buildtest history subcommands

### DIFF
--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -422,7 +422,7 @@ def history_menu(subparsers, parent_parser):
     """
 
     history_subcmd = subparsers.add_parser(
-        "history", aliases=["hy"], help="Query build history"
+        "history", aliases=["hy"], help="Query build history", parents=[parent_parser]
     )
 
     history_subparser = history_subcmd.add_subparsers(
@@ -430,7 +430,7 @@ def history_menu(subparsers, parent_parser):
     )
 
     list_parser = history_subparser.add_parser(
-        "list", help="List a summary of all builds", parents=[parent_parser]
+        "list", help="List a summary of all builds"
     )
     list_parser.add_argument(
         "-n",

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -413,16 +413,16 @@ def path_menu(subparsers):
     path.add_argument("name", help="Name of test")
 
 
-def history_menu(subparsers, parent_parser):
+def history_menu(subparsers, pager_option):
     """This method builds the command line menu for ``buildtest history`` command
 
     Args:
         subparsers (argparse._SubParsersAction): Subparser object to add subparser
-        parent_parser (argparse.ArgumentParser): Parent parser object to add to subparser
+        pager_option (argparse.ArgumentParser): Parent parser object to add to subparser
     """
 
     history_subcmd = subparsers.add_parser(
-        "history", aliases=["hy"], help="Query build history", parents=[parent_parser]
+        "history", aliases=["hy"], help="Query build history"
     )
 
     history_subparser = history_subcmd.add_subparsers(
@@ -430,7 +430,7 @@ def history_menu(subparsers, parent_parser):
     )
 
     list_parser = history_subparser.add_parser(
-        "list", help="List a summary of all builds"
+        "list", help="List a summary of all builds", parents=[pager_option]
     )
     list_parser.add_argument(
         "-n",
@@ -446,7 +446,7 @@ def history_menu(subparsers, parent_parser):
     )
 
     query = history_subparser.add_parser(
-        "query", help="Query information for a particular build"
+        "query", help="Query information for a particular build", parents=[pager_option]
     )
     query.add_argument("id", type=int, help="Select a build ID")
     query.add_argument(

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -406,7 +406,18 @@ def print_history_help():
     table.add_row("buildtest history list", "List all build history files")
     table.add_row("buildtest history list --terse", "Print output in terse format")
     table.add_row(
+        "buildtest history --pager list", "Paginate output of the history list"
+    )
+    table.add_row(
         "buildtest history query 0", "Query content of history build identifier '0'"
+    )
+    table.add_row(
+        "buildtest history --pager query 0",
+        "Paginate the query content of history build identifier '0'",
+    )
+    table.add_row(
+        "buildtest history --pager query 0 --output",
+        "Paginate the output file content of history build identifier '0'",
     )
     table.add_row(
         "buildtest history query 0 --log", "Open logfile for build identifier '0'"

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -406,18 +406,14 @@ def print_history_help():
     table.add_row("buildtest history list", "List all build history files")
     table.add_row("buildtest history list --terse", "Print output in terse format")
     table.add_row(
-        "buildtest history --pager list", "Paginate output of the history list"
+        "buildtest history list --pager", "Paginate output of the history list"
     )
     table.add_row(
         "buildtest history query 0", "Query content of history build identifier '0'"
     )
     table.add_row(
-        "buildtest history --pager query 0",
+        "buildtest history query 0 --pager",
         "Paginate the query content of history build identifier '0'",
-    )
-    table.add_row(
-        "buildtest history --pager query 0 --output",
-        "Paginate the output file content of history build identifier '0'",
     )
     table.add_row(
         "buildtest history query 0 --log", "Open logfile for build identifier '0'"

--- a/buildtest/cli/history.py
+++ b/buildtest/cli/history.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def build_history(args):
-    """This is the entry point for command ``buildtest build history`` command which reports
+    """This is the entry point for command ``buildtest history`` command which reports
 
     Args:
         args (dict): Parsed arguments from `ArgumentParser.parse_args <https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_args>`_

--- a/buildtest/cli/history.py
+++ b/buildtest/cli/history.py
@@ -203,12 +203,11 @@ def query_builds(build_id, log_option=None, output=None, pager=None):
         return
 
     if output:
-        content = read_file(
+        output_content = read_file(
             os.path.join(BUILD_HISTORY_DIR, str(build_id), "output.txt")
         )
-        if not pager:
-            print(content)
-            return
+        print(output_content)
+        return
 
     if pager:
         with console.pager():

--- a/buildtest/cli/history.py
+++ b/buildtest/cli/history.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import os
 import re
@@ -103,21 +104,18 @@ def list_build_history(no_header=None, terse=None, pager=None, color=None):
         table["fail_rate"].append(content["test_summary"]["fail_rate"])
 
     if terse:
-        row_entry = []
-
-        for key in table.keys():
-            row_entry.append(table[key])
-
+        row_entry = [table[key] for key in table.keys()]
         transpose_list = [list(i) for i in zip(*row_entry)]
 
-        # We print the table columns if --no-header is not specified
-        if not no_header:
-            console.print("|".join(table.keys()), style=consoleColor)
+        with console.pager() if pager else contextlib.suppress():
+            # We print the table columns if --no-header is not specified
+            if not no_header:
+                console.print("|".join(table.keys()), style=consoleColor)
 
-        for row in transpose_list:
-            line = "|".join(row)
-            console.print(f"[{consoleColor}]{line}")
-        return
+            for row in transpose_list:
+                line = "|".join(row)
+                console.print(f"[{consoleColor}]{line}")
+            return
 
     history_table = Table(
         header_style="blue", show_lines=True, row_styles=[consoleColor]

--- a/buildtest/cli/history.py
+++ b/buildtest/cli/history.py
@@ -128,7 +128,7 @@ def list_build_history(no_header=None, terse=None, pager=None, color=None):
         if pager:
             with console.pager():
                 print_terse(table, no_header, consoleColor)
-                return
+            return
 
         print_terse(table, no_header, consoleColor)
         return

--- a/buildtest/cli/history.py
+++ b/buildtest/cli/history.py
@@ -28,7 +28,9 @@ def build_history(args):
         )
 
     if args.history == "query":
-        query_builds(build_id=args.id, log_option=args.log, output=args.output)
+        query_builds(
+            build_id=args.id, log_option=args.log, output=args.output, pager=args.pager
+        )
 
 
 def sorted_alphanumeric(data):
@@ -170,14 +172,15 @@ def list_build_history(no_header=None, terse=None, pager=None, color=None):
     console.print(history_table)
 
 
-def query_builds(build_id, log_option, output):
+def query_builds(build_id, log_option=None, output=None, pager=None):
     """This method is called when user runs `buildtest history query` which will
     report the build.json and logfile.
 
     Args:
         build_id (int): Build Identifier which is used for querying history file. The indentifier is an integer starting from 0
-        log_option (bool): Option to control whether log file is opened in editor. This is specified via ``buildtest history query -l <id>``
-        output (bool): Display output.txt file which contains output of ``buildtest build`` command. This is passed via ``buildtest history query -o``
+        log_option (bool, optional): Option to control whether log file is opened in editor. This is specified via ``buildtest history query -l <id>``
+        output (bool, optional): Display output.txt file which contains output of ``buildtest build`` command. This is passed via ``buildtest history query -o``
+        pager (bool, optional): Print output in paging format
     """
 
     if not is_dir(BUILD_HISTORY_DIR):
@@ -200,10 +203,16 @@ def query_builds(build_id, log_option, output):
         return
 
     if output:
-        output_content = read_file(
+        content = read_file(
             os.path.join(BUILD_HISTORY_DIR, str(build_id), "output.txt")
         )
-        print(output_content)
+        if not pager:
+            print(content)
+            return
+
+    if pager:
+        with console.pager():
+            console.print(content)
         return
 
     pprint(content)

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -57,14 +57,11 @@ def test_build_history_query():
     # buildtest history query <id>
     query_builds(build_id=build_id, log_option=False, output=False)
 
-    # buildtest history --pager query <id>
+    # buildtest history query <id> --pager
     query_builds(build_id=build_id, log_option=False, output=False, pager=True)
 
     # buildtest history query <id> --output
     query_builds(build_id=build_id, log_option=False, output=True)
-
-    # buildtest history --pager query <id> --output
-    query_builds(build_id=build_id, log_option=False, output=True, pager=True)
 
     # buildtest history query <id> --log
     query_builds(build_id=build_id, log_option=True, output=False)

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -19,7 +19,7 @@ def test_build_history_list():
         terse=False, no_header=False, pager=False, color=Color.default().name
     )
 
-    # test with pager support: buildtest history --pager list
+    # buildtest history list --pager
     list_build_history(terse=False, no_header=False, pager=True)
 
     # test with terse mode and with color: buildtest --color <Color> history list --terse
@@ -54,19 +54,19 @@ def test_build_history_query():
     build_id = list(range(len(os.listdir(BUILD_HISTORY_DIR))))[-1]
     print(build_id)
 
-    # run buildtest history query <id>
+    # buildtest history query <id>
     query_builds(build_id=build_id, log_option=False, output=False)
 
-    # run buildtest history --pager query <id>
+    # buildtest history --pager query <id>
     query_builds(build_id=build_id, log_option=False, output=False, pager=True)
 
-    # run buildtest history query <id> --output
+    # buildtest history query <id> --output
     query_builds(build_id=build_id, log_option=False, output=True)
 
-    # run buildtest history --pager query <id> --output
+    # buildtest history --pager query <id> --output
     query_builds(build_id=build_id, log_option=False, output=True, pager=True)
 
-    # run buildtest history query <id> --log
+    # buildtest history query <id> --log
     query_builds(build_id=build_id, log_option=True, output=False)
 
 

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -11,10 +11,10 @@ from rich.color import Color
 
 
 def test_build_history_list():
-    # Testing command:  buildtest history list
+    # buildtest history list
     list_build_history(terse=False, no_header=False, pager=False)
 
-    # test with a color: buildtest history list --color <color>
+    # buildtest history list --color <color>
     list_build_history(
         terse=False, no_header=False, pager=False, color=Color.default().name
     )
@@ -22,12 +22,12 @@ def test_build_history_list():
     # buildtest history list --pager
     list_build_history(terse=False, no_header=False, pager=True)
 
-    # test with terse mode with color and pager: buildtest --color <Color> history list --terse --pager
+    # buildtest --color <Color> history list --terse --pager
     list_build_history(
         terse=True, no_header=False, pager=True, color=Color.default().name
     )
 
-    # test with terse and no header: buildtest history list --terse --no-header
+    # buildtest history list --terse --no-header
     list_build_history(terse=True, no_header=True, pager=False)
 
 

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -19,7 +19,7 @@ def test_build_history_list():
         terse=False, no_header=False, pager=False, color=Color.default().name
     )
 
-    # test with pager support: buildtest history list --pager
+    # test with pager support: buildtest history --pager list
     list_build_history(terse=False, no_header=False, pager=True)
 
     # test with terse mode and with color: buildtest --color <Color> history list --terse
@@ -57,8 +57,14 @@ def test_build_history_query():
     # run buildtest history query <id>
     query_builds(build_id=build_id, log_option=False, output=False)
 
+    # run buildtest history --pager query <id>
+    query_builds(build_id=build_id, log_option=False, output=False, pager=True)
+
     # run buildtest history query <id> --output
     query_builds(build_id=build_id, log_option=False, output=True)
+
+    # run buildtest history --pager query <id> --output
+    query_builds(build_id=build_id, log_option=False, output=True, pager=True)
 
     # run buildtest history query <id> --log
     query_builds(build_id=build_id, log_option=True, output=False)

--- a/tests/cli/test_history.py
+++ b/tests/cli/test_history.py
@@ -22,9 +22,9 @@ def test_build_history_list():
     # buildtest history list --pager
     list_build_history(terse=False, no_header=False, pager=True)
 
-    # test with terse mode and with color: buildtest --color <Color> history list --terse
+    # test with terse mode with color and pager: buildtest --color <Color> history list --terse --pager
     list_build_history(
-        terse=True, no_header=False, pager=False, color=Color.default().name
+        terse=True, no_header=False, pager=True, color=Color.default().name
     )
 
     # test with terse and no header: buildtest history list --terse --no-header


### PR DESCRIPTION
Hi @shahzebsiddiqui . Please review the PR. I didn't add short "-p" option because it was giving a conflict error. Also, for the "--pager" option along the "--output" (`buildtest history --pager query 0 --output`) the output looks somewhat unreadable (see the image below) as there are these "ESC" characters in the output.txt. Do you think it is a good idea to keep the --pager option for the above command ?

<img width="1680" alt="Screen Shot 2023-03-15 at 10 37 37 AM" src="https://user-images.githubusercontent.com/35829130/225395810-1bb2aa43-f9d7-430c-9538-20dae197aced.png">

<img width="540" alt="Screen Shot 2023-03-15 at 2 10 33 AM" src="https://user-images.githubusercontent.com/35829130/225395608-967b8eed-0c64-4761-a077-973457e11139.png">

<img width="1680" alt="Screen Shot 2023-03-15 at 10 38 41 AM" src="https://user-images.githubusercontent.com/35829130/225396027-5ac5e30d-0d4e-4d51-9777-02b19a45d482.png">



