### PR TITLE
Add pagination support for subcommands in "buildtest inspect" command

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -276,7 +276,7 @@ _buildtest ()
         query|q)
           COMPREPLY=( $( compgen -W "$(_builder_names)" -- $cur ) )
           if [[ $cur == -* ]] ; then
-            local opts="--buildscript --buildenv --error --help --output --testpath --theme -b -be -e -o -h -o -t"
+            local opts="--buildscript --buildenv --error --help --output --pager --testpath --theme -b -be -e -o -h -o -t"
             COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
           fi
           case "${prev}" in --theme)

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -1170,7 +1170,7 @@ def inspect_menu(subparsers, pager_option):
         "name", aliases=["n"], help="Specify name of test", parents=[pager_option]
     )
     query_list = subparser.add_parser(
-        "query", aliases=["q"], help="Query fields from record"
+        "query", aliases=["q"], help="Query fields from record", parents=[pager_option]
     )
 
     # buildtest inspect buildspec

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -1143,7 +1143,7 @@ def report_menu(subparsers, parent_parser):
     )
 
 
-def inspect_menu(subparsers, parent_parser):
+def inspect_menu(subparsers, pager_option):
     """This method builds argument for ``buildtest inspect`` command
 
     Args:
@@ -1164,10 +1164,10 @@ def inspect_menu(subparsers, parent_parser):
         "buildspec",
         aliases=["b"],
         help="Inspect a test based on buildspec",
-        parents=[parent_parser],
+        parents=[pager_option],
     )
     name = subparser.add_parser(
-        "name", aliases=["n"], help="Specify name of test", parents=[parent_parser]
+        "name", aliases=["n"], help="Specify name of test", parents=[pager_option]
     )
     query_list = subparser.add_parser(
         "query", aliases=["q"], help="Query fields from record"
@@ -1188,7 +1188,7 @@ def inspect_menu(subparsers, parent_parser):
         "list",
         aliases=["l"],
         help="List all test names, ids, and corresponding buildspecs",
-        parents=[parent_parser],
+        parents=[pager_option],
     )
     inspect_list.add_argument(
         "-n",

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -310,8 +310,13 @@ def print_inspect_help():
         "Display all test names, ids, and corresponding buildspec file",
     )
     table.add_row("buildtest inspect list -t", "Show output in terse format")
+    table.add_row("buildtest inspect list --pager", "Paginate output of inspect list")
     table.add_row(
         "buildtest inspect name hello", "Display last run for test name 'hello'"
+    )
+    table.add_row(
+        "buildtest inspect name hello --pager",
+        "Paginate output of last run for test name 'hello'",
     )
     table.add_row(
         "buildtest inspect name hello/9ac bar/ac9",
@@ -322,8 +327,16 @@ def print_inspect_help():
         "Fetch latest runs for all tests in buildspec file 'tutorials/vars.yml'",
     )
     table.add_row(
+        "buildtest inspect buildspec tutorials/vars.yml --pager",
+        "Paginate output of test runs for the tests in file 'tutorials/vars.yml'",
+    )
+    table.add_row(
         "buildtest inspect query -o exit1_fail",
         "Display content of output file for latest run for test name 'exit1_fail'",
+    )
+    table.add_row(
+        "buildtest inspect query -o exit1_fail --pager",
+        "Paginate content of output file for latest run for test name 'exit1_fail'",
     )
     table.add_row(
         "buildtest inspect query -e hello",

--- a/buildtest/cli/help.py
+++ b/buildtest/cli/help.py
@@ -315,10 +315,6 @@ def print_inspect_help():
         "buildtest inspect name hello", "Display last run for test name 'hello'"
     )
     table.add_row(
-        "buildtest inspect name hello --pager",
-        "Paginate output of last run for test name 'hello'",
-    )
-    table.add_row(
         "buildtest inspect name hello/9ac bar/ac9",
         "Display record for test 'hello/9ac' and 'bar/ac9'. Will find first match for each test ID",
     )
@@ -327,16 +323,8 @@ def print_inspect_help():
         "Fetch latest runs for all tests in buildspec file 'tutorials/vars.yml'",
     )
     table.add_row(
-        "buildtest inspect buildspec tutorials/vars.yml --pager",
-        "Paginate output of test runs for the tests in file 'tutorials/vars.yml'",
-    )
-    table.add_row(
         "buildtest inspect query -o exit1_fail",
         "Display content of output file for latest run for test name 'exit1_fail'",
-    )
-    table.add_row(
-        "buildtest inspect query -o exit1_fail --pager",
-        "Paginate content of output file for latest run for test name 'exit1_fail'",
     )
     table.add_row(
         "buildtest inspect query -e hello",

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -39,7 +39,7 @@ def inspect_cmd(args, report_file=None):
         return
 
     if args.inspect in ["query", "q"]:
-        inspect_query(report, args)
+        inspect_query(report, args, args.pager)
         return
 
     if args.inspect in ["buildspec", "b"]:
@@ -111,7 +111,7 @@ def print_terse(table, no_header=None, consoleColor=None):
 
     Args:
         table (dict): Table with columns required for the ``buildtest inspect list`` command.
-        header (bool, optional): Determine whether to print header in terse format.
+        no_header (bool, optional): Determine whether to print header in terse format.
         consoleColor (bool, optional): Select desired color when displaying results
     """
 
@@ -198,12 +198,12 @@ def inspect_list(
     console.print(inspect_table)
 
 
-def inspect_query(report, args):
-    """Entry point for ``buildtest inspect query`` command.
+def print_by_query(report, args):
+    """This method prints the test records when they are queried using ``buildtest inspect query`` command.
 
     Args:
-        args (dict): Parsed arguments from `ArgumentParser.parse_args <https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_args>`_
         report (str): Path to report file
+        args (dict): Parsed arguments from `ArgumentParser.parse_args <https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_args>`_
     """
 
     records = {}
@@ -283,6 +283,23 @@ def inspect_query(report, args):
 
                     syntax = Syntax(content, lexer="text", theme=theme)
                     console.print(syntax)
+
+
+def inspect_query(report, args, pager=None):
+    """Entry point for ``buildtest inspect query`` command.
+
+    Args:
+        report (str): Path to report file
+        args (dict): Parsed arguments from `ArgumentParser.parse_args <https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_args>`_
+        pager (bool, optional): Print output in paging format
+    """
+
+    if pager:
+        with console.pager():
+            print_by_query(report, args)
+        return
+
+    print_by_query(report, args)
 
 
 def inspect_buildspec(report, input_buildspecs, all_records, pager=None):

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -9,7 +9,7 @@ from buildtest.utils.file import read_file, resolve_path
 from buildtest.utils.tools import checkColor
 from rich.pretty import pprint
 from rich.syntax import Syntax
-from rich.table import Column, Table
+from rich.table import Table
 
 
 def inspect_cmd(args, report_file=None):

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -35,7 +35,7 @@ def inspect_cmd(args, report_file=None):
 
     # implements command 'buildtest inspect name'
     if args.inspect in ["name", "n"]:
-        inspect_by_name(report, args.name)
+        inspect_by_name(report, args.name, args.pager)
         return
 
     if args.inspect in ["query", "q"]:
@@ -343,18 +343,8 @@ def inspect_buildspec(report, input_buildspecs, all_records):
     pprint(records)
 
 
-def inspect_by_name(report, names):
-    """Implements command ``buildtest inspect name`` which will print all test records by given name in JSON format.
-
-    .. code-block:: console
-
-        # get last run for test exit1_fail
-        buildtest inspect name exit1_fail
-
-    .. code-block:: console
-
-        # get record exit1_fail that starts with id 123
-        buildtest inspect name exit1_fail/123
+def print_by_name(report, names):
+    """This method prints test records by given name in JSON format.
 
     Args:
         report (str): Path to report file
@@ -376,4 +366,32 @@ def inspect_by_name(report, names):
 
         records[name].append(report.fetch_records_by_ids([tid]))
 
-    pprint(records)
+    console.print(records)
+
+
+def inspect_by_name(report, names, pager=None):
+    """Implements command ``buildtest inspect name`` which will print all test records by given name in JSON format.
+
+    .. code-block:: console
+
+        # get last run for test exit1_fail
+        buildtest inspect name exit1_fail
+
+    .. code-block:: console
+
+        # get record exit1_fail that starts with id 123
+        buildtest inspect name exit1_fail/123
+
+    Args:
+        report (str): Path to report file
+        names (list): List of test names to search in report file. This is specified as positional arguments to ``buildtest inspect name``
+        pager (bool, optional): Print output in paging format
+    """
+
+    if pager:
+        with console.pager():
+            print_by_name(report, names)
+        return
+
+    print_by_name(report, names)
+    return

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -43,7 +43,12 @@ def inspect_cmd(args, report_file=None):
         return
 
     if args.inspect in ["buildspec", "b"]:
-        inspect_buildspec(report, input_buildspecs=args.buildspec, all_records=args.all)
+        inspect_buildspec(
+            report,
+            input_buildspecs=args.buildspec,
+            all_records=args.all,
+            pager=args.pager,
+        )
 
 
 def fetch_test_names(report, names):
@@ -280,13 +285,14 @@ def inspect_query(report, args):
                     console.print(syntax)
 
 
-def inspect_buildspec(report, input_buildspecs, all_records):
+def inspect_buildspec(report, input_buildspecs, all_records, pager=None):
     """This method implements command ``buildtest inspect buildspec``
 
     Args:
         report (str): Path to report file
         input_buildspecs (list): List of buildspecs to search in report file. This is specified as positional arguments to ``buildtest inspect buildspec``
         all_records (bool): Determine whether to display all records for every test that matches the buildspec. By default we retrieve the latest record.
+        pager (bool, optional): Print output in paging format
     """
 
     search_buildspecs = []
@@ -339,6 +345,11 @@ def inspect_buildspec(report, input_buildspecs, all_records):
                 latest_records[buildspec][test] = records[buildspec][test][-1]
 
     records = latest_records or records
+
+    if pager:
+        with console.pager():
+            console.print(records)
+        return
 
     pprint(records)
 

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -106,26 +106,24 @@ def print_builders(report):
         console.print(name)
 
 
-def print_terse(table, no_header=None, consoleColor=None):
-    """This method prints the buildtest inspect list in terse mode which is run via command ``buildtest inspect list --terse``
+def print_terse(table, no_header=None, console_color=None):
+    """This method prints output of builders in terse mode which is run via command ``buildtest inspect list --terse``
 
     Args:
         table (dict): Table with columns required for the ``buildtest inspect list`` command.
         no_header (bool, optional): Determine whether to print header in terse format.
-        consoleColor (bool, optional): Select desired color when displaying results
+        console_color (bool, optional): Select desired color when displaying results
     """
 
     row_entry = [table[key] for key in table.keys()]
     transpose_list = [list(i) for i in zip(*row_entry)]
-    header = "|".join(table.keys())
 
     # We print the table columns if --no-header is not specified
     if not no_header:
-        console.print(header, style=consoleColor)
+        console.print("|".join(table.keys()), style=console_color)
 
     for row in transpose_list:
-        line = "|".join(row)
-        console.print(f"[{consoleColor}]{line}")
+        console.print("|".join(row), style=console_color)
 
 
 def inspect_list(
@@ -183,9 +181,8 @@ def inspect_list(
         title="Test Summary by id, name, buildspec",
         row_styles=[consoleColor],
     )
-    inspect_table.add_column("id")
-    inspect_table.add_column("name")
-    inspect_table.add_column("buildspec")
+    for column in table.keys():
+        inspect_table.add_column(column)
 
     for (identifier, name, buildspec) in zip(
         table["id"], table["name"], table["buildspec"]

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -187,8 +187,8 @@ def inspect_list(
     inspect_table.add_column("name")
     inspect_table.add_column("buildspec")
 
-    for (id, name, buildspec) in zip(table["id"], table["name"], table["buildspec"]):
-        inspect_table.add_row(id, name, buildspec)
+    for (identifier, name, buildspec) in zip(table["id"], table["name"], table["buildspec"]):
+        inspect_table.add_row(identifier, name, buildspec)
 
     if pager:
         with console.pager():

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -187,7 +187,9 @@ def inspect_list(
     inspect_table.add_column("name")
     inspect_table.add_column("buildspec")
 
-    for (identifier, name, buildspec) in zip(table["id"], table["name"], table["buildspec"]):
+    for (identifier, name, buildspec) in zip(
+        table["id"], table["name"], table["buildspec"]
+    ):
         inspect_table.add_row(identifier, name, buildspec)
 
     if pager:

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -95,6 +95,7 @@ def test_buildtest_inspect_name():
         inspect = "name"
         name = test_names
         report = None
+        pager = True
 
     print(f"Querying test names: {args.name}")
     # buildtest inspect name <name1> <name2>
@@ -110,6 +111,7 @@ def test_buildtest_inspect_name():
         inspect = "name"
         name = random_test
         report = None
+        pager = False
 
     print(f"Querying test names: {args.name}")
     with pytest.raises(SystemExit):
@@ -120,6 +122,7 @@ def test_buildtest_inspect_name():
         inspect = "name"
         name = [r.builder_names()[0]]
         report = None
+        pager = False
 
     inspect_cmd(args)
 

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -190,8 +190,9 @@ def test_buildtest_query():
         buildscript = True
         buildenv = True
         theme = "emacs"
+        pager = True
 
-    # check buildtest inspect query --output --error --testpath --buildscript --buildenv <name1> <name2> ...
+    # buildtest inspect query --output --error --testpath --buildscript --buildenv <name1> <name2> ...
     inspect_cmd(args)
 
     class args:
@@ -204,10 +205,11 @@ def test_buildtest_query():
         buildscript = False
         buildenv = False
         theme = None
+        pager = False
 
     # buildtest inspect query stream_test
     # the 'stream_test' will add coverage where metrics are printed in output of 'buildtest inspect query'
-    inspect_cmd(args)
+    iinspect_cmd(args)
 
     class args:
         subcommands = "inspect"
@@ -220,6 +222,7 @@ def test_buildtest_query():
         buildscript = False
         buildenv = False
         theme = None
+        pager = False
 
     # check invalid test name when querying result which will result in exception SystemExit
     with pytest.raises(SystemExit):

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -136,6 +136,7 @@ def test_buildspec_inspect_buildspec():
         buildspec = [tf.name]
         report = None
         all = None
+        pager = False
 
     # if buildspec not in cache we raise error
     with pytest.raises(SystemExit):
@@ -158,8 +159,9 @@ def test_buildspec_inspect_buildspec():
         buildspec = search_buildspec
         report = None
         all = False
+        pager = False
 
-    # run buildtest inspect buildspec $BUILDTEST_ROOT/tutorials/vars.yml $BUILDTEST_ROOT/tutorials/pass_returncode.yml
+    # buildtest inspect buildspec $BUILDTEST_ROOT/tutorials/vars.yml $BUILDTEST_ROOT/tutorials/pass_returncode.yml
     inspect_cmd(args)
 
     class args:
@@ -168,8 +170,9 @@ def test_buildspec_inspect_buildspec():
         buildspec = search_buildspec
         report = None
         all = True
+        pager = True
 
-    # run buildtest inspect buildspec --all $BUILDTEST_ROOT/tutorials/vars.yml $BUILDTEST_ROOT/tutorials/pass_returncode.yml
+    # buildtest inspect buildspec --all --pager $BUILDTEST_ROOT/tutorials/vars.yml $BUILDTEST_ROOT/tutorials/pass_returncode.yml
     inspect_cmd(args)
 
 

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -11,7 +11,7 @@ from rich.color import Color
 
 
 def test_buildtest_inspect_list():
-    # running buildtest inspect list
+    # buildtest inspect list
     class args:
         subcommands = "inspect"
         inspect = "list"
@@ -19,10 +19,23 @@ def test_buildtest_inspect_list():
         no_header = False
         builder = False
         color = Color.default().name
+        pager = False
 
     inspect_cmd(args)
 
-    # running buildtest inspect list --terse --no-header
+    # buildtest inspect list --pager
+    class args:
+        subcommands = "inspect"
+        inspect = "list"
+        terse = False
+        no_header = False
+        builder = False
+        color = Color.default().name
+        pager = True
+
+    inspect_cmd(args)
+
+    # buildtest inspect list --terse --no-header
     class args:
         subcommands = "inspect"
         inspect = "list"
@@ -30,10 +43,11 @@ def test_buildtest_inspect_list():
         no_header = True
         builder = False
         color = False
+        pager = False
 
     inspect_cmd(args)
 
-    # running buildtest inspect list --terse
+    # buildtest inspect list --terse --pager
     class args:
         subcommands = "inspect"
         inspect = "list"
@@ -41,10 +55,11 @@ def test_buildtest_inspect_list():
         no_header = False
         builder = False
         color = False
+        pager = True
 
     inspect_cmd(args)
 
-    # running buildtest inspect list --builder
+    # buildtest inspect list --builder
     class args:
         subcommands = "inspect"
         inspect = "list"
@@ -52,6 +67,19 @@ def test_buildtest_inspect_list():
         no_header = False
         builder = True
         color = False
+        pager = False
+
+    inspect_cmd(args)
+
+    # buildtest inspect list --builder --pager
+    class args:
+        subcommands = "inspect"
+        inspect = "list"
+        terse = False
+        no_header = False
+        builder = True
+        color = False
+        pager = True
 
     inspect_cmd(args)
 

--- a/tests/cli/test_inspect.py
+++ b/tests/cli/test_inspect.py
@@ -209,7 +209,7 @@ def test_buildtest_query():
 
     # buildtest inspect query stream_test
     # the 'stream_test' will add coverage where metrics are printed in output of 'buildtest inspect query'
-    iinspect_cmd(args)
+    inspect_cmd(args)
 
     class args:
         subcommands = "inspect"


### PR DESCRIPTION
Hi @shahzebsiddiqui I have added pagination for buildtest inspect subcommands. I have also refactored the function `inspect_list()` as the terse option in it was using hardcoded column names without a color option. Please review the PR.

<img width="1071" alt="Screen Shot 2023-03-21 at 1 29 26 PM" src="https://user-images.githubusercontent.com/35829130/226734083-f9aaf15e-a7da-4e60-963b-76a4b26df830.png">

<img width="1678" alt="Screen Shot 2023-03-21 at 1 35 12 PM" src="https://user-images.githubusercontent.com/35829130/226734378-b4f94996-ea75-41df-a0bc-6ee3bea3ccf9.png">
