### PR TITLE
remove codecov from pypi dependency 

### DIFF
--- a/.gitlab/ascent.yml
+++ b/.gitlab/ascent.yml
@@ -27,7 +27,9 @@ ascent_pr_regression_test:
     - pip install -r docs/requirements.txt
     - python $BUILDTEST_ROOT/buildtest/tools/unittests.py -c
     - echo $?
+    - curl -Os https://uploader.codecov.io/latest/linux/codecov
+    - chmod +x codecov
     # CODECOV_TOKEN environment must be set, this value is stored in CI/CD variable at https://code.ornl.gov/ecpcitest/buildtest/-/settings/ci_cd
-    - codecov -t $CODECOV_TOKEN
+    - ./codecov -t $CODECOV_TOKEN
     - source deactivate
     - rm -rf $CI_PROJECT_DIR/.conda

--- a/.gitlab/nersc.yml
+++ b/.gitlab/nersc.yml
@@ -26,6 +26,8 @@ cori_pr_regression_test:
     - pip install -r docs/requirements.txt
     - python $BUILDTEST_ROOT/buildtest/tools/unittests.py -c
     - echo $?
+    - curl -Os https://uploader.codecov.io/latest/linux/codecov
+    - chmod +x codecov
     # CODECOV_TOKEN environment must be set, this value is stored in CI/CD variable at https://software.nersc.gov/NERSC/buildtest/-/settings/ci_cd
     - codecov -t $CODECOV_TOKEN
     - source deactivate
@@ -52,6 +54,8 @@ perlmutter_regression_test:
     - pip install -r docs/requirements.txt
     - python $BUILDTEST_ROOT/buildtest/tools/unittests.py -c
     - echo $?
+    - curl -Os https://uploader.codecov.io/latest/linux/codecov
+    - chmod +x codecov
     # CODECOV_TOKEN environment must be set, this value is stored in CI/CD variable at https://software.nersc.gov/NERSC/buildtest/-/settings/ci_cd
     - codecov -t $CODECOV_TOKEN
     - source deactivate

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-codecov
 # issue with rendering bullet points in sphinx docutils 0.17 or higher see https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file
 docutils==0.16
 pre-commit


### PR DESCRIPTION
@prathmesh4321 and @Xiangs18 just a heads up. I recently noticed `codecov` is not available in pypi so i reported an issue https://github.com/codecov/uploader/issues/1019 this was caused by CI failure in https://github.com/buildtesters/buildtest/pull/1435 in particular it was the docs build


![Screen Shot 2023-04-13 at 5 27 35 PM](https://user-images.githubusercontent.com/12942230/231886765-e8d701e1-27f6-4c43-8b3a-ef76c533fc98.png)

So i am going to remove this apparently if you have a python environment setup with `codecov` you may still have the binary 

```
(buildtest)  ~/Documents/github/buildtest/ [remove_codecov_from_deps] pip list | grep codecov 
codecov                        2.1.12
```

I think they want us to use the new uploader described in https://docs.codecov.com/docs/codecov-uploader which is to download via `curl`. 