### PR TITLE
add support for configuring 'buildtest buildspec find' through configuration file

### DIFF
--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -230,12 +230,12 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
 
         parent_parser["pager"] = argparse.ArgumentParser(add_help=False)
         parent_parser["pager"].add_argument(
-            "--pager", help="Enable PAGING when viewing result"
+            "--pager", action="store_true", help="Enable PAGING when viewing result"
         )
 
         parent_parser["file"] = argparse.ArgumentParser(add_help=False)
         parent_parser["file"].add_argument(
-            "--file", help="Wrtie configuration file to a new file"
+            "--file", help="Write configuration file to a new file"
         )
         return parent_parser
 

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -778,7 +778,7 @@ class BuildspecCache:
         """
 
         # Don't print anything if --quiet is set
-        if quiet:
+        if quiet and self.rebuild:
             return
 
         self.terse = terse or self.terse

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -84,7 +84,9 @@ class BuildspecCache:
             "buildspecs"
         ].get("formatfields")
         self.header = header
-        self.pager = pager
+        self.pager = pager or self.configuration.target_config["buildspecs"].get(
+            "pager"
+        )
         self.count = count or self.configuration.target_config["buildspecs"].get(
             "count"
         )

--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -80,10 +80,14 @@ class BuildspecCache:
 
         self.configuration = configuration
         self.filter = filterfields
-        self.format = formatfields
+        self.format = formatfields or self.configuration.target_config[
+            "buildspecs"
+        ].get("formatfields")
         self.header = header
         self.pager = pager
-        self.count = count
+        self.count = count or self.configuration.target_config["buildspecs"].get(
+            "count"
+        )
         # if --root is not specified we set to empty list instead of None
         self.roots = roots or []
 
@@ -93,10 +97,14 @@ class BuildspecCache:
         # stores invalid buildspecs and the error messages
         self.invalid_buildspecs = {}
 
-        self.terse = terse
+        self.terse = terse or self.configuration.target_config["buildspecs"].get(
+            "terse"
+        )
         self.color = checkColor(color)
 
-        self.rebuild = rebuild
+        self.rebuild = rebuild or self.configuration.target_config["buildspecs"].get(
+            "rebuild"
+        )
         self.cache = {}
 
         self.load_paths()

--- a/buildtest/schemas/settings.schema.json
+++ b/buildtest/schemas/settings.schema.json
@@ -96,6 +96,11 @@
             "terse": {
               "type": "boolean",
               "description": "A boolean to determine whether to enable terse mode when viewing buildspec cache"
+            },
+            "pager":
+            {
+              "type": "boolean",
+              "description": "A boolean to determine whether to enable paging when viewing buildspec cache"
             }
           }
         },

--- a/buildtest/schemas/settings.schema.json
+++ b/buildtest/schemas/settings.schema.json
@@ -74,6 +74,31 @@
           "minimum": 1,
           "description": "Specify timeout duration in number of seconds"
         },
+        "buildspecs":
+        {
+          "type": "object",
+          "description": "Specify configuration for ``buildtest buildspec`` command",
+          "additionalProperties": false,
+          "properties": {
+            "rebuild": {
+              "type": "boolean",
+              "description": "A boolean to determine whether to rebuild buildspec cache"
+            },
+            "count": {
+              "type": "integer",
+               "minimum": 1,
+              "description": "Determine number of records to display when running ``buildtest buildspec find``"
+            },
+            "formatfields": {
+              "type": "string",
+              "description": "Determine the format fields to display when running ``buildtest buildspec find``"
+            },
+            "terse": {
+              "type": "boolean",
+              "description": "A boolean to determine whether to enable terse mode when viewing buildspec cache"
+            }
+          }
+        },
         "processor": {
           "type": "object",
           "description": "Specify processor information",

--- a/buildtest/settings/config.yml
+++ b/buildtest/settings/config.yml
@@ -14,6 +14,16 @@ system:
     # pool size for parallel processing using multiprocessing.Pool. Pool Size must be 1 or higher. The pool size is calculated as follows: poolsize = min(poolsize, os.cpu_count())
     poolsize: 1
 
+    buildspecs:
+      # whether to rebuild cache file automatically when running `buildtest buildspec find`
+      rebuild: False
+      # limit number of records to display when running `buildtest buildspec find`
+      count: 15
+      # format fields to display when running `buildtest buildspec find`, By default we will show name,description
+      formatfields: "name,description"
+
+      # enable terse mode
+      terse: False
     executors:
       # define local executors for running jobs locally
       local:

--- a/buildtest/settings/config.yml
+++ b/buildtest/settings/config.yml
@@ -24,6 +24,9 @@ system:
 
       # enable terse mode
       terse: False
+
+      # determine whether to enable pagination
+      pager: False
     executors:
       # define local executors for running jobs locally
       local:

--- a/buildtest/settings/config.yml
+++ b/buildtest/settings/config.yml
@@ -21,10 +21,8 @@ system:
       count: 15
       # format fields to display when running `buildtest buildspec find`, By default we will show name,description
       formatfields: "name,description"
-
       # enable terse mode
       terse: False
-
       # determine whether to enable pagination
       pager: False
     executors:

--- a/docs/configuring_buildtest/overview.rst
+++ b/docs/configuring_buildtest/overview.rst
@@ -118,31 +118,6 @@ configure buildtest to use the module tool. This can be defined via ``moduletool
 
 The `moduletool` property is used for :ref:`detecting compilers <detect_compilers>` when you run ``buildtest config compilers find``.
 
-.. _buildspec_roots:
-
-buildspec roots
------------------
-
-buildtest can discover buildspec using ``buildspec_roots`` keyword. This field is a list
-of directory paths to search for buildspecs. For example we clone the repo
-https://github.com/buildtesters/buildtest-nersc at **$HOME/buildtest-nersc** and assign
-this to **buildspec_roots** as follows:
-
-.. code-block:: yaml
-
-    buildspec_roots:
-      - $HOME/buildtest-nersc
-
-This field is used with the ``buildtest buildspec find`` command. If you rebuild
-your buildspec cache via ``--rebuild`` option, buildtest will search for all buildspecs in
-directories specified by **buildspec_roots** property. buildtest will recursively
-find all **.yml** extension and validate each buildspec with appropriate schema.
-
-By default buildtest will add the ``$BUILDTEST_ROOT/tutorials`` and ``$BUILDTEST_ROOT/general_tests``
-to search path when searching for buildspecs with ``buildtest buildspec find`` command. This
-is only true if there is no root buildspec directory specified which can be done via `buildspec_roots`
-or `--root` option.
-
 .. _configuring_executors:
 
 Configuring Executors
@@ -399,7 +374,7 @@ Alternately, you can override configuration setting via ``buildtest build --acco
 for all batch jobs.
 
 Poll Interval
-----------------
+~~~~~~~~~~~~~~
 
 The ``pollinterval`` field is used  to poll jobs at set interval in seconds
 when job is active in queue. The poll interval can be configured on command line
@@ -411,7 +386,7 @@ using ``buildtest build --pollinterval`` which overrides the configuration value
 
 
 Max Pend Time
----------------
+~~~~~~~~~~~~~~
 
 The ``maxpendtime`` is **maximum** time job can be pending
 within an executor, if it exceeds the limit buildtest will cancel the job.
@@ -441,7 +416,7 @@ For more details on `maxpendtime` click :ref:`here <max_pend_time>`.
 .. _pbs_executors:
 
 PBS Executors
---------------
+~~~~~~~~~~~~~~
 
 .. Note:: buildtest PBS support relies on job history set because buildtest needs to query job after completion using ``qstat -x``. This
           can be configured using ``qmgr`` by setting ``set server job_history_enable=True``. For more details see section **14.15.5.1 Enabling Job History** in `PBS 2021.1.3 Admin Guide <https://help.altair.com/2021.1.3/PBS%20Professional/PBSAdminGuide2021.1.3.pdf>`_
@@ -542,6 +517,57 @@ based on platform (Linux, Mac).
 
 The buildtest logs will start with **buildtest_** followed by random identifier with
 a **.log** extension.
+
+Configuring Buildspec Cache
+----------------------------
+
+The :ref:`buildtest buildspec find <find_buildspecs>`_ command can be configured using the configuration file to provide sensible
+defaults. This can be shown in the configuration file below:
+
+.. code-block::
+
+    :language: yaml
+
+        buildspecs:
+          # whether to rebuild cache file automatically when running `buildtest buildspec find`
+          rebuild: False
+          # limit number of records to display when running `buildtest buildspec find`
+          count: 15
+          # format fields to display when running `buildtest buildspec find`, By default we will show name,description
+          formatfields: "name,description"
+          # enable terse mode
+          terse: False
+          # determine whether to enable pagination
+          pager: False
+
+Each configuration can be overridden by command line option. For instance, the default behavior for pagination is disabled
+with ``pager: False`` but if you want to enable pagination you can run ``buildtest buildspec find --pager``.
+
+.. _buildspec_roots:
+
+buildspec roots
+-----------------
+
+buildtest can discover buildspec using ``buildspec_roots`` keyword. This field is a list
+of directory paths to search for buildspecs. For example we clone the repo
+https://github.com/buildtesters/buildtest-nersc at **$HOME/buildtest-nersc** and assign
+this to **buildspec_roots** as follows:
+
+.. code-block:: yaml
+
+    buildspec_roots:
+      - $HOME/buildtest-nersc
+
+This field is used with the ``buildtest buildspec find`` command. If you rebuild
+your buildspec cache via ``--rebuild`` option, buildtest will search for all buildspecs in
+directories specified by **buildspec_roots** property. buildtest will recursively
+find all **.yml** extension and validate each buildspec with appropriate schema.
+
+By default buildtest will add the ``$BUILDTEST_ROOT/tutorials`` and ``$BUILDTEST_ROOT/general_tests``
+to search path when searching for buildspecs with ``buildtest buildspec find`` command. This
+is only true if there is no root buildspec directory specified which can be done via `buildspec_roots`
+or `--root` option.
+
 
 .. _cdash_configuration:
 

--- a/docs/configuring_buildtest/overview.rst
+++ b/docs/configuring_buildtest/overview.rst
@@ -521,12 +521,10 @@ a **.log** extension.
 Configuring Buildspec Cache
 ----------------------------
 
-The :ref:`buildtest buildspec find <find_buildspecs>`_ command can be configured using the configuration file to provide sensible
+The :ref:`buildtest buildspec find <find_buildspecs>` command can be configured using the configuration file to provide sensible
 defaults. This can be shown in the configuration file below:
 
-.. code-block::
-
-    :language: yaml
+.. code-block:: yaml
 
         buildspecs:
           # whether to rebuild cache file automatically when running `buildtest buildspec find`


### PR DESCRIPTION
This PR can control behavior of few options in `buildtest buildspec find` that will be exposed during the default configuration file.