### PR TITLE
fix error in config file for buildtest tutorials

### DIFF
--- a/buildtest/settings/spack_container.yml
+++ b/buildtest/settings/spack_container.yml
@@ -10,9 +10,19 @@ system:
     buildspecs:
       rebuild: False
       count: 15
-      formatfields: "name,description"
+      format: "name,description"
       terse: False
       root: [$BUILDTEST_ROOT/examples]
+
+    report:
+      count: 25
+      #enable terse mode for report
+      terse: False
+      format: "name,id,state,runtime,returncode"
+      # show the latest for every test
+      latest: True
+      # show the oldest for every test
+      oldest: False
 
     executors:
       local:

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -510,7 +510,7 @@ class TestBuildTest:
             configuration=configuration,
             buildspecs=buildspecs,
             buildtest_system=self.system,
-            retry=3,
+            retry=2,
         )
         cmd.build()
 

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -510,7 +510,7 @@ class TestBuildTest:
             configuration=configuration,
             buildspecs=buildspecs,
             buildtest_system=self.system,
-            retry=2,
+            retry=3,
         )
         cmd.build()
 


### PR DESCRIPTION
Added report and fixed the syntax for  `format` in the file [buildtest/settings/spack_container.yml](url).  Closes #1508 