### PR TITLE
fix issue with running buildtest with multiprocessing library

### DIFF
--- a/bin/buildtest
+++ b/bin/buildtest
@@ -31,6 +31,8 @@ sys.path.insert(0, prefix)
 if sys.version_info[:3] < (3, 8, 0):
     sys.exit("buildtest requires Python 3.8.0 or higher.")
 
-import buildtest.main
+from buildtest.main import main
 
-buildtest.main.main()
+if __name__ == "__main__":
+
+  sys.exit(main())


### PR DESCRIPTION
we were seeing issue with running `buildtest build` command on mac with some error message like this

```
│ /usr/local/Cellar/python@3.10/3.10.12/Frameworks/Python.framework/Versions/3.10/lib/python3.10/m │
│ ultiprocessing/spawn.py:134 in _check_not_importing_main                                         │
│                                                                                                  │
│   131                                                                                            │
│   132 def _check_not_importing_main():                                                           │
│   133 │   if getattr(process.current_process(), '_inheriting', False):                           │
│ ❱ 134 │   │   raise RuntimeError('''                                                             │
│   135 │   │   An attempt has been made to start a new process before the                         │
│   136 │   │   current process has finished its bootstrapping phase.                              │
│   137                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
RuntimeError: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.

```

This was because the entry point to `buildtest` command wasnt invoked in `if __name__`. This was discovered according to https://superfastpython.com/multiprocessing-spawn-runtimeerror/. Note that if one runs `python buildtest/main.py build -t pass` it should work without this change. With this change it should work both ways.