### PR TITLE
Add Coverage to check runtime status

### DIFF
--- a/tests/builders/runtime_status_test.yml
+++ b/tests/builders/runtime_status_test.yml
@@ -1,0 +1,1 @@
+../../tutorials/test_status/runtime_status_test.yml

--- a/tests/builders/test_builders.py
+++ b/tests/builders/test_builders.py
@@ -174,3 +174,13 @@ def test_file_regex():
         configuration=config,
     )
     cmd.build()
+
+
+def test_runtime_check():
+    """This test will perform status check with runtime"""
+    cmd = BuildTest(
+        buildspecs=[os.path.join(here, "runtime_status_test.yml")],
+        buildtest_system=system,
+        configuration=config,
+    )
+    cmd.build()


### PR DESCRIPTION
This test will add coverage in the runtime status check for the case when only max runtime is specified and for the case when both max and min runtime are specified in the buildspec.