### PR TITLE
Add --detailed feature to buidltest report commandDetailed option

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -219,7 +219,7 @@ _buildtest ()
       ;;
 
     report|rt)
-      local opts="--end --fail --filter --filterfields --format --formatfields --help --helpfilter --helpformat --latest --no-header --oldest --pager --pass --row-count --start --terse  -e -f -h -n -p -s -t c clear l list p path sm summary"
+      local opts="--detailed --end --fail --filter --filterfields --format --formatfields --help --helpfilter --helpformat --latest --no-header --oldest --pager --pass --row-count --start --terse  -d -e -f -h -n -p -s -t c clear l list p path sm summary"
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       case "${prev}" in --filter)
         COMPREPLY=( $( compgen -W "$(_avail_report_filterfields)" -- $cur ) )

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -1104,6 +1104,13 @@ def report_menu(subparsers, parent_parser):
 
     # buildtest report
     filter_group.add_argument(
+        "-d",
+        "--detailed",
+        action="store_true",
+        help="Print a detailed summary of the test results",
+    )
+
+    filter_group.add_argument(
         "--filter",
         type=handle_kv_string,
         help="Filter report by filter fields. The filter fields must be a key=value pair and multiple fields can be comma separated in the following format: --filter key1=val1,key2=val2 . For list of filter fields run: --helpfilter.",

--- a/tests/builders/test_builders.py
+++ b/tests/builders/test_builders.py
@@ -174,3 +174,16 @@ def test_file_regex():
         configuration=config,
     )
     cmd.build()
+
+
+def test_runtime_check():
+    """This test will perform status check with runtime"""
+    cmd = BuildTest(
+        buildspecs=[
+            os.path.join(here, "runtime_status_test.yml"),
+        ],
+        buildtest_system=system,
+        configuration=config,
+    )
+    cmd.build()
+


### PR DESCRIPTION
This new feature will let the user to run
buildtest rt --format name,id,user,state,returncode,runtime,outfile,errfile,buildspec --count=1
By running
buildtest rt --detailed