### PR TITLE
Add --detailed option for buildtest report

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -219,7 +219,7 @@ _buildtest ()
       ;;
 
     report|rt)
-      local opts="--end --fail --filter --filterfields --format --formatfields --help --helpfilter --helpformat --latest --no-header --oldest --pager --pass --row-count --start --terse  -e -f -h -n -p -s -t c clear l list p path sm summary"
+      local opts="--detailed --end --fail --filter --filterfields --format --formatfields --help --helpfilter --helpformat --latest --no-header --oldest --pager --pass --row-count --start --terse -d -e -f -h -n -p -s -t c clear l list p path sm summary"
       COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
       case "${prev}" in --filter)
         COMPREPLY=( $( compgen -W "$(_avail_report_filterfields)" -- $cur ) )

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -1123,15 +1123,11 @@ def report_menu(subparsers, parent_parser):
     )
 
     format_group = parser_report.add_argument_group("format", "Format options")
+    format_detailed_group = parser_report.add_mutually_exclusive_group()
 
-    # buildtest report
-    format_group.add_argument(
+    format_detailed_group.add_argument(
         "--format",
-        type=handle_kv_string,
-        help="Format report by format fields. The format fields must be a key=value pair and multiple fields can be comma separated in the following format: --format key1=val1,key2=val2 . For list of format fields run: --helpformat.",
-    )
-    format_group.add_argument(
-        "-d", "--detailed", help="Print a detailed summary of the test results", action="store_true",
+        help="format field for printing purposes. For more details see --helpformat for list of available fields. Fields must be separated by comma (usage: --format <field1>,<field2>,...)",
     )
 
     format_group.add_argument(
@@ -1142,6 +1138,13 @@ def report_menu(subparsers, parent_parser):
         "--formatfields",
         action="store_true",
         help="Print raw format fields for --format option to format the report",
+    )
+
+    format_detailed_group.add_argument(
+        "-d",
+        "--detailed",
+        help="Print a detailed summary of the test results",
+        action="store_true",
     )
 
     pass_fail = parser_report.add_mutually_exclusive_group()
@@ -1176,6 +1179,7 @@ def report_menu(subparsers, parent_parser):
     parser_report_summary.add_argument(
         "--detailed", "-d", action="store_true", help="Enable a more detailed report"
     )
+
 
 def inspect_menu(subparsers, parent_parser):
     """This method builds argument for ``buildtest inspect`` command

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -1104,13 +1104,6 @@ def report_menu(subparsers, parent_parser):
 
     # buildtest report
     filter_group.add_argument(
-        "-d",
-        "--detailed",
-        action="store_true",
-        help="Print a detailed summary of the test results",
-    )
-
-    filter_group.add_argument(
         "--filter",
         type=handle_kv_string,
         help="Filter report by filter fields. The filter fields must be a key=value pair and multiple fields can be comma separated in the following format: --filter key1=val1,key2=val2 . For list of filter fields run: --helpfilter.",
@@ -1167,10 +1160,15 @@ def report_menu(subparsers, parent_parser):
         help="Retrieve oldest record of particular test",
         action="store_true",
     )
+    parser_report.add_argument(
+        "-d",
+        "--detailed",
+        action="store_true",
+        help="Print a detailed summary of the test results",
+    )
     parser_report_summary.add_argument(
         "--detailed", "-d", action="store_true", help="Enable a more detailed report"
     )
-
 
 def inspect_menu(subparsers, parent_parser):
     """This method builds argument for ``buildtest inspect`` command

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -1104,6 +1104,13 @@ def report_menu(subparsers, parent_parser):
 
     # buildtest report
     filter_group.add_argument(
+        "-d",
+        "--detailed",
+        action="store_true",
+        help="Print a detailed summary of the test results",
+    )
+
+    filter_group.add_argument(
         "--filter",
         type=handle_kv_string,
         help="Filter report by filter fields. The filter fields must be a key=value pair and multiple fields can be comma separated in the following format: --filter key1=val1,key2=val2 . For list of filter fields run: --helpfilter.",

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -604,6 +604,7 @@ def build_menu(subparsers):
         action="store_true",
         help="Rerun last successful buildtest build command.",
     )
+
     filter_group.add_argument(
         "-f",
         "--filter",
@@ -1100,7 +1101,7 @@ def report_menu(subparsers, parent_parser):
         help="Summarize test report",
         parents=[parent_parser["pager"]],
     )
-    filter_group = parser_report.add_argument_group("filter", "Filter and Format table")
+    filter_group = parser_report.add_argument_group("filter", "Filter options")
 
     # buildtest report
     filter_group.add_argument(
@@ -1110,27 +1111,39 @@ def report_menu(subparsers, parent_parser):
     )
 
     filter_group.add_argument(
-        "--format",
-        help="format field for printing purposes. For more details see --helpformat for list of available fields. Fields must be separated by comma (usage: --format <field1>,<field2>,...)",
-    )
-    filter_group.add_argument(
         "--helpfilter",
         action="store_true",
         help="List available filter fields to be used with --filter option",
     )
-    filter_group.add_argument(
-        "--helpformat", action="store_true", help="List of available format fields"
-    )
+
     filter_group.add_argument(
         "--filterfields",
         action="store_true",
         help="Print raw filter fields for --filter option to filter the report",
     )
-    filter_group.add_argument(
+
+    format_group = parser_report.add_argument_group("format", "Format options")
+
+    # buildtest report
+    format_group.add_argument(
+        "--format",
+        type=handle_kv_string,
+        help="Format report by format fields. The format fields must be a key=value pair and multiple fields can be comma separated in the following format: --format key1=val1,key2=val2 . For list of format fields run: --helpformat.",
+    )
+    format_group.add_argument(
+        "-d", "--detailed", help="Print a detailed summary of the test results", action="store_true",
+    )
+
+    format_group.add_argument(
+        "--helpformat", action="store_true", help="List of available format fields"
+    )
+
+    format_group.add_argument(
         "--formatfields",
         action="store_true",
         help="Print raw format fields for --format option to format the report",
     )
+
     pass_fail = parser_report.add_mutually_exclusive_group()
 
     pass_fail.add_argument(
@@ -1159,12 +1172,6 @@ def report_menu(subparsers, parent_parser):
         "--oldest",
         help="Retrieve oldest record of particular test",
         action="store_true",
-    )
-    parser_report.add_argument(
-        "-d",
-        "--detailed",
-        action="store_true",
-        help="Print a detailed summary of the test results",
     )
     parser_report_summary.add_argument(
         "--detailed", "-d", action="store_true", help="Enable a more detailed report"

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -1123,12 +1123,6 @@ def report_menu(subparsers, parent_parser):
     )
 
     format_group = parser_report.add_argument_group("format", "Format options")
-    format_detailed_group = parser_report.add_mutually_exclusive_group()
-
-    format_detailed_group.add_argument(
-        "--format",
-        help="format field for printing purposes. For more details see --helpformat for list of available fields. Fields must be separated by comma (usage: --format <field1>,<field2>,...)",
-    )
 
     format_group.add_argument(
         "--helpformat", action="store_true", help="List of available format fields"
@@ -1138,6 +1132,12 @@ def report_menu(subparsers, parent_parser):
         "--formatfields",
         action="store_true",
         help="Print raw format fields for --format option to format the report",
+    )
+
+    format_detailed_group = parser_report.add_mutually_exclusive_group()
+    format_detailed_group.add_argument(
+        "--format",
+        help="format field for printing purposes. For more details see --helpformat for list of available fields. Fields must be separated by comma (usage: --format <field1>,<field2>,...)",
     )
 
     format_detailed_group.add_argument(

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -1,3 +1,4 @@
+import argparse
 import datetime
 import logging
 import os
@@ -109,7 +110,7 @@ class Report:
             oldest (bool, optional): Fetch oldest run for all tests discovered. This is specified via ``buildtest report --oldest``
             count (int, optional): Fetch limited number of rows get printed for all tests discovered. This is specified via ``buildtest report --count``
             pager (bool, optional): Enabling PAGING output for ``buildtest report``. This can be specified via ``buildtest report --pager``
-            format_detailed(bool,optional): Print a detailed summary of the test results. This can be specified via ``buildtest report --detailed``
+            format_detailed(bool, optional): Print a detailed summary of the test results. This can be specified via ``buildtest report --detailed``
             color (str, optional): An instance of a string class that tells print_report what color the output should be printed in.
 
         """

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -78,21 +78,22 @@ class Report:
     }
 
     def __init__(
-            self,
-            configuration,
-            report_file=None,
-            filter_args=None,
-            format_args=None,
-            start=None,
-            end=None,
-            failure=None,
-            passed=None,
-            latest=None,
-            oldest=None,
-            count=None,
-            pager=None,
-            detailed=None,
-            color=None,
+        self,
+        configuration,
+        report_file=None,
+        filter_args=None,
+        format_args=None,
+        start=None,
+        end=None,
+        failure=None,
+        passed=None,
+        latest=None,
+        oldest=None,
+        count=None,
+        pager=None,
+        format_detailed=None,
+        detailed=None,
+        color=None,
     ):
         """
         Args:
@@ -125,6 +126,11 @@ class Report:
         self.pager = pager
         self.color = color
         self.input_report = report_file
+
+        if format_detailed:
+            self.format = (
+                "name,id,user,state,returncode,runtime,outfile,errfile,buildspec"
+            )
 
         # if no report specified use default report
         if not self.input_report:
@@ -371,7 +377,7 @@ class Report:
         """
 
         if self.filter.get("executor") and self.filter.get("executor") != test.get(
-                "executor"
+            "executor"
         ):
             return True
 
@@ -516,13 +522,13 @@ class Report:
             console.print(field)
 
     def print_report(
-            self,
-            terse=None,
-            row_count=None,
-            noheader=None,
-            title=None,
-            count=None,
-            color=None,
+        self,
+        terse=None,
+        row_count=None,
+        noheader=None,
+        title=None,
+        count=None,
+        color=None,
     ):
         """This method will print report table after processing report file. By default we print output in
         table format but this can be changed to terse format which will print output in parseable format.
@@ -828,6 +834,7 @@ def report_cmd(args, configuration, report_file=None):
         oldest=args.oldest,
         report_file=report_file,
         count=args.count,
+        format_detailed=args.detailed,
     )
 
     if args.report_subcommand in ["path", "p"]:
@@ -851,10 +858,6 @@ def report_cmd(args, configuration, report_file=None):
             color=consoleColor,
             configuration=configuration,
         )
-        return
-
-    if args.detailed:
-        report_detailed(results, configuration)
         return
 
     if args.helpfilter:
@@ -934,7 +937,7 @@ def report_summary(report, configuration, detailed=None, color=None):
 
 
 def print_report_summary_output(
-        report, table, pass_results, fail_results, color=None, detailed=None
+    report, table, pass_results, fail_results, color=None, detailed=None
 ):
     """Print output of ``buildtest report summary``.
 
@@ -958,17 +961,3 @@ def print_report_summary_output(
     console.print(table)
     pass_results.print_report(title="PASS Tests", color=color)
     fail_results.print_report(title="FAIL Tests", color=color)
-
-
-def report_detailed(report, configuration):
-    """This method will print detailed summary test results which can be retrieved via ``buildtest report --detailed`` command
-    Args:
-        report (buildtest.cli.report.Report): An instance of Report class
-        configuration (buildtest.config.SiteConfiguration): Instance of SiteConfiguration class that is loaded buildtest configuration.
-    """
-    detailed_results = Report(
-        format_args="name,id,user,state,returncode,runtime,outfile,errfile,buildspec",
-        report_file=report.reportfile(),
-        configuration=configuration,
-    )
-    detailed_results.print_report(count=1)

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -1,4 +1,3 @@
-import argparse
 import datetime
 import logging
 import os
@@ -129,15 +128,16 @@ class Report:
         self.color = color
         self.input_report = report_file
 
-        try:
-            report=Report(configuration=configuration, format_detailed=True, format_args="name,id,user")
-        except argparse.ArgumentError:
-            console.print_exception()
-            return True
-
+        # if detailed option is specified
         if format_detailed:
             self.format = (
                 "name,id,user,state,returncode,runtime,outfile,errfile,buildspec"
+            )
+
+        # if both format and detailed options are specified
+        if format_detailed and format_args:
+            raise BuildTestError(
+                "Argument -d/--detailed is not allowed with argument --format"
             )
 
         # if no report specified use default report

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -854,7 +854,7 @@ def report_cmd(args, configuration, report_file=None):
         return
 
     if args.detailed:
-        report_detailed()
+        report_detailed(results,configuration)
         return
 
     if args.helpfilter:
@@ -959,6 +959,7 @@ def print_report_summary_output(
     pass_results.print_report(title="PASS Tests", color=color)
     fail_results.print_report(title="FAIL Tests", color=color)
 
+
 def report_detailed(report, configuration):
     """This method will print detailed summary test results which can be retrieved via ``buildtest report --detailed`` command
     Args:
@@ -970,8 +971,4 @@ def report_detailed(report, configuration):
         report_file=report.reportfile(),
         configuration=configuration,
     )
-    detailed_results.print_report(
-        terse=False,
-        row_count=1,
-        args_count=9,
-    )
+    detailed_results.print_report(count=1)

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -28,34 +28,77 @@ def is_int(val):
 
 class Report:
     # list of format fields
-    format_field_description = {"buildspec": "Buildspec File", "buildenv": "Show build environment file for test",
-        "command": "Command executed", "compiler": "Retrieve compiler used for test (applicable for compiler schema)",
-        "endtime": "End Time for test", "errfile": "Error File", "executor": "Name of executor used for running test",
-        "hostname": "Hostname of machine where job was submitted from", "full_id": "Fully qualified build identifier",
-        "id": "Unique build identifier", "metrics": "List all metrics for test", "name": "Name of test",
-        "outfile": "Output file", "returncode": "Return Code", "runtime": "Total runtime in seconds",
-        "schemafile": "Schema file used for validating test", "starttime": "Start time of test",
-        "state": "State of test (PASS/FAIL)", "tags": "Tag name", "testroot": "Root of test directory",
-        "testpath": "Path to test", "user": "User who ran the test", }
-    filter_field_description = {"buildspec": {"description": "Filter by buildspec file", "type": "FILE"},
+    format_field_description = {
+        "buildspec": "Buildspec File",
+        "buildenv": "Show build environment file for test",
+        "command": "Command executed",
+        "compiler": "Retrieve compiler used for test (applicable for compiler schema)",
+        "endtime": "End Time for test",
+        "errfile": "Error File",
+        "executor": "Name of executor used for running test",
+        "hostname": "Hostname of machine where job was submitted from",
+        "full_id": "Fully qualified build identifier",
+        "id": "Unique build identifier",
+        "metrics": "List all metrics for test",
+        "name": "Name of test",
+        "outfile": "Output file",
+        "returncode": "Return Code",
+        "runtime": "Total runtime in seconds",
+        "schemafile": "Schema file used for validating test",
+        "starttime": "Start time of test",
+        "state": "State of test (PASS/FAIL)",
+        "tags": "Tag name",
+        "testroot": "Root of test directory",
+        "testpath": "Path to test",
+        "user": "User who ran the test",
+    }
+    filter_field_description = {
+        "buildspec": {"description": "Filter by buildspec file", "type": "FILE"},
         "name": {"description": "Filter by test name", "type": "STRING"},
         "executor": {"description": "Filter by executor name", "type": "STRING"},
         "returncode": {"description": "Filter tests by returncode", "type": "INT"},
         "state": {"description": "Filter by test state", "type": "PASS/FAIL"},
-        "tags": {"description": "Filter tests by tag name", "type": "STRING"}, }
+        "tags": {"description": "Filter tests by tag name", "type": "STRING"},
+    }
     format_fields = format_field_description.keys()
     # list of filter fields
     filter_fields = filter_field_description.keys()
 
     # default table format fields
-    display_table = {"name": [], "id": [], "state": [], "returncode": [], "starttime": [], "endtime": [], "runtime": [],
-        "tags": [], "buildspec": [], }
+    display_table = {
+        "name": [],
+        "id": [],
+        "state": [],
+        "returncode": [],
+        "starttime": [],
+        "endtime": [],
+        "runtime": [],
+        "tags": [],
+        "buildspec": [],
+    }
 
-    format_fields_detailed = ("name,id,user,state,returncode,runtime,outfile,errfile,buildspec")
+    format_fields_detailed = (
+        "name,id,user,state,returncode,runtime,outfile,errfile,buildspec"
+    )
 
-    def __init__(self, configuration, report_file=None, filter_args=None, format_args=None, start=None, end=None,
-            failure=None, passed=None, latest=None, oldest=None, count=None, pager=None, format_detailed=None,
-            detailed=None, color=None, ):
+    def __init__(
+        self,
+        configuration,
+        report_file=None,
+        filter_args=None,
+        format_args=None,
+        start=None,
+        end=None,
+        failure=None,
+        passed=None,
+        latest=None,
+        oldest=None,
+        count=None,
+        pager=None,
+        format_detailed=None,
+        detailed=None,
+        color=None,
+    ):
         """
         Args:
             configuration (buildtest.config.SiteConfiguration): Instance of SiteConfiguration class that is loaded buildtest configuration.
@@ -82,7 +125,9 @@ class Report:
         self.latest = latest or self.configuration.target_config["report"].get("latest")
         self.oldest = oldest or self.configuration.target_config["report"].get("oldest")
         self.filter = filter_args
-        self.format = format_args or self.configuration.target_config["report"].get("format")
+        self.format = format_args or self.configuration.target_config["report"].get(
+            "format"
+        )
         self.pager = pager
         self.color = color
         self.input_report = report_file
@@ -93,7 +138,9 @@ class Report:
 
         # if both format and detailed options are specified
         if format_detailed and format_args:
-            raise BuildTestError("Argument -d/--detailed is not allowed with argument --format")
+            raise BuildTestError(
+                "Argument -d/--detailed is not allowed with argument --format"
+            )
 
         # if no report specified use default report
         if not self.input_report:
@@ -135,10 +182,13 @@ class Report:
                 if key not in self.filter_fields:
                     self.print_filter_fields()
                     raise BuildTestError(
-                        f"Invalid filter key: {key}, please run 'buildtest report --helpfilter' for list of available filter fields")
+                        f"Invalid filter key: {key}, please run 'buildtest report --helpfilter' for list of available filter fields"
+                    )
 
                 if key == "returncode" and not is_int(self.filter[key]):
-                    raise BuildTestError(f"Invalid returncode:{self.filter[key]} must be an integer")
+                    raise BuildTestError(
+                        f"Invalid returncode:{self.filter[key]} must be an integer"
+                    )
 
                 logger.debug(f"filter field: {key} is valid")
 
@@ -184,12 +234,16 @@ class Report:
             logger.debug(f"checking end field: {self.end}")
 
             if self.end > current_time:
-                raise BuildTestError(f"Invalid --end {self.end} is greater than current time {current_time}")
+                raise BuildTestError(
+                    f"Invalid --end {self.end} is greater than current time {current_time}"
+                )
 
             logger.debug(f"checking start field: {self.start}")
 
             if self.start and self.start > self.end:
-                raise BuildTestError(f"Invalid --start {self.start} is greater than --end {self.end}")
+                raise BuildTestError(
+                    f"Invalid --start {self.start} is greater than --end {self.end}"
+                )
 
     def load(self):
         """This method is responsible for loading report file. If file not found
@@ -202,11 +256,18 @@ class Report:
         """
 
         if not self._reportfile:
-            sys.exit(console.print(f"[red]Unable to resolve path to report file: {self.input_report}"))
+            sys.exit(
+                console.print(
+                    f"[red]Unable to resolve path to report file: {self.input_report}"
+                )
+            )
 
         if not is_file(self._reportfile):
-            sys.exit(console.print(
-                f"Unable to find report please check if {self._reportfile} is a file or run a test via 'buildtest build' to generate report file"))
+            sys.exit(
+                console.print(
+                    f"Unable to find report please check if {self._reportfile} is a file or run a test via 'buildtest build' to generate report file"
+                )
+            )
 
         report = load_json(self._reportfile)
 
@@ -215,8 +276,10 @@ class Report:
         # if report is None or issue with how json.load returns content of file we
         # raise error
         if not report:
-            sys.exit(f"Fail to process {self._reportfile} please check if file is valid json"
-                     f"or remove file")
+            sys.exit(
+                f"Fail to process {self._reportfile} please check if file is valid json"
+                f"or remove file"
+            )
         return report
 
     def filter_buildspecs_from_report(self):
@@ -239,11 +302,15 @@ class Report:
 
             # if file doesn't exist we terminate with message
             if not resolved_buildspecs:
-                raise BuildTestError(f"Invalid File Path for filter field 'buildspec': {self.filter['buildspec']}")
+                raise BuildTestError(
+                    f"Invalid File Path for filter field 'buildspec': {self.filter['buildspec']}"
+                )
 
             # if file not found in cache we exit
             if not resolved_buildspecs in self.report.keys():
-                raise BuildTestError(f"buildspec file: {resolved_buildspecs} not found in cache")
+                raise BuildTestError(
+                    f"buildspec file: {resolved_buildspecs} not found in cache"
+                )
 
             # need to set as a list since we will loop over all tests
             self.filtered_buildspecs = [resolved_buildspecs]
@@ -252,7 +319,8 @@ class Report:
         if self.filter.get("state"):
             if self.filter["state"] not in ["PASS", "FAIL"]:
                 raise BuildTestError(
-                    f"filter argument 'state' must be 'PASS' or 'FAIL' got value {self.filter['state']}")
+                    f"filter argument 'state' must be 'PASS' or 'FAIL' got value {self.filter['state']}"
+                )
 
     def filter_by_start_end(self, test):
         """This method will return a boolean (True/False) to check if test should be included from report. Given an input test, we
@@ -269,7 +337,9 @@ class Report:
 
         if self.start and self.end:
             end_include = self.end + datetime.timedelta(days=1)
-            return (True if test_start >= self.start and test_end <= end_include else False)
+            return (
+                True if test_start >= self.start and test_end <= end_include else False
+            )
 
         if self.start:
             return True if test_start >= self.start else False
@@ -288,7 +358,9 @@ class Report:
         if not self.filter.get("name"):
             return False
 
-        logger.debug(f"Checking if test: '{name}' matches filter name: '{self.filter['name']}'")
+        logger.debug(
+            f"Checking if test: '{name}' matches filter name: '{self.filter['name']}'"
+        )
 
         return not name == self.filter["name"]
 
@@ -314,7 +386,9 @@ class Report:
             test (dict): Test recorded loaded as dictionary
         """
 
-        if self.filter.get("executor") and self.filter.get("executor") != test.get("executor"):
+        if self.filter.get("executor") and self.filter.get("executor") != test.get(
+            "executor"
+        ):
             return True
 
         return False
@@ -358,7 +432,10 @@ class Report:
 
                 # if --latest and --oldest specified together we retrieve first and last record
                 if self.latest and self.oldest:
-                    tests = [self.report[buildspec][name][0], self.report[buildspec][name][-1], ]
+                    tests = [
+                        self.report[buildspec][name][0],
+                        self.report[buildspec][name][-1],
+                    ]
                 # retrieve last record of every test if --latest is specified
                 elif self.latest:
                     tests = [self.report[buildspec][name][-1]]
@@ -429,10 +506,19 @@ class Report:
     def print_filter_fields(self):
         """Displays list of help filters which implements command ``buildtest report --helpfilter``"""
 
-        table = Table("[blue]Field", "[blue]Description", "[blue]Expected Value", title="Filter Fields", )
+        table = Table(
+            "[blue]Field",
+            "[blue]Description",
+            "[blue]Expected Value",
+            title="Filter Fields",
+        )
 
         for field, value in self.filter_field_description.items():
-            table.add_row(f"[red]{field}", f"[green]{value['description']}", f"[magenta]{value['type']}", )
+            table.add_row(
+                f"[red]{field}",
+                f"[green]{value['description']}",
+                f"[magenta]{value['type']}",
+            )
         console.print(table)
 
     def print_raw_filter_fields(self):
@@ -445,7 +531,15 @@ class Report:
         for field in self.format_fields:
             console.print(field)
 
-    def print_report(self, terse=None, row_count=None, noheader=None, title=None, count=None, color=None, ):
+    def print_report(
+        self,
+        terse=None,
+        row_count=None,
+        noheader=None,
+        title=None,
+        count=None,
+        color=None,
+    ):
         """This method will print report table after processing report file. By default we print output in
         table format but this can be changed to terse format which will print output in parseable format.
 
@@ -494,8 +588,16 @@ class Report:
             root_disk_usage|PASS|0
         """
 
-        count = (self.configuration.target_config["report"].get("count") if count is None else count)
-        terse = (self.configuration.target_config["report"].get("terse") if terse is None else terse)
+        count = (
+            self.configuration.target_config["report"].get("count")
+            if count is None
+            else count
+        )
+        terse = (
+            self.configuration.target_config["report"].get("terse")
+            if terse is None
+            else terse
+        )
 
         consoleColor = checkColor(color)
         if terse:
@@ -660,7 +762,11 @@ class Report:
                     else:
                         fail_tests += 1
 
-                tests[name] = {"runs": len(self.report[buildspec][name]), "pass": pass_tests, "fail": fail_tests, }
+                tests[name] = {
+                    "runs": len(self.report[buildspec][name]),
+                    "pass": pass_tests,
+                    "fail": fail_tests,
+                }
         return tests
 
     def fetch_records_by_ids(self, testids):
@@ -684,7 +790,11 @@ class Report:
 def list_report():
     """This method will list all report files. This method will implement ``buildtest report list`` command."""
     if not is_file(BUILDTEST_REPORTS):
-        sys.exit(console.print("There are no report files, please run 'buildtest build' to generate a report file."))
+        sys.exit(
+            console.print(
+                "There are no report files, please run 'buildtest build' to generate a report file."
+            )
+        )
 
     content = load_json(BUILDTEST_REPORTS)
     for fname in content:
@@ -722,9 +832,20 @@ def report_cmd(args, configuration, report_file=None):
         list_report()
         return
 
-    results = Report(configuration=configuration, filter_args=args.filter, format_args=args.format, start=args.start,
-        end=args.end, failure=args.fail, passed=args.passed, latest=args.latest, oldest=args.oldest,
-        report_file=report_file, count=args.count, format_detailed=args.detailed, )
+    results = Report(
+        configuration=configuration,
+        filter_args=args.filter,
+        format_args=args.format,
+        start=args.start,
+        end=args.end,
+        failure=args.fail,
+        passed=args.passed,
+        latest=args.latest,
+        oldest=args.oldest,
+        report_file=report_file,
+        count=args.count,
+        format_detailed=args.detailed,
+    )
 
     if args.report_subcommand in ["path", "p"]:
         console.print(results.reportfile())
@@ -733,10 +854,20 @@ def report_cmd(args, configuration, report_file=None):
     if args.report_subcommand in ["summary", "sm"]:
         if pager:
             with console.pager():
-                report_summary(results, detailed=args.detailed, color=consoleColor, configuration=configuration, )
+                report_summary(
+                    results,
+                    detailed=args.detailed,
+                    color=consoleColor,
+                    configuration=configuration,
+                )
             return
 
-        report_summary(results, detailed=args.detailed, color=consoleColor, configuration=configuration, )
+        report_summary(
+            results,
+            detailed=args.detailed,
+            color=consoleColor,
+            configuration=configuration,
+        )
         return
 
     if args.helpfilter:
@@ -757,10 +888,20 @@ def report_cmd(args, configuration, report_file=None):
 
     if pager:
         with console.pager():
-            results.print_report(terse=args.terse, noheader=args.no_header, count=args.count, color=consoleColor, )
+            results.print_report(
+                terse=args.terse,
+                noheader=args.no_header,
+                count=args.count,
+                color=consoleColor,
+            )
         return
-    results.print_report(terse=args.terse, row_count=args.row_count, noheader=args.no_header, count=args.count,
-        color=consoleColor, )
+    results.print_report(
+        terse=args.terse,
+        row_count=args.row_count,
+        noheader=args.no_header,
+        count=args.count,
+        color=consoleColor,
+    )
 
 
 def report_summary(report, configuration, detailed=None, color=None):
@@ -780,18 +921,34 @@ def report_summary(report, configuration, detailed=None, color=None):
     table.add_column("Total Runs", style=consoleColor)
 
     for k in test_breakdown.keys():
-        table.add_row(k, str(test_breakdown[k]["pass"]), str(test_breakdown[k]["fail"]),
-            str(test_breakdown[k]["runs"]), )
-    pass_results = Report(filter_args={"state": "PASS"}, format_args="name,id,executor,state,returncode,runtime",
-        report_file=report.reportfile(), configuration=configuration, )
+        table.add_row(
+            k,
+            str(test_breakdown[k]["pass"]),
+            str(test_breakdown[k]["fail"]),
+            str(test_breakdown[k]["runs"]),
+        )
+    pass_results = Report(
+        filter_args={"state": "PASS"},
+        format_args="name,id,executor,state,returncode,runtime",
+        report_file=report.reportfile(),
+        configuration=configuration,
+    )
 
-    fail_results = Report(filter_args={"state": "FAIL"}, format_args="name,id,executor,state,returncode,runtime",
-        report_file=report.reportfile(), configuration=configuration, )
+    fail_results = Report(
+        filter_args={"state": "FAIL"},
+        format_args="name,id,executor,state,returncode,runtime",
+        report_file=report.reportfile(),
+        configuration=configuration,
+    )
 
-    print_report_summary_output(report, table, pass_results, fail_results, color=color, detailed=detailed)
+    print_report_summary_output(
+        report, table, pass_results, fail_results, color=color, detailed=detailed
+    )
 
 
-def print_report_summary_output(report, table, pass_results, fail_results, color=None, detailed=None):
+def print_report_summary_output(
+    report, table, pass_results, fail_results, color=None, detailed=None
+):
     """Print output of ``buildtest report summary``.
 
     Args:

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -109,6 +109,7 @@ class Report:
             oldest (bool, optional): Fetch oldest run for all tests discovered. This is specified via ``buildtest report --oldest``
             count (int, optional): Fetch limited number of rows get printed for all tests discovered. This is specified via ``buildtest report --count``
             pager (bool, optional): Enabling PAGING output for ``buildtest report``. This can be specified via ``buildtest report --pager``
+            format_detailed(bool,optional): Print a detailed summary of the test results. This can be specified via ``buildtest report --detailed``
             color (str, optional): An instance of a string class that tells print_report what color the output should be printed in.
 
         """

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -77,6 +77,8 @@ class Report:
         "buildspec": [],
     }
 
+    format_fields_detailed = ("name,id,user,state,returncode,runtime,outfile,errfile,buildspec")
+
     def __init__(
         self,
         configuration,
@@ -130,9 +132,7 @@ class Report:
 
         # if detailed option is specified
         if format_detailed:
-            self.format = (
-                "name,id,user,state,returncode,runtime,outfile,errfile,buildspec"
-            )
+            self.format = self.format_fields_detailed
 
         # if both format and detailed options are specified
         if format_detailed and format_args:

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -78,21 +78,21 @@ class Report:
     }
 
     def __init__(
-        self,
-        configuration,
-        report_file=None,
-        filter_args=None,
-        format_args=None,
-        start=None,
-        end=None,
-        failure=None,
-        passed=None,
-        latest=None,
-        oldest=None,
-        count=None,
-        pager=None,
-        detailed=None,
-        color=None,
+            self,
+            configuration,
+            report_file=None,
+            filter_args=None,
+            format_args=None,
+            start=None,
+            end=None,
+            failure=None,
+            passed=None,
+            latest=None,
+            oldest=None,
+            count=None,
+            pager=None,
+            detailed=None,
+            color=None,
     ):
         """
         Args:
@@ -371,7 +371,7 @@ class Report:
         """
 
         if self.filter.get("executor") and self.filter.get("executor") != test.get(
-            "executor"
+                "executor"
         ):
             return True
 
@@ -516,13 +516,13 @@ class Report:
             console.print(field)
 
     def print_report(
-        self,
-        terse=None,
-        row_count=None,
-        noheader=None,
-        title=None,
-        count=None,
-        color=None,
+            self,
+            terse=None,
+            row_count=None,
+            noheader=None,
+            title=None,
+            count=None,
+            color=None,
     ):
         """This method will print report table after processing report file. By default we print output in
         table format but this can be changed to terse format which will print output in parseable format.
@@ -854,7 +854,7 @@ def report_cmd(args, configuration, report_file=None):
         return
 
     if args.detailed:
-        report_detailed(results,configuration)
+        report_detailed(results, configuration)
         return
 
     if args.helpfilter:
@@ -934,7 +934,7 @@ def report_summary(report, configuration, detailed=None, color=None):
 
 
 def print_report_summary_output(
-    report, table, pass_results, fail_results, color=None, detailed=None
+        report, table, pass_results, fail_results, color=None, detailed=None
 ):
     """Print output of ``buildtest report summary``.
 

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -853,6 +853,10 @@ def report_cmd(args, configuration, report_file=None):
         )
         return
 
+    if args.detailed:
+        report_detailed()
+        return
+
     if args.helpfilter:
         results.print_filter_fields()
         return
@@ -954,3 +958,20 @@ def print_report_summary_output(
     console.print(table)
     pass_results.print_report(title="PASS Tests", color=color)
     fail_results.print_report(title="FAIL Tests", color=color)
+
+def report_detailed(report, configuration):
+    """This method will print detailed summary test results which can be retrieved via ``buildtest report --detailed`` command
+    Args:
+        report (buildtest.cli.report.Report): An instance of Report class
+        configuration (buildtest.config.SiteConfiguration): Instance of SiteConfiguration class that is loaded buildtest configuration.
+    """
+    detailed_results = Report(
+        format_args="name,id,user,state,returncode,runtime,outfile,errfile,buildspec",
+        report_file=report.reportfile(),
+        configuration=configuration,
+    )
+    detailed_results.print_report(
+        terse=False,
+        row_count=1,
+        args_count=9,
+    )

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -77,7 +77,9 @@ class Report:
         "buildspec": [],
     }
 
-    format_fields_detailed = ("name,id,user,state,returncode,runtime,outfile,errfile,buildspec")
+    format_fields_detailed = (
+        "name,id,user,state,returncode,runtime,outfile,errfile,buildspec"
+    )
 
     def __init__(
         self,

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -129,6 +129,12 @@ class Report:
         self.color = color
         self.input_report = report_file
 
+        try:
+            report=Report(configuration=configuration, format_detailed=True, format_args="name,id,user")
+        except argparse.ArgumentError:
+            console.print_exception()
+            return True
+
         if format_detailed:
             self.format = (
                 "name,id,user,state,returncode,runtime,outfile,errfile,buildspec"

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -28,77 +28,34 @@ def is_int(val):
 
 class Report:
     # list of format fields
-    format_field_description = {
-        "buildspec": "Buildspec File",
-        "buildenv": "Show build environment file for test",
-        "command": "Command executed",
-        "compiler": "Retrieve compiler used for test (applicable for compiler schema)",
-        "endtime": "End Time for test",
-        "errfile": "Error File",
-        "executor": "Name of executor used for running test",
-        "hostname": "Hostname of machine where job was submitted from",
-        "full_id": "Fully qualified build identifier",
-        "id": "Unique build identifier",
-        "metrics": "List all metrics for test",
-        "name": "Name of test",
-        "outfile": "Output file",
-        "returncode": "Return Code",
-        "runtime": "Total runtime in seconds",
-        "schemafile": "Schema file used for validating test",
-        "starttime": "Start time of test",
-        "state": "State of test (PASS/FAIL)",
-        "tags": "Tag name",
-        "testroot": "Root of test directory",
-        "testpath": "Path to test",
-        "user": "User who ran the test",
-    }
-    filter_field_description = {
-        "buildspec": {"description": "Filter by buildspec file", "type": "FILE"},
+    format_field_description = {"buildspec": "Buildspec File", "buildenv": "Show build environment file for test",
+        "command": "Command executed", "compiler": "Retrieve compiler used for test (applicable for compiler schema)",
+        "endtime": "End Time for test", "errfile": "Error File", "executor": "Name of executor used for running test",
+        "hostname": "Hostname of machine where job was submitted from", "full_id": "Fully qualified build identifier",
+        "id": "Unique build identifier", "metrics": "List all metrics for test", "name": "Name of test",
+        "outfile": "Output file", "returncode": "Return Code", "runtime": "Total runtime in seconds",
+        "schemafile": "Schema file used for validating test", "starttime": "Start time of test",
+        "state": "State of test (PASS/FAIL)", "tags": "Tag name", "testroot": "Root of test directory",
+        "testpath": "Path to test", "user": "User who ran the test", }
+    filter_field_description = {"buildspec": {"description": "Filter by buildspec file", "type": "FILE"},
         "name": {"description": "Filter by test name", "type": "STRING"},
         "executor": {"description": "Filter by executor name", "type": "STRING"},
         "returncode": {"description": "Filter tests by returncode", "type": "INT"},
         "state": {"description": "Filter by test state", "type": "PASS/FAIL"},
-        "tags": {"description": "Filter tests by tag name", "type": "STRING"},
-    }
+        "tags": {"description": "Filter tests by tag name", "type": "STRING"}, }
     format_fields = format_field_description.keys()
     # list of filter fields
     filter_fields = filter_field_description.keys()
 
     # default table format fields
-    display_table = {
-        "name": [],
-        "id": [],
-        "state": [],
-        "returncode": [],
-        "starttime": [],
-        "endtime": [],
-        "runtime": [],
-        "tags": [],
-        "buildspec": [],
-    }
+    display_table = {"name": [], "id": [], "state": [], "returncode": [], "starttime": [], "endtime": [], "runtime": [],
+        "tags": [], "buildspec": [], }
 
-    format_fields_detailed = (
-        "name,id,user,state,returncode,runtime,outfile,errfile,buildspec"
-    )
+    format_fields_detailed = ("name,id,user,state,returncode,runtime,outfile,errfile,buildspec")
 
-    def __init__(
-        self,
-        configuration,
-        report_file=None,
-        filter_args=None,
-        format_args=None,
-        start=None,
-        end=None,
-        failure=None,
-        passed=None,
-        latest=None,
-        oldest=None,
-        count=None,
-        pager=None,
-        format_detailed=None,
-        detailed=None,
-        color=None,
-    ):
+    def __init__(self, configuration, report_file=None, filter_args=None, format_args=None, start=None, end=None,
+            failure=None, passed=None, latest=None, oldest=None, count=None, pager=None, format_detailed=None,
+            detailed=None, color=None, ):
         """
         Args:
             configuration (buildtest.config.SiteConfiguration): Instance of SiteConfiguration class that is loaded buildtest configuration.
@@ -125,9 +82,7 @@ class Report:
         self.latest = latest or self.configuration.target_config["report"].get("latest")
         self.oldest = oldest or self.configuration.target_config["report"].get("oldest")
         self.filter = filter_args
-        self.format = format_args or self.configuration.target_config["report"].get(
-            "format"
-        )
+        self.format = format_args or self.configuration.target_config["report"].get("format")
         self.pager = pager
         self.color = color
         self.input_report = report_file
@@ -138,9 +93,7 @@ class Report:
 
         # if both format and detailed options are specified
         if format_detailed and format_args:
-            raise BuildTestError(
-                "Argument -d/--detailed is not allowed with argument --format"
-            )
+            raise BuildTestError("Argument -d/--detailed is not allowed with argument --format")
 
         # if no report specified use default report
         if not self.input_report:
@@ -182,13 +135,10 @@ class Report:
                 if key not in self.filter_fields:
                     self.print_filter_fields()
                     raise BuildTestError(
-                        f"Invalid filter key: {key}, please run 'buildtest report --helpfilter' for list of available filter fields"
-                    )
+                        f"Invalid filter key: {key}, please run 'buildtest report --helpfilter' for list of available filter fields")
 
                 if key == "returncode" and not is_int(self.filter[key]):
-                    raise BuildTestError(
-                        f"Invalid returncode:{self.filter[key]} must be an integer"
-                    )
+                    raise BuildTestError(f"Invalid returncode:{self.filter[key]} must be an integer")
 
                 logger.debug(f"filter field: {key} is valid")
 
@@ -234,16 +184,12 @@ class Report:
             logger.debug(f"checking end field: {self.end}")
 
             if self.end > current_time:
-                raise BuildTestError(
-                    f"Invalid --end {self.end} is greater than current time {current_time}"
-                )
+                raise BuildTestError(f"Invalid --end {self.end} is greater than current time {current_time}")
 
             logger.debug(f"checking start field: {self.start}")
 
             if self.start and self.start > self.end:
-                raise BuildTestError(
-                    f"Invalid --start {self.start} is greater than --end {self.end}"
-                )
+                raise BuildTestError(f"Invalid --start {self.start} is greater than --end {self.end}")
 
     def load(self):
         """This method is responsible for loading report file. If file not found
@@ -256,18 +202,11 @@ class Report:
         """
 
         if not self._reportfile:
-            sys.exit(
-                console.print(
-                    f"[red]Unable to resolve path to report file: {self.input_report}"
-                )
-            )
+            sys.exit(console.print(f"[red]Unable to resolve path to report file: {self.input_report}"))
 
         if not is_file(self._reportfile):
-            sys.exit(
-                console.print(
-                    f"Unable to find report please check if {self._reportfile} is a file or run a test via 'buildtest build' to generate report file"
-                )
-            )
+            sys.exit(console.print(
+                f"Unable to find report please check if {self._reportfile} is a file or run a test via 'buildtest build' to generate report file"))
 
         report = load_json(self._reportfile)
 
@@ -276,10 +215,8 @@ class Report:
         # if report is None or issue with how json.load returns content of file we
         # raise error
         if not report:
-            sys.exit(
-                f"Fail to process {self._reportfile} please check if file is valid json"
-                f"or remove file"
-            )
+            sys.exit(f"Fail to process {self._reportfile} please check if file is valid json"
+                     f"or remove file")
         return report
 
     def filter_buildspecs_from_report(self):
@@ -302,15 +239,11 @@ class Report:
 
             # if file doesn't exist we terminate with message
             if not resolved_buildspecs:
-                raise BuildTestError(
-                    f"Invalid File Path for filter field 'buildspec': {self.filter['buildspec']}"
-                )
+                raise BuildTestError(f"Invalid File Path for filter field 'buildspec': {self.filter['buildspec']}")
 
             # if file not found in cache we exit
             if not resolved_buildspecs in self.report.keys():
-                raise BuildTestError(
-                    f"buildspec file: {resolved_buildspecs} not found in cache"
-                )
+                raise BuildTestError(f"buildspec file: {resolved_buildspecs} not found in cache")
 
             # need to set as a list since we will loop over all tests
             self.filtered_buildspecs = [resolved_buildspecs]
@@ -319,8 +252,7 @@ class Report:
         if self.filter.get("state"):
             if self.filter["state"] not in ["PASS", "FAIL"]:
                 raise BuildTestError(
-                    f"filter argument 'state' must be 'PASS' or 'FAIL' got value {self.filter['state']}"
-                )
+                    f"filter argument 'state' must be 'PASS' or 'FAIL' got value {self.filter['state']}")
 
     def filter_by_start_end(self, test):
         """This method will return a boolean (True/False) to check if test should be included from report. Given an input test, we
@@ -337,9 +269,7 @@ class Report:
 
         if self.start and self.end:
             end_include = self.end + datetime.timedelta(days=1)
-            return (
-                True if test_start >= self.start and test_end <= end_include else False
-            )
+            return (True if test_start >= self.start and test_end <= end_include else False)
 
         if self.start:
             return True if test_start >= self.start else False
@@ -358,9 +288,7 @@ class Report:
         if not self.filter.get("name"):
             return False
 
-        logger.debug(
-            f"Checking if test: '{name}' matches filter name: '{self.filter['name']}'"
-        )
+        logger.debug(f"Checking if test: '{name}' matches filter name: '{self.filter['name']}'")
 
         return not name == self.filter["name"]
 
@@ -386,9 +314,7 @@ class Report:
             test (dict): Test recorded loaded as dictionary
         """
 
-        if self.filter.get("executor") and self.filter.get("executor") != test.get(
-            "executor"
-        ):
+        if self.filter.get("executor") and self.filter.get("executor") != test.get("executor"):
             return True
 
         return False
@@ -432,10 +358,7 @@ class Report:
 
                 # if --latest and --oldest specified together we retrieve first and last record
                 if self.latest and self.oldest:
-                    tests = [
-                        self.report[buildspec][name][0],
-                        self.report[buildspec][name][-1],
-                    ]
+                    tests = [self.report[buildspec][name][0], self.report[buildspec][name][-1], ]
                 # retrieve last record of every test if --latest is specified
                 elif self.latest:
                     tests = [self.report[buildspec][name][-1]]
@@ -506,19 +429,10 @@ class Report:
     def print_filter_fields(self):
         """Displays list of help filters which implements command ``buildtest report --helpfilter``"""
 
-        table = Table(
-            "[blue]Field",
-            "[blue]Description",
-            "[blue]Expected Value",
-            title="Filter Fields",
-        )
+        table = Table("[blue]Field", "[blue]Description", "[blue]Expected Value", title="Filter Fields", )
 
         for field, value in self.filter_field_description.items():
-            table.add_row(
-                f"[red]{field}",
-                f"[green]{value['description']}",
-                f"[magenta]{value['type']}",
-            )
+            table.add_row(f"[red]{field}", f"[green]{value['description']}", f"[magenta]{value['type']}", )
         console.print(table)
 
     def print_raw_filter_fields(self):
@@ -531,15 +445,7 @@ class Report:
         for field in self.format_fields:
             console.print(field)
 
-    def print_report(
-        self,
-        terse=None,
-        row_count=None,
-        noheader=None,
-        title=None,
-        count=None,
-        color=None,
-    ):
+    def print_report(self, terse=None, row_count=None, noheader=None, title=None, count=None, color=None, ):
         """This method will print report table after processing report file. By default we print output in
         table format but this can be changed to terse format which will print output in parseable format.
 
@@ -588,16 +494,8 @@ class Report:
             root_disk_usage|PASS|0
         """
 
-        count = (
-            self.configuration.target_config["report"].get("count")
-            if count is None
-            else count
-        )
-        terse = (
-            self.configuration.target_config["report"].get("terse")
-            if terse is None
-            else terse
-        )
+        count = (self.configuration.target_config["report"].get("count") if count is None else count)
+        terse = (self.configuration.target_config["report"].get("terse") if terse is None else terse)
 
         consoleColor = checkColor(color)
         if terse:
@@ -762,11 +660,7 @@ class Report:
                     else:
                         fail_tests += 1
 
-                tests[name] = {
-                    "runs": len(self.report[buildspec][name]),
-                    "pass": pass_tests,
-                    "fail": fail_tests,
-                }
+                tests[name] = {"runs": len(self.report[buildspec][name]), "pass": pass_tests, "fail": fail_tests, }
         return tests
 
     def fetch_records_by_ids(self, testids):
@@ -790,11 +684,7 @@ class Report:
 def list_report():
     """This method will list all report files. This method will implement ``buildtest report list`` command."""
     if not is_file(BUILDTEST_REPORTS):
-        sys.exit(
-            console.print(
-                "There are no report files, please run 'buildtest build' to generate a report file."
-            )
-        )
+        sys.exit(console.print("There are no report files, please run 'buildtest build' to generate a report file."))
 
     content = load_json(BUILDTEST_REPORTS)
     for fname in content:
@@ -832,20 +722,9 @@ def report_cmd(args, configuration, report_file=None):
         list_report()
         return
 
-    results = Report(
-        configuration=configuration,
-        filter_args=args.filter,
-        format_args=args.format,
-        start=args.start,
-        end=args.end,
-        failure=args.fail,
-        passed=args.passed,
-        latest=args.latest,
-        oldest=args.oldest,
-        report_file=report_file,
-        count=args.count,
-        format_detailed=args.detailed,
-    )
+    results = Report(configuration=configuration, filter_args=args.filter, format_args=args.format, start=args.start,
+        end=args.end, failure=args.fail, passed=args.passed, latest=args.latest, oldest=args.oldest,
+        report_file=report_file, count=args.count, format_detailed=args.detailed, )
 
     if args.report_subcommand in ["path", "p"]:
         console.print(results.reportfile())
@@ -854,20 +733,10 @@ def report_cmd(args, configuration, report_file=None):
     if args.report_subcommand in ["summary", "sm"]:
         if pager:
             with console.pager():
-                report_summary(
-                    results,
-                    detailed=args.detailed,
-                    color=consoleColor,
-                    configuration=configuration,
-                )
+                report_summary(results, detailed=args.detailed, color=consoleColor, configuration=configuration, )
             return
 
-        report_summary(
-            results,
-            detailed=args.detailed,
-            color=consoleColor,
-            configuration=configuration,
-        )
+        report_summary(results, detailed=args.detailed, color=consoleColor, configuration=configuration, )
         return
 
     if args.helpfilter:
@@ -888,20 +757,10 @@ def report_cmd(args, configuration, report_file=None):
 
     if pager:
         with console.pager():
-            results.print_report(
-                terse=args.terse,
-                noheader=args.no_header,
-                count=args.count,
-                color=consoleColor,
-            )
+            results.print_report(terse=args.terse, noheader=args.no_header, count=args.count, color=consoleColor, )
         return
-    results.print_report(
-        terse=args.terse,
-        row_count=args.row_count,
-        noheader=args.no_header,
-        count=args.count,
-        color=consoleColor,
-    )
+    results.print_report(terse=args.terse, row_count=args.row_count, noheader=args.no_header, count=args.count,
+        color=consoleColor, )
 
 
 def report_summary(report, configuration, detailed=None, color=None):
@@ -921,34 +780,18 @@ def report_summary(report, configuration, detailed=None, color=None):
     table.add_column("Total Runs", style=consoleColor)
 
     for k in test_breakdown.keys():
-        table.add_row(
-            k,
-            str(test_breakdown[k]["pass"]),
-            str(test_breakdown[k]["fail"]),
-            str(test_breakdown[k]["runs"]),
-        )
-    pass_results = Report(
-        filter_args={"state": "PASS"},
-        format_args="name,id,executor,state,returncode,runtime",
-        report_file=report.reportfile(),
-        configuration=configuration,
-    )
+        table.add_row(k, str(test_breakdown[k]["pass"]), str(test_breakdown[k]["fail"]),
+            str(test_breakdown[k]["runs"]), )
+    pass_results = Report(filter_args={"state": "PASS"}, format_args="name,id,executor,state,returncode,runtime",
+        report_file=report.reportfile(), configuration=configuration, )
 
-    fail_results = Report(
-        filter_args={"state": "FAIL"},
-        format_args="name,id,executor,state,returncode,runtime",
-        report_file=report.reportfile(),
-        configuration=configuration,
-    )
+    fail_results = Report(filter_args={"state": "FAIL"}, format_args="name,id,executor,state,returncode,runtime",
+        report_file=report.reportfile(), configuration=configuration, )
 
-    print_report_summary_output(
-        report, table, pass_results, fail_results, color=color, detailed=detailed
-    )
+    print_report_summary_output(report, table, pass_results, fail_results, color=color, detailed=detailed)
 
 
-def print_report_summary_output(
-    report, table, pass_results, fail_results, color=None, detailed=None
-):
+def print_report_summary_output(report, table, pass_results, fail_results, color=None, detailed=None):
     """Print output of ``buildtest report summary``.
 
     Args:

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -52,16 +52,16 @@ The **buildtest report --detailed** option can be used to show a detailed test r
 examining a test. This option is synonymous to running ``buildtest report --format name,id,user,state,returncode,runtime,outfile,errfile,buildspec``.
 Shown below is an example output.
 
-    .. dropdown:: ``buildtest report --detailed``
-        .. command-output:: buildtest report --detailed
+.. dropdown:: ``buildtest report --detailed``
+    .. command-output:: buildtest report --detailed
 
-    .. note::
-        The --detailed and --format options are mutually exclusive options because both options will alter the format
-        fields when displaying test results.
+.. note::
+        The ``--detailed`` and ``--format`` options are mutually exclusive options because both options
+        will alter the format fields when displaying test results.
 
 You will get the following error if you specify both options as shown below
-    .. dropdown::``buildtest report --detailed --format name``
 
+.. dropdown:: ``buildtest report --detailed --format name``
     .. command-output:: buildtest report --detailed --format name
        :returncode: 1
 

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -52,23 +52,15 @@ The **buildtest report --detailed** option can be used to show a detailed test r
 examining a test. This option is synonymous to running ``buildtest report --format name,id,user,state,returncode,runtime,outfile,errfile,buildspec``.
 Shown below is an example output.
 
-.. dropdown:: ``buildtest report --detailed``
+    .. dropdown:: ``buildtest report --detailed``
+        .. command-output:: buildtest report --detailed
 
-    .. command-output:: buildtest report --detailed
+    .. note::
+        The --detailed and --format options are mutually exclusive options because both options will alter the format
+        fields when displaying test results.
 
-Notes
-*******
-
-.. note::
-The detailed and --format options are mutually exclusive options because both options will alter the format fields when displaying test results.
-Later in text after the note state the following.
-
-.. code-block:: RST
-
- .. note::
 You will get the following error if you specify both options as shown below
-
-dropdown::``buildtest report --detailed --format name``
+    .. dropdown::``buildtest report --detailed --format name``
 
     .. command-output:: buildtest report --detailed --format name
        :returncode: 1

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -45,6 +45,17 @@ You may find it useful to fetch all failed records and determine pass/fail crite
 
 .. _report_format_fields:
 
+Detailed Reports (``buildtest report --detailed``)
+---------------------------------------------------
+
+The **buildtest report --detailed** option can be used to show a detailed test report that may be of interest when
+examining a test. This option is synonymous to running ``buildtest report --format name, id, user, state, returncode,
+runtime, outfile, errfile, buildspec``. Shown below is an example output.
+
+.. dropdown:: ``buildtest report --detailed``
+
+    .. command-output:: buildtest report --detailed
+
 Format Reports (``buildtest report --format``)
 -----------------------------------------------
 

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -49,12 +49,20 @@ Detailed Reports (``buildtest report --detailed``)
 ---------------------------------------------------
 
 The **buildtest report --detailed** option can be used to show a detailed test report that may be of interest when
-examining a test. This option is synonymous to running ``buildtest report --format name, id, user, state, returncode,
-runtime, outfile, errfile, buildspec``. Shown below is an example output.
+examining a test. This option is synonymous to running ``buildtest report --format name,id,user,state,returncode,runtime,outfile,errfile,buildspec``.
+Shown below is an example output.
 
 .. dropdown:: ``buildtest report --detailed``
 
     .. command-output:: buildtest report --detailed
+
+Note that ``--detailed`` and ``--format`` options can't be used together in ``buildtest report`` command they are
+mutually exclusive options that affect format fields.
+
+dropdown:: ``buildtest report --detailed --format name``
+
+    .. command-output:: buildtest report --detailed --format name
+        :returncode: 1
 
 Format Reports (``buildtest report --format``)
 -----------------------------------------------

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -64,9 +64,10 @@ Shown below is an example output.
 You will get the following error if you specify both options as shown below
 
 .. dropdown:: ``buildtest report --detailed --format name``
+   :color: warning
 
     .. command-output:: buildtest report --detailed --format name
-       :returncode: 1
+       :returncode: 2
 
 Format Reports (``buildtest report --format``)
 -----------------------------------------------

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -49,7 +49,8 @@ Detailed Reports (``buildtest report --detailed``)
 ---------------------------------------------------
 
 The **buildtest report --detailed** option can be used to show a detailed test report that may be of interest when
-examining a test. This option is synonymous to running ``buildtest report --format name,id,user,state,returncode,runtime,outfile,errfile,buildspec``.
+examining a test. This option is synonymous to running ``buildtest report --format name,id,user,state,returncode,
+runtime,outfile,errfile,buildspec``.
 Shown below is an example output.
 
 .. dropdown:: ``buildtest report --detailed``

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -56,13 +56,22 @@ Shown below is an example output.
 
     .. command-output:: buildtest report --detailed
 
-Note that ``--detailed`` and ``--format`` options can't be used together in ``buildtest report`` command they are
-mutually exclusive options that affect format fields.
+Notes
+*******
 
-dropdown:: ``buildtest report --detailed --format name``
+.. note::
+The detailed and --format options are mutually exclusive options because both options will alter the format fields when displaying test results.
+Later in text after the note state the following.
+
+.. code-block:: RST
+
+ .. note::
+You will get the following error if you specify both options as shown below
+
+dropdown::``buildtest report --detailed --format name``
 
     .. command-output:: buildtest report --detailed --format name
-        :returncode: 1
+       :returncode: 1
 
 Format Reports (``buildtest report --format``)
 -----------------------------------------------

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -54,6 +54,7 @@ runtime,outfile,errfile,buildspec``.
 Shown below is an example output.
 
 .. dropdown:: ``buildtest report --detailed``
+
     .. command-output:: buildtest report --detailed
 
 .. note::
@@ -63,6 +64,7 @@ Shown below is an example output.
 You will get the following error if you specify both options as shown below
 
 .. dropdown:: ``buildtest report --detailed --format name``
+
     .. command-output:: buildtest report --detailed --format name
        :returncode: 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ docs = [
 ]
 [tool.black]
 required-version = '23.3.0'
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311']
 skip_magic_trailing_comma = true
 line-length = 88
 verbose = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ docs = [
 ]
 [tool.black]
 required-version = '23.3.0'
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310']
 skip_magic_trailing_comma = true
 line-length = 88
 verbose = true

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -55,6 +55,11 @@ def test_report():
     result.print_report()
 
 
+def test_report_detailed():
+    # buildtest report --detailed
+    Report(configuration=configuration, format_detailed=True)
+
+
 @pytest.mark.cli
 def test_report_format():
     # buildtest report --helpformat
@@ -65,7 +70,7 @@ def test_report_format():
     report.print_raw_format_fields()
 
     # buildtest report --detailed
-    report = Report(configuration=configuration, format_detailed=True)
+    # report = Report(configuration=configuration, format_detailed=True)
 
     # buildtest report --format XYZ is invalid format field
     with pytest.raises(BuildTestError):

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -11,8 +11,8 @@ from buildtest.cli.report import (
     clear_report,
     list_report,
     report_cmd,
-    report_summary,
     report_detailed,
+    report_summary,
 )
 from buildtest.config import SiteConfiguration
 from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORTS, BUILDTEST_ROOT
@@ -329,9 +329,11 @@ def test_report_limited_rows():
     report.print_report(terse=True, count=0)
     report.print_report(terse=True, count=-1)
 
+
 def test_report_detailed():
     report = Report(configuration=configuration)
     report_detailed(report, configuration)
+
 
 @pytest.mark.cli
 def test_report_path():

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -58,6 +58,7 @@ def test_report():
 def test_report_detailed():
     # buildtest report --detailed
     Report(configuration=configuration, format_detailed=True)
+    Report(configuration=configuration, format_detailed=True, format_args="name")
 
 
 @pytest.mark.cli
@@ -68,9 +69,6 @@ def test_report_format():
 
     # buildtest report --formatfields
     report.print_raw_format_fields()
-
-    # buildtest report --detailed
-    # report = Report(configuration=configuration, format_detailed=True)
 
     # buildtest report --format XYZ is invalid format field
     with pytest.raises(BuildTestError):

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -58,8 +58,8 @@ def test_report():
 def test_report_detailed():
     # buildtest report --detailed
     Report(configuration=configuration, format_detailed=True)
-    Report(configuration=configuration, format_detailed=True, format_args="name")
-
+    with pytest.raises(BuildTestError):
+        Report(configuration=configuration, format_detailed=True, format_args="name")
 
 @pytest.mark.cli
 def test_report_format():

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -58,6 +58,8 @@ def test_report():
 def test_report_detailed():
     # buildtest report --detailed
     Report(configuration=configuration, format_detailed=True)
+
+    # buildtest report --detailed --format name
     with pytest.raises(BuildTestError):
         Report(configuration=configuration, format_detailed=True, format_args="name")
 

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -11,7 +11,6 @@ from buildtest.cli.report import (
     clear_report,
     list_report,
     report_cmd,
-    report_detailed,
     report_summary,
 )
 from buildtest.config import SiteConfiguration
@@ -64,6 +63,12 @@ def test_report_format():
 
     # buildtest report --formatfields
     report.print_raw_format_fields()
+
+    # buildtest report --detailed
+    report = Report(
+        configuration=configuration,
+        format_detailed=True
+    )
 
     # buildtest report --format XYZ is invalid format field
     with pytest.raises(BuildTestError):
@@ -330,9 +335,9 @@ def test_report_limited_rows():
     report.print_report(terse=True, count=-1)
 
 
-def test_report_detailed():
-    report = Report(configuration=configuration)
-    report_detailed(report, configuration)
+# def test_report_detailed():
+# report = Report(configuration=configuration)
+# report_detailed(report, configuration)
 
 
 @pytest.mark.cli

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -37,6 +37,13 @@ def test_report():
 
     result.print_report(row_count=True)
 
+    # run 'buildtest report --detailed'
+    result = Report(
+        configuration=configuration,
+        format_args="name,id,user,state,returncode,runtime,outfile,errfile,buildspec",
+    )
+    result.print_report()
+
     # run 'buildtest report --format name,state,returncode,buildspec'
     result = Report(
         configuration=configuration, format_args="name,state,returncode,buildspec"

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -61,6 +61,7 @@ def test_report_detailed():
     with pytest.raises(BuildTestError):
         Report(configuration=configuration, format_detailed=True, format_args="name")
 
+
 @pytest.mark.cli
 def test_report_format():
     # buildtest report --helpformat

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -353,5 +353,6 @@ def test_report_path():
         count = None
         color = None
         pager = None
+        detailed = None
 
     report_cmd(args, configuration=configuration)

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -331,6 +331,7 @@ def test_report_limited_rows():
     report.print_report(terse=True, count=0)
     report.print_report(terse=True, count=-1)
 
+
 @pytest.mark.cli
 def test_report_path():
     class args:

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -65,10 +65,7 @@ def test_report_format():
     report.print_raw_format_fields()
 
     # buildtest report --detailed
-    report = Report(
-        configuration=configuration,
-        format_detailed=True
-    )
+    report = Report(configuration=configuration, format_detailed=True)
 
     # buildtest report --format XYZ is invalid format field
     with pytest.raises(BuildTestError):

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -12,6 +12,7 @@ from buildtest.cli.report import (
     list_report,
     report_cmd,
     report_summary,
+    report_detailed,
 )
 from buildtest.config import SiteConfiguration
 from buildtest.defaults import BUILD_REPORT, BUILDTEST_REPORTS, BUILDTEST_ROOT
@@ -36,13 +37,6 @@ def test_report():
     result.print_report(terse=True, color=Color.default().name)
 
     result.print_report(row_count=True)
-
-    # run 'buildtest report --detailed'
-    result = Report(
-        configuration=configuration,
-        format_args="name,id,user,state,returncode,runtime,outfile,errfile,buildspec",
-    )
-    result.print_report()
 
     # run 'buildtest report --format name,state,returncode,buildspec'
     result = Report(
@@ -335,6 +329,9 @@ def test_report_limited_rows():
     report.print_report(terse=True, count=0)
     report.print_report(terse=True, count=-1)
 
+def test_report_detailed():
+    report = Report(configuration=configuration)
+    report_detailed(report, configuration)
 
 @pytest.mark.cli
 def test_report_path():

--- a/tests/cli/test_report.py
+++ b/tests/cli/test_report.py
@@ -331,12 +331,6 @@ def test_report_limited_rows():
     report.print_report(terse=True, count=0)
     report.print_report(terse=True, count=-1)
 
-
-# def test_report_detailed():
-# report = Report(configuration=configuration)
-# report_detailed(report, configuration)
-
-
 @pytest.mark.cli
 def test_report_path():
     class args:


### PR DESCRIPTION
This new feature will let the user to run
buildtest rt --format name,id,user,state,returncode,runtime,outfile,errfile,buildspec --count=1
By running
buildtest rt --detailed