### PR TITLE
Modified behavior of --help/-h and added commands -H/--help--all

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -458,7 +458,7 @@ _buildtest ()
     *)
       local cmds="build buildspec cd cdash clean config debugreport docs help info inspect history path report schema schemadocs stats stylecheck tutorial-examples unittests"
       local alias_cmds="bd bc cg debug it h hy rt style test"
-      local opts="--color --config --debug --editor --help --helpcolor --help--all --logpath --loglevel --print-log --no-color --report --version --view-log -c -d -h -l -p -r -V -H"
+      local opts="--color --config --debug --editor --help --helpcolor --help--all --logpath --loglevel --print-log --no-color --report --version --view-log -c -d -h -l -p -r -H -V"
 
       case "${cur}" in
       # print main options to buildtest

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -133,7 +133,7 @@ _buildtest ()
 
   COMPREPLY=()   # Array variable storing the possible completions.
 
-  declare -a buildtest_opts=("--color" "--config" "--debug" "--editor" "--help" "--helpcolor" "--logpath" "--loglevel" "--print-log" "--no-color" "--report" "--version" "--view-log" "-c" "-d" "-h" "-l" "-p" "-r" "-V")
+  declare -a buildtest_opts=("--color" "--config" "--debug" "--editor" "--help" "--helpcolor" "--help--all" "--logpath" "--loglevel" "--print-log" "--no-color" "--report" "--version" "--view-log" "-c" "-d" "-h" "-l" "-p" "-r" "-V" "-H")
 
   commands_with_input=( "--color" "--config" "-c" "--report" "-r" "--loglevel" "-l" "--editor" )   # Array variable storing commands which require an input argument from the user.
 
@@ -200,7 +200,7 @@ _buildtest ()
       COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
       ;;
     path)
-      local opts="-b -be -e -h -o -s -t --buildscript --buildenv --errfile --help --outfile --stagedir --testpath"
+      local opts="-b -be -e -h -o -s -t --buildscript --buildenv --errfile --help  --outfile --stagedir --testpath"
       COMPREPLY=( $( compgen -W "$(_builder_names)" -- $cur ) )
       if [[ $cur == -* ]] ; then
         COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
@@ -458,7 +458,7 @@ _buildtest ()
     *)
       local cmds="build buildspec cd cdash clean config debugreport docs help info inspect history path report schema schemadocs stats stylecheck tutorial-examples unittests"
       local alias_cmds="bd bc cg debug it h hy rt style test"
-      local opts="--color --config --debug --editor --help --helpcolor --logpath --loglevel --print-log --no-color --report --version --view-log -c -d -h -l -p -r -V"
+      local opts="--color --config --debug --editor --help --helpcolor --help--all --logpath --loglevel --print-log --no-color --report --version --view-log -c -d -h -l -p -r -V -H"
 
       case "${cur}" in
       # print main options to buildtest

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -133,7 +133,7 @@ _buildtest ()
 
   COMPREPLY=()   # Array variable storing the possible completions.
 
-  declare -a buildtest_opts=("--color" "--config" "--debug" "--editor" "--help" "--helpcolor" "--help-all" "--logpath" "--loglevel" "--print-log" "--no-color" "--report" "--version" "--view-log" "-c" "-d" "-h" "-l" "-p" "-r" "-V" "-H")
+  declare -a buildtest_opts=("--color" "--config" "--debug" "--editor" "--help" "--helpcolor" "--help-all" "--logpath" "--loglevel" "--print-log" "--no-color" "--report" "--version" "--view-log" "-c" "-d" "-h" "-l" "-p" "-r" "-H" "-V")
 
   commands_with_input=( "--color" "--config" "-c" "--report" "-r" "--loglevel" "-l" "--editor" )   # Array variable storing commands which require an input argument from the user.
 

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -133,7 +133,7 @@ _buildtest ()
 
   COMPREPLY=()   # Array variable storing the possible completions.
 
-  declare -a buildtest_opts=("--color" "--config" "--debug" "--editor" "--help" "--helpcolor" "--help--all" "--logpath" "--loglevel" "--print-log" "--no-color" "--report" "--version" "--view-log" "-c" "-d" "-h" "-l" "-p" "-r" "-V" "-H")
+  declare -a buildtest_opts=("--color" "--config" "--debug" "--editor" "--help" "--helpcolor" "--help-all" "--logpath" "--loglevel" "--print-log" "--no-color" "--report" "--version" "--view-log" "-c" "-d" "-h" "-l" "-p" "-r" "-V" "-H")
 
   commands_with_input=( "--color" "--config" "-c" "--report" "-r" "--loglevel" "-l" "--editor" )   # Array variable storing commands which require an input argument from the user.
 
@@ -458,7 +458,7 @@ _buildtest ()
     *)
       local cmds="build buildspec cd cdash clean config debugreport docs help info inspect history path report schema schemadocs stats stylecheck tutorial-examples unittests"
       local alias_cmds="bd bc cg debug it h hy rt style test"
-      local opts="--color --config --debug --editor --help --helpcolor --help--all --logpath --loglevel --print-log --no-color --report --version --view-log -c -d -h -l -p -r -H -V"
+      local opts="--color --config --debug --editor --help --helpcolor --help-all --logpath --loglevel --print-log --no-color --report --version --view-log -c -d -h -l -p -r -H -V"
 
       case "${cur}" in
       # print main options to buildtest

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -426,7 +426,7 @@ def stylecheck_menu(subparsers):
     h_stylecheck = {
         "command": "stylecheck",
         "help_msg": "Run buildtest style checks",
-        "aliases": ["style"],
+        "aliases": ["style"]
     }
     if show_all_help:
         add_hidden_parser(subparsers, h_stylecheck)

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -471,6 +471,7 @@ def tutorial_examples_menu(subparsers):
 
     subparsers.add_parser("tutorial-examples")
 
+
 def path_menu(subparsers):
     """This method builds the command line menu for ``buildtest path`` command
 
@@ -1314,7 +1315,7 @@ def help_all(subparser):
     hidden_parser = {
         "tutorial-examples": "Generate documentation examples for Buildtest Tutorial",
         "docs": "Open buildtest docs in browser",
-        "schemadocs": "Open buildtest schema docs in browser"
+        "schemadocs": "Open buildtest schema docs in browser",
     }
     for command, help_msg in hidden_parser.items():
         subparser.add_parser(command, help=help_msg)
@@ -1328,7 +1329,7 @@ def help_all(subparser):
     h_stylecheck = {
         "command": "stylecheck",
         "help_msg": "Run buildtest style checks",
-        "aliases": ["style"]
+        "aliases": ["style"],
     }
     add_hidden_parser(subparser, h_unittests)
     add_hidden_parser(subparser, h_stylecheck)

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -320,6 +320,9 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         )
         return parent_parser
 
+    # Displays all hidden comands
+    if show_all_help:
+        help_all(subparsers)
     parent_parser = get_parent_parser()
     build_menu(subparsers)
     buildspec_menu(subparsers, parent_parser)
@@ -346,14 +349,6 @@ def misc_menu(subparsers):
     """
 
     # Subcommands that do not need to be shown in --help
-    hidden_parser = {
-        "docs": "Open buildtest docs in browser",
-        "schemadocs": "Open buildtest schema docs in browser",
-    }
-
-    if show_all_help:
-        add_hidden_parser(subparsers, hidden_parser)
-
     subparsers.add_parser("docs")
     subparsers.add_parser("schemadocs")
 
@@ -423,13 +418,6 @@ def stylecheck_menu(subparsers):
     """
 
     # Subcommands that do not need to be shown in --help
-    h_stylecheck = {
-        "command": "stylecheck",
-        "help_msg": "Run buildtest style checks",
-        "aliases": ["style"]
-    }
-    if show_all_help:
-        add_hidden_parser(subparsers, h_stylecheck)
     stylecheck_parser = subparsers.add_parser("stylecheck", aliases=["style"])
 
     stylecheck_parser.add_argument(
@@ -454,14 +442,6 @@ def unittest_menu(subparsers):
     """
 
     # Subcommands that do not need to be shown in --help
-    h_unittests = {
-        "command": "unittests",
-        "help_msg": "Run buildtest unit tests",
-        "aliases": ["test"],
-    }
-    if show_all_help:
-        add_hidden_parser(subparsers, h_unittests)
-
     unittests_parser = subparsers.add_parser("unittests", aliases=["test"])
 
     unittests_parser.add_argument(
@@ -489,16 +469,7 @@ def tutorial_examples_menu(subparsers):
         subparsers (argparse._SubParsersAction): Subparser object to add subparser
     """
 
-    # Subcommands that do not need to be shown in --help
-    hidden_parser = {
-        "tutorial-examples": "Generate documentation examples for Buildtest Tutorial"
-    }
-
-    if show_all_help:
-        add_hidden_parser(subparsers, hidden_parser)
-
     subparsers.add_parser("tutorial-examples")
-
 
 def path_menu(subparsers):
     """This method builds the command line menu for ``buildtest path`` command
@@ -1333,22 +1304,40 @@ def cdash_menu(subparsers):
     )
 
 
-def add_hidden_parser(subparser, hidden_parser):
-    """This method adds a help message to certain parsers
+def help_all(subparser):
+    """This method will add parser for hidden command that can be shown when using --help-all/-H
 
     Args:
         subparsers (argparse._SubParsersAction): Subparser object
-        hidden_parser: dictionary
     """
-    if "command" not in hidden_parser.keys():
-        for command, help_msg in hidden_parser.items():
-            subparser.add_parser(command, help=help_msg)
-        return
+    # Logic to create help message for parsers without aliases
+    hidden_parser = {
+        "tutorial-examples": "Generate documentation examples for Buildtest Tutorial",
+        "docs": "Open buildtest docs in browser",
+        "schemadocs": "Open buildtest schema docs in browser"
+    }
+    for command, help_msg in hidden_parser.items():
+        subparser.add_parser(command, help=help_msg)
 
-    command = hidden_parser.get("command")
-    help_msg = hidden_parser.get("help_msg")
-    als = hidden_parser.get("aliases")
+    # Logic to create help message for parsers with aliases
+    h_unittests = {
+        "command": "unittests",
+        "help_msg": "Run buildtest unit tests",
+        "aliases": ["test"],
+    }
+    h_stylecheck = {
+        "command": "stylecheck",
+        "help_msg": "Run buildtest style checks",
+        "aliases": ["style"]
+    }
+    add_hidden_parser(subparser, h_unittests)
+    add_hidden_parser(subparser, h_stylecheck)
 
-    if type(hidden_parser.get("aliases")) is list:
-        subparser.add_parser(command, help=help_msg, aliases=als)
-        return
+
+def add_hidden_parser(subparser, h_parser):
+    # Creates help message for parsers with aliases
+    command = h_parser.get("command")
+    help_msg = h_parser.get("help_msg")
+    als = h_parser.get("aliases")
+
+    subparser.add_parser(command, help=help_msg, aliases=als)

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -13,9 +13,10 @@ from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import console
 from buildtest.schemas.defaults import schema_table
 
-help1 = '-H' in sys.argv
-help2 = '--help--all' in sys.argv
+help1 = "-H" in sys.argv
+help2 = "--help--all" in sys.argv
 show_all_help = help1 or help2
+
 
 def build_filters_format(val):
     """This method is used as validate argument type for ``buildtest build --filter``.
@@ -264,7 +265,9 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         help="Print available color options in a table format.",
     )
     parser.add_argument("-r", "--report", help="Specify path to test report file")
-    parser.add_argument("-H", "--help--all", help="Show help for all commands", action='help')
+    parser.add_argument(
+        "-H", "--help--all", help="Show help for all commands", action="help"
+    )
 
     subparsers = parser.add_subparsers(title="COMMANDS", dest="subcommands", metavar="")
 
@@ -359,7 +362,9 @@ def misc_menu(subparsers):
     )
 
     if show_all_help:
-        subparsers.add_parser("schemadocs", help="Open buildtest schema docs in browser")
+        subparsers.add_parser(
+            "schemadocs", help="Open buildtest schema docs in browser"
+        )
         subparsers.add_parser("docs", help="Open buildtest docs in browser")
     else:
         subparsers.add_parser("schemadocs")
@@ -418,9 +423,7 @@ def stylecheck_menu(subparsers):
             "stylecheck", aliases=["style"], help="Run buildtest style checks"
         )
     else:
-        stylecheck_parser = subparsers.add_parser(
-            "stylecheck", aliases=["style"]
-        )
+        stylecheck_parser = subparsers.add_parser("stylecheck", aliases=["style"])
 
     stylecheck_parser.add_argument(
         "--no-black", action="store_true", help="Don't run black style check"
@@ -444,12 +447,10 @@ def unittest_menu(subparsers):
     """
     if show_all_help:
         unittests_parser = subparsers.add_parser(
-            "unittests", help="Run buildtest unit tests",aliases=["test"]
+            "unittests", help="Run buildtest unit tests", aliases=["test"]
         )
     else:
-        unittests_parser = subparsers.add_parser(
-            "unittests", aliases=["test"]
-        )
+        unittests_parser = subparsers.add_parser("unittests", aliases=["test"])
     unittests_parser.add_argument(
         "-c",
         "--coverage",
@@ -480,9 +481,7 @@ def tutorial_examples_menu(subparsers):
             help="Generate documentation examples for Buildtest Tutorial",
         )
     else:
-        subparsers.add_parser(
-            "tutorial-examples",
-        )
+        subparsers.add_parser("tutorial-examples")
 
 
 def path_menu(subparsers):

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -320,9 +320,6 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         )
         return parent_parser
 
-    # Displays all hidden comands
-    if show_all_help:
-        help_all(subparsers)
     parent_parser = get_parent_parser()
     build_menu(subparsers)
     buildspec_menu(subparsers, parent_parser)
@@ -338,6 +335,10 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
     misc_menu(subparsers)
     tutorial_examples_menu(subparsers)
 
+    # Displays all hidden comands
+    if show_all_help:
+        help_all(subparsers)
+
     return parser
 
 
@@ -348,7 +349,7 @@ def misc_menu(subparsers):
         subparsers (argparse._SubParsersAction): Subparser object to add subparser
     """
 
-    # Subcommands that do not need to be shown in --help
+    # Subcommands that do not need to be shown in ``--help``
     subparsers.add_parser("docs")
     subparsers.add_parser("schemadocs")
 
@@ -417,7 +418,7 @@ def stylecheck_menu(subparsers):
         subparsers (argparse._SubParsersAction): Subparser object to add subparser
     """
 
-    # Subcommands that do not need to be shown in --help
+    # Subcommands that do not need to be shown in ``--help``
     stylecheck_parser = subparsers.add_parser("stylecheck", aliases=["style"])
 
     stylecheck_parser.add_argument(
@@ -1306,7 +1307,7 @@ def cdash_menu(subparsers):
 
 
 def help_all(subparsers):
-    """This method will add parser for hidden command that can be shown when using --help-all/-H
+    """This method will add parser for hidden command that can be shown when using ``--help-all/-H``
 
     Args:
         subparsers (argparse._SubParsersAction): Subparser object

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -15,7 +15,7 @@ from buildtest.schemas.defaults import schema_table
 
 # Variables needed to show all sub commands and their help mesaage
 help1 = "-H" in sys.argv
-help2 = "--help--all" in sys.argv
+help2 = "--help-all" in sys.argv
 show_all_help = help1 or help2
 
 
@@ -267,7 +267,7 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
     )
     parser.add_argument("-r", "--report", help="Specify path to test report file")
     parser.add_argument(
-        "-H", "--help--all", help="Show help for all commands", action="help"
+        "-H", "--help-all", help="Show help for all commands", action="help"
     )
 
     subparsers = parser.add_subparsers(title="COMMANDS", dest="subcommands", metavar="")

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -4,6 +4,7 @@ interact with a global configuration for buildtest.
 """
 import argparse
 import datetime
+import sys
 
 from pygments.styles import STYLE_MAP
 from rich.color import Color, ColorParseError
@@ -12,6 +13,9 @@ from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import console
 from buildtest.schemas.defaults import schema_table
 
+help1 = '-H' in sys.argv
+help2 = '--help--all' in sys.argv
+show_all_help = help1 or help2
 
 def build_filters_format(val):
     """This method is used as validate argument type for ``buildtest build --filter``.
@@ -260,6 +264,7 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         help="Print available color options in a table format.",
     )
     parser.add_argument("-r", "--report", help="Specify path to test report file")
+    parser.add_argument("-H", "--help--all", help="Show help for all commands", action='help')
 
     subparsers = parser.add_subparsers(title="COMMANDS", dest="subcommands", metavar="")
 
@@ -353,8 +358,12 @@ def misc_menu(subparsers):
         "-y", "--yes", action="store_true", help="Confirm yes for all prompts"
     )
 
-    subparsers.add_parser("docs", help="Open buildtest docs in browser")
-    subparsers.add_parser("schemadocs", help="Open buildtest schema docs in browser")
+    if show_all_help:
+        subparsers.add_parser("schemadocs", help="Open buildtest schema docs in browser")
+        subparsers.add_parser("docs", help="Open buildtest docs in browser")
+    else:
+        subparsers.add_parser("schemadocs")
+        subparsers.add_parser("docs")
     subparsers.add_parser(
         "debugreport",
         help="Display system information and additional information for debugging purposes.",
@@ -404,10 +413,14 @@ def stylecheck_menu(subparsers):
     Args:
         subparsers (argparse._SubParsersAction): Subparser object to add subparser
     """
-
-    stylecheck_parser = subparsers.add_parser(
-        "stylecheck", aliases=["style"], help="Run buildtest style checks"
-    )
+    if show_all_help:
+        stylecheck_parser = subparsers.add_parser(
+            "stylecheck", aliases=["style"], help="Run buildtest style checks"
+        )
+    else:
+        stylecheck_parser = subparsers.add_parser(
+            "stylecheck", aliases=["style"]
+        )
 
     stylecheck_parser.add_argument(
         "--no-black", action="store_true", help="Don't run black style check"
@@ -429,10 +442,14 @@ def unittest_menu(subparsers):
     Args:
         subparsers (argparse._SubParsersAction): Subparser object to add subparser
     """
-
-    unittests_parser = subparsers.add_parser(
-        "unittests", help="Run buildtest unit tests", aliases=["test"]
-    )
+    if show_all_help:
+        unittests_parser = subparsers.add_parser(
+            "unittests", help="Run buildtest unit tests",aliases=["test"]
+        )
+    else:
+        unittests_parser = subparsers.add_parser(
+            "unittests", aliases=["test"]
+        )
     unittests_parser.add_argument(
         "-c",
         "--coverage",
@@ -457,11 +474,15 @@ def tutorial_examples_menu(subparsers):
     Args:
         subparsers (argparse._SubParsersAction): Subparser object to add subparser
     """
-
-    subparsers.add_parser(
-        "tutorial-examples",
-        help="Generate documentation examples for Buildtest Tutorial",
-    )
+    if show_all_help:
+        subparsers.add_parser(
+            "tutorial-examples",
+            help="Generate documentation examples for Buildtest Tutorial",
+        )
+    else:
+        subparsers.add_parser(
+            "tutorial-examples",
+        )
 
 
 def path_menu(subparsers):

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -1305,40 +1305,24 @@ def cdash_menu(subparsers):
     )
 
 
-def help_all(subparser):
+def help_all(subparsers):
     """This method will add parser for hidden command that can be shown when using --help-all/-H
 
     Args:
         subparsers (argparse._SubParsersAction): Subparser object
     """
-    # Logic to create help message for parsers without aliases
     hidden_parser = {
         "tutorial-examples": "Generate documentation examples for Buildtest Tutorial",
         "docs": "Open buildtest docs in browser",
         "schemadocs": "Open buildtest schema docs in browser",
+        "unittests": {"help": "Run buildtest unit tests", "aliases": ["test"]},
+        "stylecheck": {"help": "Run buildtest style checks", "aliases": ["style"]},
     }
-    for command, help_msg in hidden_parser.items():
-        subparser.add_parser(command, help=help_msg)
 
-    # Logic to create help message for parsers with aliases
-    h_unittests = {
-        "command": "unittests",
-        "help_msg": "Run buildtest unit tests",
-        "aliases": ["test"],
-    }
-    h_stylecheck = {
-        "command": "stylecheck",
-        "help_msg": "Run buildtest style checks",
-        "aliases": ["style"],
-    }
-    add_hidden_parser(subparser, h_unittests)
-    add_hidden_parser(subparser, h_stylecheck)
-
-
-def add_hidden_parser(subparser, h_parser):
-    # Creates help message for parsers with aliases
-    command = h_parser.get("command")
-    help_msg = h_parser.get("help_msg")
-    als = h_parser.get("aliases")
-
-    subparser.add_parser(command, help=help_msg, aliases=als)
+    for command, val in hidden_parser.items():
+        if type(val) is dict:
+            subparsers.add_parser(
+                command, help=val.get("help"), aliases=val.get("aliases")
+            )
+        else:
+            subparsers.add_parser(command, help=val)

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -13,6 +13,7 @@ from buildtest import BUILDTEST_COPYRIGHT, BUILDTEST_VERSION
 from buildtest.defaults import console
 from buildtest.schemas.defaults import schema_table
 
+# Variables needed to show all sub commands and their help mesaage
 help1 = "-H" in sys.argv
 help2 = "--help--all" in sys.argv
 show_all_help = help1 or help2
@@ -361,6 +362,7 @@ def misc_menu(subparsers):
         "-y", "--yes", action="store_true", help="Confirm yes for all prompts"
     )
 
+    # Subcommands that do not need to be shown in --help
     if show_all_help:
         subparsers.add_parser(
             "schemadocs", help="Open buildtest schema docs in browser"
@@ -369,6 +371,7 @@ def misc_menu(subparsers):
     else:
         subparsers.add_parser("schemadocs")
         subparsers.add_parser("docs")
+
     subparsers.add_parser(
         "debugreport",
         help="Display system information and additional information for debugging purposes.",
@@ -418,6 +421,8 @@ def stylecheck_menu(subparsers):
     Args:
         subparsers (argparse._SubParsersAction): Subparser object to add subparser
     """
+
+    # Subcommands that do not need to be shown in --help
     if show_all_help:
         stylecheck_parser = subparsers.add_parser(
             "stylecheck", aliases=["style"], help="Run buildtest style checks"
@@ -445,12 +450,15 @@ def unittest_menu(subparsers):
     Args:
         subparsers (argparse._SubParsersAction): Subparser object to add subparser
     """
+
+    # Subcommands that do not need to be shown in --help
     if show_all_help:
         unittests_parser = subparsers.add_parser(
             "unittests", help="Run buildtest unit tests", aliases=["test"]
         )
     else:
         unittests_parser = subparsers.add_parser("unittests", aliases=["test"])
+
     unittests_parser.add_argument(
         "-c",
         "--coverage",
@@ -475,6 +483,8 @@ def tutorial_examples_menu(subparsers):
     Args:
         subparsers (argparse._SubParsersAction): Subparser object to add subparser
     """
+
+    # Subcommands that do not need to be shown in --help
     if show_all_help:
         subparsers.add_parser(
             "tutorial-examples",


### PR DESCRIPTION
Closes  #1453 

- Changed the behavior of `--help` / `-h`. Some subcommands and there respective help messages were removed since they are only used for development purposes, it will now only show less subcommands. 
- Added the subcommand `--help-all` / `-H`, which will now do what `--help` did before. It will show all subcommands and their help message.

Output of `-h` and `--help`:
```console
optional arguments:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
  -c CONFIGFILE, --config CONFIGFILE
                        Specify Path to Configuration File
  -d, --debug           Stream log messages to stdout
  -l {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                        Filter log messages based on logging level
  --editor {vi,vim,emacs,nano}
                        Select your preferred editor when opening files.
  --view-log            Show content of last log
  --logpath             Print full path to last log file
  --print-log           Print content of last log without pagination
  --color COLOR         Print output of table with the selected color.
  --no-color            Disable colored output
  --helpcolor           Print available color options in a table format.
  -r REPORT, --report REPORT
                        Specify path to test report file
  -H, --help--all       Show help for all commands

COMMANDS:
  
    build (bd)          Build and Run test
    buildspec (bc)      Buildspec Interface
    config (cg)         Query buildtest configuration
    report (rt)         Query test report
    inspect (it)        Inspect a test based on NAME or ID
    path                Show path attributes for a given test
    history (hy)        Query build history
    schema              List schema contents and examples
    cdash               Upload test to CDASH server
    cd                  change directory to root of test given a test name
    clean               Remove all generate files from buildtest including test directory, log files, report file, buildspec cache, history files.
    debugreport (debug)
                        Display system information and additional information for debugging purposes.
    stats               Show test statistics for given test
    info                Show details regarding current buildtest setup
    show (s)            buildtest command guide

```

Output of `-H` and `--help-all`

```console
optional arguments:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
  -c CONFIGFILE, --config CONFIGFILE
                        Specify Path to Configuration File
  -d, --debug           Stream log messages to stdout
  -l {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                        Filter log messages based on logging level
  --editor {vi,vim,emacs,nano}
                        Select your preferred editor when opening files.
  --view-log            Show content of last log
  --logpath             Print full path to last log file
  --print-log           Print content of last log without pagination
  --color COLOR         Print output of table with the selected color.
  --no-color            Disable colored output
  --helpcolor           Print available color options in a table format.
  -r REPORT, --report REPORT
                        Specify path to test report file
  -H, --help--all       Show help for all commands

COMMANDS:
  
    build (bd)          Build and Run test
    buildspec (bc)      Buildspec Interface
    config (cg)         Query buildtest configuration
    report (rt)         Query test report
    inspect (it)        Inspect a test based on NAME or ID
    path                Show path attributes for a given test
    history (hy)        Query build history
    schema              List schema contents and examples
    cdash               Upload test to CDASH server
    unittests (test)    Run buildtest unit tests
    stylecheck (style)  Run buildtest style checks
    cd                  change directory to root of test given a test name
    clean               Remove all generate files from buildtest including test directory, log files, report file, buildspec cache, history files.
    schemadocs          Open buildtest schema docs in browser
    docs                Open buildtest docs in browser
    debugreport (debug)
                        Display system information and additional information for debugging purposes.
    stats               Show test statistics for given test
    info                Show details regarding current buildtest setup
    show (s)            buildtest command guide
    tutorial-examples   Generate documentation examples for Buildtest Tutorial
```
