### PR TITLE
Remove short option "-t" for "--theme"

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -261,10 +261,10 @@ _buildtest ()
           local opts="-h --help"
           COMPREPLY=( $( compgen -W "${opts}" -- $cur ) );;
         view|v)
-          local opts="--help --pager --theme -h -t"
+          local opts="--help --pager --theme -h"
           COMPREPLY=( $( compgen -W "${opts}" -- $cur ) )
 
-          case "${prev}" in --theme|-t)
+          case "${prev}" in --theme)
             COMPREPLY=( $( compgen -W "$(_avail_color_themes)" -- $cur ) )
             return
           esac
@@ -362,7 +362,7 @@ _buildtest ()
           COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
         fi
 
-        case "${prev}" in --theme|-t)
+        case "${prev}" in --theme)
           COMPREPLY=( $( compgen -W "$(_avail_color_themes)" -- $cur ) )
           return
         esac
@@ -373,7 +373,7 @@ _buildtest ()
         if [[ $cur == -* ]] ; then
           COMPREPLY=( $( compgen -W "$opts" -- $cur ) )
         fi
-        case "${prev}" in --theme|-t)
+        case "${prev}" in --theme)
           COMPREPLY=( $( compgen -W "$(_avail_color_themes)" -- $cur ) )
           return
         esac

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -305,7 +305,6 @@ Please report issues at https://github.com/buildtesters/buildtest/issues
         )
         parent_parser["theme"] = argparse.ArgumentParser(add_help=False)
         parent_parser["theme"].add_argument(
-            "-t",
             "--theme",
             metavar="Color Themes",
             help="Specify a color theme, Pygments style to use when displaying output. See https://pygments.org/docs/styles/#getting-a-list-of-available-styles for available themese",

--- a/docs/command_line_tutorial.rst
+++ b/docs/command_line_tutorial.rst
@@ -218,12 +218,12 @@ Let's run the following::
     buildtest bc show sleep hello_world
 
 Buildtest uses `rich <https://rich.readthedocs.io/>`_ python library for coloring which is used extensively throughout the buildtest output.
-Rich supports several built-in themes that can be used for your preference. The ``buildtest bc show -t <THEME>`` can be used
+Rich supports several built-in themes that can be used for your preference. The ``buildtest bc show --theme <THEME>`` can be used
 select a color theme.
 
 Currently, buildtest supports the following themes, feel free to tab complete::
 
-       buildtest bc show -t
+       buildtest bc show --theme
     abap                borland             emacs               gruvbox-dark        lovelace            native              paraiso-light       sas                 stata-dark          vs
     algol               bw                  friendly            gruvbox-light       manni               nord                pastie              solarized-dark      stata-light         xcode
     algol_nu            colorful            friendly_grayscale  igor                material            nord-darker         perldoc             solarized-light     tango               zenburn
@@ -232,7 +232,7 @@ Currently, buildtest supports the following themes, feel free to tab complete::
 
 Let's try running the same example with ``emacs`` theme::
 
-    buildtest bc show -t emacs sleep
+    buildtest bc show --theme emacs sleep
 
 If you want to see list of invalid buildspecs you can run::
 


### PR DESCRIPTION
To complete this issue the following will be done:
- [x] Update [bash completion](https://github.com/buildtesters/buildtest/blob/devel/bash_completion.sh) script and remove -t option wherever its used for --theme
- [x] Remove -t from documentation wherever its mentioned for --theme also check all .. command-output where its -t and replace with --theme
- [x] Update any docstring or comment throughout the code base