### PR TITLE
fix where buildtest commands were printed in every run

### DIFF
--- a/buildtest/cli/commands.py
+++ b/buildtest/cli/commands.py
@@ -1,29 +1,28 @@
 def list_buildtest_commands():
     """This method implements command ``buildtest commands`` which shows a list of buildtest commands"""
 
+    cmds_list = [
+        "build",
+        "buildspec",
+        "cd",
+        "cdash",
+        "clean",
+        "config",
+        "debugreport",
+        "docs",
+        "history",
+        "info",
+        "inspect",
+        "path",
+        "report",
+        "schema",
+        "schemadocs",
+        "show",
+        "stats",
+        "stylecheck",
+        "tutorial-examples",
+        "unittests",
+    ]
 
-cmds_list = [
-    "build",
-    "buildspec",
-    "cd",
-    "cdash",
-    "clean",
-    "config",
-    "debugreport",
-    "docs",
-    "history",
-    "info",
-    "inspect",
-    "path",
-    "report",
-    "schema",
-    "schemadocs",
-    "show",
-    "stats",
-    "stylecheck",
-    "tutorial-examples",
-    "unittests",
-]
-
-for field in cmds_list:
-    print(field)
+    for field in cmds_list:
+        print(field)


### PR DESCRIPTION
@braeeast2001 i fixed an issue with `buildtest commands` apparently i discovered this when i saw the CI checks and is present on `devel` branch

```console
(buildtest)  ~/Documents/github/buildtest/ [devel] buildtest cg validate
build
buildspec
cd
cdash
clean
config
debugreport
docs
history
info
inspect
path
report
schema
schemadocs
show
stats
stylecheck
tutorial-examples
unittests
/Users/siddiq90/Documents/github/buildtest/buildtest/settings/config.yml is valid
```

You forgot to indent the code and instead it was run when file was imported everytime which was why this output was printed. 