### PR TITLE
Assign Vars value to metrics

### DIFF
--- a/buildtest/schemas/definitions.schema.json
+++ b/buildtest/schemas/definitions.schema.json
@@ -200,7 +200,7 @@
           "$ref": "#/definitions/regex"
         },
         "vars": {
-          "$ref": "#/definitions/vars"
+          "$ref": "#/definitions/env"
         },
         "file_regex": {
           "$ref": "#/definitions/file_regex_in_metrics"
@@ -221,25 +221,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/metrics_field"
       }
-    },
-    "vars": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "Specify the type of the variable",
-          "enum": [
-            "str",
-            "int",
-            "float"
-          ]
-        }
-      }
-    },
+    }
     "state": {
       "type": "string",
       "description": "explicitly mark state of test regardless of status calculation",

--- a/buildtest/schemas/definitions.schema.json
+++ b/buildtest/schemas/definitions.schema.json
@@ -199,13 +199,17 @@
         "regex": {
           "$ref": "#/definitions/regex"
         },
+        "vars": {
+          "$ref": "#/definitions/vars"
+        },
         "file_regex": {
           "$ref": "#/definitions/file_regex_in_metrics"
         }
       },
         "oneOf": [
           { "required": ["regex" ] },
-          { "required": [ "file_regex"] }
+          { "required": [ "file_regex"] },
+          { "required": [ "vars"] }
         ]
     },
     "metrics": {
@@ -216,6 +220,24 @@
       },
       "additionalProperties": {
         "$ref": "#/definitions/metrics_field"
+      }
+    },
+    "vars": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Specify the type of the variable",
+          "enum": [
+            "str",
+            "int",
+            "float"
+          ]
+        }
       }
     },
     "state": {


### PR DESCRIPTION
This pull is to assign metrics from variables defined in tests. A property name vars is defined with value for vars.