### PR TITLE
exclude cdash url from url check

### DIFF
--- a/.github/workflows/urlchecker.yml
+++ b/.github/workflows/urlchecker.yml
@@ -35,6 +35,6 @@ jobs:
         retry_count: 5
 
         # Cannot check private GitHub settings
-        exclude_patterns: https://github.com/buildtesters/buildtest/settings,https://hpckp.org/past-edition/hpckp-17/,https://hpckp.org/past-edition/hpckp-18,https://sc19.supercomputing.org/presentation/?id=bof195&sess=sess324,https://sc19.supercomputing.org/,https://trac.mcs.anl.gov/projects/cobalt,https://cache.e4s.io,https://readthedocs.org/accounts/signup/,http://localhost:9000,https://www.hpcwire.com/2019/01/17/pfizer-hpc-engineer-aims-to-automate-software-stack-testing/
+        exclude_patterns: https://github.com/buildtesters/buildtest/settings,https://hpckp.org/past-edition/hpckp-17/,https://hpckp.org/past-edition/hpckp-18,https://sc19.supercomputing.org/presentation/?id=bof195&sess=sess324,https://sc19.supercomputing.org/,https://trac.mcs.anl.gov/projects/cobalt,https://cache.e4s.io,https://readthedocs.org/accounts/signup/,http://localhost:9000,https://www.hpcwire.com/2019/01/17/pfizer-hpc-engineer-aims-to-automate-software-stack-testing/,https://my.cdash.org/
         
         verbose: true


### PR DESCRIPTION
this PR will exclude the cdash url https://my.cdash.org/ from the url checker action since some of the paths like https://my.cdash.org//viewTest.php?buildid=2278337 will get broken over time.