### PR TITLE
readthedocs build to not fail on warning messages

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ version: 2
 sphinx:
     builder: html
     configuration: docs/conf.py
-    fail_on_warning: true
+    #fail_on_warning: true
 
 build:
   os: "ubuntu-20.04"


### PR DESCRIPTION
This PR will ensure we get docs generated when there are warning messages like the one in #1607 