### PR TITLE
fix issue with CDASH upload with uniccode characters

### DIFF
--- a/buildtest/cli/cdash.py
+++ b/buildtest/cli/cdash.py
@@ -250,6 +250,10 @@ def upload_test_cdash(
                     ansi_escape.sub("", test["output"])
                     ansi_escape.sub("", test["error"])
 
+                    # need to encode in ASCII characters for example any uniccoded characters will cause CDASH upload to fail
+                    test["output"] = test["output"].encode("ascii", "ignore").decode()
+                    test["error"] = test["error"].encode("ascii", "ignore").decode()
+
     console.print(f"Uploading {len(tests)} tests")
 
     build_stamp = build_starttime.strftime(output_datetime_format)


### PR DESCRIPTION
CDASH can't handle output when there are uniccode characters in output this will result in failure. This PR will force output and error to be encoded in ascii characters and remove all other characters