### PR TITLE
change logic of how build scripts are run

### DIFF
--- a/buildtest/builders/base.py
+++ b/buildtest/builders/base.py
@@ -165,11 +165,10 @@ class BuilderBase(ABC):
 
     def shell_detection(self):
         """Detect shell and shebang used for test script"""
-
         # if 'shell' property not defined in buildspec use this shell otherwise use the 'shell' property from the executor definition
         self.shell = Shell(
             self.recipe.get("shell")
-            or self.buildexecutor.executors[self.executor].shell
+            or self.buildexecutor.executors[self.executor]._settings.get("shell")
         )
 
         # set shebang to value defined in Buildspec, if not defined then get one from Shell class
@@ -608,11 +607,8 @@ trap cleanup SIGINT SIGTERM SIGHUP SIGQUIT SIGABRT SIGKILL SIGALRM SIGPIPE SIGTE
 
         lines.append("# Get return code")
 
-        # for csh returncode is determined by $status environment, for bash,sh,zsh its $?
-        if is_csh_shell(self.shell.name):
-            lines.append("set returncode = $status")
-        else:
-            lines.append("returncode=$?")
+        # get returncode of executed script which is retrieved by '$?'
+        lines.append("returncode=$?")
 
         lines.append("# Exit with return code")
         lines.append("exit $returncode")
@@ -670,16 +666,16 @@ trap cleanup SIGINT SIGTERM SIGHUP SIGQUIT SIGABRT SIGKILL SIGALRM SIGPIPE SIGTE
             Test can be run with shell name followed by path to script: ``bash /path/to/script.sh``
             Test can be run with shell name, shell options and path to script: ``bash -x /path/to/script.sh``
         """
-
+        console.print(f"{self}: {self.recipe.get('shell')} {self.shell.opts}")
         # if not self.recipe.get("shell") or self.recipe.get("shell") == "python":
         if self.recipe.get("shell") == "python":
             return [self.testpath]
 
-        if not self.recipe.get("shell"):
-            return [self.shell.name, self.shell.default_opts, self.testpath]
+        # if not self.recipe.get("shell"):
+        #    return [self.shell.name, self.shell.default_opts, self.testpath]
 
-        if not self.shell.opts:
-            return [self.shell.name, self.testpath]
+        # if not self.shell.opts:
+        #    return [self.shell.name, self.testpath]
 
         return [self.shell.name, self.shell.opts, self.testpath]
 
@@ -696,20 +692,6 @@ trap cleanup SIGINT SIGTERM SIGHUP SIGQUIT SIGABRT SIGKILL SIGALRM SIGPIPE SIGTE
         """Return a list of lines inserted in build script that define buildtest specific variables
         that can be referenced when writing tests. The buildtest variables all start with BUILDTEST_*
         """
-
-        if is_csh_shell(self.shell.name):
-            lines = [
-                f"setenv BUILDTEST_TEST_NAME {self.name}",
-                f"setenv BUILDTEST_TEST_ROOT {self.test_root}",
-                f"setenv BUILDTEST_BUILDSPEC_DIR {os.path.dirname(self.buildspec)}",
-                f"setenv BUILDTEST_STAGE_DIR {self.stage_dir}",
-            ]
-            if self.numnodes:
-                lines.append(f"setenv BUILDTEST_NUMNODES {self.numnodes}")
-            if self.numprocs:
-                lines.append(f"setenv BUILDTEST_NUMPROCS {self.numprocs}")
-
-            return lines
 
         lines = [
             f"export BUILDTEST_TEST_NAME={self.name}",

--- a/buildtest/builders/base.py
+++ b/buildtest/builders/base.py
@@ -595,9 +595,7 @@ trap cleanup SIGINT SIGTERM SIGHUP SIGQUIT SIGABRT SIGKILL SIGALRM SIGPIPE SIGTE
         lines.append("# Run generated script")
         # local executor
         if self.is_local_executor():
-            cmd = self._emit_command()
-
-            lines += [" ".join(cmd)]
+            lines += [" ".join(self._emit_command())]
         # batch executor
         else:
             launcher = self.buildexecutor.executors[self.executor].launcher_command(
@@ -666,7 +664,6 @@ trap cleanup SIGINT SIGTERM SIGHUP SIGQUIT SIGABRT SIGKILL SIGALRM SIGPIPE SIGTE
             Test can be run with shell name followed by path to script: ``bash /path/to/script.sh``
             Test can be run with shell name, shell options and path to script: ``bash -x /path/to/script.sh``
         """
-        console.print(f"{self}: {self.recipe.get('shell')} {self.shell.opts}")
         # if not self.recipe.get("shell") or self.recipe.get("shell") == "python":
         if self.recipe.get("shell") == "python":
             return [self.testpath]

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -34,11 +34,6 @@ class BaseExecutor:
             maxpendtime (int, optional): Maximum Pending Time until job is cancelled. The default is 1 day (86400s)
         """
 
-        self._bashopts = "--norc --noprofile -eo pipefail"
-        self._shopts = "--norc --noprofile -eo pipefail"
-        self._cshopts = "-ef"
-        self._zshopts = "-f"
-        self.cmd = None
         self.shell = "bash"
         self.logger = logging.getLogger(__name__)
         self.name = name

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -68,7 +68,7 @@ class CobaltExecutor(BaseExecutor):
 
         os.chdir(builder.stage_dir)
 
-        cmd = f"bash {self._bashopts} {os.path.basename(builder.build_script)}"
+        cmd = f"{self.shell} {os.path.basename(builder.build_script)}"
 
         timeout = self.timeout or self._buildtestsettings.target_config.get("timeout")
 

--- a/buildtest/executors/local.py
+++ b/buildtest/executors/local.py
@@ -5,11 +5,9 @@ when initializing the executors.
 """
 
 import os
-import shlex
 
 from buildtest.executors.base import BaseExecutor
 from buildtest.utils.file import write_file
-from buildtest.utils.shell import is_bash_shell, is_csh_shell, is_sh_shell, is_zsh_shell
 
 
 class LocalExecutor(BaseExecutor):
@@ -19,28 +17,6 @@ class LocalExecutor(BaseExecutor):
     """
 
     type = "local"
-
-    def load(self):
-        self.shell = shlex.split(self._settings["shell"])[0]
-        shell_options = shlex.split(self._settings["shell"])[1:]
-
-        self.cmd = [self.shell]
-
-        # default options for shell if no shell option specified
-        if is_bash_shell(self.shell) and not shell_options:
-            self.cmd.append(self._bashopts)
-
-        elif is_sh_shell(self.shell) and not shell_options:
-            self.cmd.append(self._shopts)
-
-        elif is_csh_shell(self.shell) and not shell_options:
-            self.cmd.append(self._cshopts)
-
-        elif is_zsh_shell(self.shell) and not shell_options:
-            self.cmd.append(self._zshopts)
-
-        if shell_options:
-            self.cmd.append(" ".join(shell_options))
 
     def run(self, builder):
         """This method is responsible for running test for LocalExecutor which
@@ -56,8 +32,7 @@ class LocalExecutor(BaseExecutor):
         os.chdir(builder.stage_dir)
         self.logger.debug(f"Changing to directory {builder.stage_dir}")
 
-        run_cmd = self.cmd + [os.path.basename(builder.build_script)]
-        run_cmd = " ".join(run_cmd)
+        run_cmd = f"{self.shell} {os.path.basename(builder.build_script)}"
 
         # ---------- Start of Run ---------- #
         timeout = self.timeout or self._buildtestsettings.target_config.get("timeout")

--- a/buildtest/executors/lsf.py
+++ b/buildtest/executors/lsf.py
@@ -78,7 +78,7 @@ class LSFExecutor(BaseExecutor):
         os.chdir(builder.stage_dir)
         self.logger.debug(f"Changing to stage directory {builder.stage_dir}")
 
-        cmd = f"bash {self._bashopts} {os.path.basename(builder.build_script)}"
+        cmd = f"{self.shell} {os.path.basename(builder.build_script)}"
 
         self.timeout = self.timeout or self._buildtestsettings.target_config.get(
             "timeout"

--- a/buildtest/executors/pbs.py
+++ b/buildtest/executors/pbs.py
@@ -70,7 +70,7 @@ class PBSExecutor(BaseExecutor):
 
         os.chdir(builder.stage_dir)
 
-        cmd = f"bash {self._bashopts} {os.path.basename(builder.build_script)}"
+        cmd = f"{self.shell} {os.path.basename(builder.build_script)}"
 
         self.timeout = self.timeout or self._buildtestsettings.target_config.get(
             "timeout"

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -80,7 +80,7 @@ class SlurmExecutor(BaseExecutor):
         os.chdir(builder.stage_dir)
         self.logger.debug(f"Changing to directory {builder.stage_dir}")
 
-        cmd = f"bash {self._bashopts} {os.path.basename(builder.build_script)}"
+        cmd = f"{self.shell} {os.path.basename(builder.build_script)}"
 
         self.timeout = self.timeout or self._buildtestsettings.target_config.get(
             "timeout"

--- a/buildtest/settings/config.yml
+++ b/buildtest/settings/config.yml
@@ -50,13 +50,13 @@ system:
       local:
         bash:
           description: submit jobs on local machine using bash shell
-          shell: bash
+          shell: bash --noprofile --norc
         sh:
           description: submit jobs on local machine using sh shell
           shell: sh
         csh:
           description: submit jobs on local machine using csh shell
-          shell: csh
+          shell: csh -xv
         zsh:
           description: submit jobs on local machine using zsh shell
           shell: zsh

--- a/buildtest/settings/config.yml
+++ b/buildtest/settings/config.yml
@@ -50,13 +50,13 @@ system:
       local:
         bash:
           description: submit jobs on local machine using bash shell
-          shell: bash --noprofile --norc
+          shell: bash
         sh:
           description: submit jobs on local machine using sh shell
           shell: sh
         csh:
           description: submit jobs on local machine using csh shell
-          shell: csh -xv
+          shell: csh
         zsh:
           description: submit jobs on local machine using zsh shell
           shell: zsh

--- a/buildtest/utils/shell.py
+++ b/buildtest/utils/shell.py
@@ -151,16 +151,6 @@ class Shell:
 
         self._opts = " ".join(shell.split()[1:])
         self.path = self.name
-        self.default_opts = None
-
-        if self.name == "bash":
-            self.default_opts = "--norc --noprofile -eo pipefail"
-        elif self.name == "csh":
-            self.default_opts = "-ef"
-        elif self.name == "zsh":
-            self.default_opts = "-f"
-        else:
-            self.default_opts = ""
 
     @property
     def opts(self):

--- a/tutorials/csh_shell_examples.yml
+++ b/tutorials/csh_shell_examples.yml
@@ -8,9 +8,9 @@ buildspecs:
     vars:
       file: "/etc/csh.cshrc"
     run: |
-      if (-e $file) then
-        echo "$file file found"
-      else
+      if (! -e $file) then
         echo "$file file not found"
         exit 1
+      else
+        echo "$file file found"        
       endif


### PR DESCRIPTION
This PR will change the following.
1. All test will be invoked with `bash` without any options when executing the buildscript. Previously the build script was invoked with shell type for the executor along with defined shell options 
2. The run command in the build script that will execute the actual test will be using the shell type of the executor or the `shell` key defined in the buildspec. Any shell options specified in the executor or in buildspec will be passed to script as well.
3. Remove unused variables and `load` method from the LocalExecutor class