### PR TITLE
add new aliases for list and profile command

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -245,7 +245,7 @@ _buildtest ()
     report|rt)
       local opts="--detailed --end --fail --filter --filterfields --format --formatfields --help --helpfilter --helpformat --latest --no-header --oldest --pager --pass --row-count --start --terse -d -e -f -h -n -p -s -t"
       local cmds="clear list path summary"
-      local aliases="c l p sm"
+      local aliases="c ls p sm"
       COMPREPLY=( $( compgen -W "${cmds} ${aliases}" -- "${cur}" ) )
 
       if [[ $cur == -* ]] ; then
@@ -307,10 +307,10 @@ _buildtest ()
           esac
           ;;
         executors|ex)
-          local cmds="list rm remove"
+          local cmds="list ls rm remove"
 
           case ${COMP_WORDS[3+offset]} in
-              list)
+              list|ls)
                   local opts="--help --all --disabled --invalid --json --yaml -a -d -h -i -j -y"
                   COMPREPLY=( $( compgen -W "$opts" -- "${cur}" ) )
                   ;;
@@ -334,10 +334,10 @@ _buildtest ()
             ;;
           esac
         ;;
-        profiles)
+        profiles|prof)
           local opts="--help -h"
           local cmds="list remove"
-          local aliases="rm"
+          local aliases="ls rm"
           COMPREPLY=( $( compgen -W "${cmds} ${aliases}" -- "${cur}" ) )
           if [[ $cur == -* ]] ; then
             COMPREPLY=( $( compgen -W "$opts" -- "${cur}" ) )
@@ -347,7 +347,7 @@ _buildtest ()
             remove|rm)
               COMPREPLY=( $( compgen -W "$(_avail_profiles)" -- "${cur}" ) )
               ;;
-            list)
+            list|ls)
               local opts="--json --theme --yaml -j -y"
               COMPREPLY=( $( compgen -W "${opts}" -- "${cur}" ) )
               ;;
@@ -359,12 +359,12 @@ _buildtest ()
         esac
       ;;
     inspect|it)
-      local cmds="--help -h b buildspec l list n name q query"
+      local cmds="--help -h b buildspec ls list n name q query"
       COMPREPLY=( $( compgen -W "${cmds}" -- "${cur}" ) )
 
       # case statement to handle completion for buildtest inspect [name|id|list] command
       case "${COMP_WORDS[2+offset]}" in
-        list|l)
+        list|ls)
           local opts="--builder --help --no-header --pager --row-count --terse -b -h -n"
           COMPREPLY=( $( compgen -W "${opts}" -- "${cur}" ) );;
         name|n)

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -1302,10 +1302,12 @@ class BuildTestParser:
             },
             {
                 "name": "profiles",
+                "aliases": ["prof"],
                 "help": "Query profile from buildtest configuration",
                 "subcommands": [
                     {
                         "name": "list",
+                        "aliases": ["ls"],
                         "help": "List all profiles",
                         "parents": [self.parent_parser["theme"]],
                         "arguments": [
@@ -1341,6 +1343,7 @@ class BuildTestParser:
                 "subcommands": [
                     {
                         "name": "list",
+                        "aliases": ["ls"],
                         "help": "List all executors",
                         "mutually_exclusive_group": True,
                         "arguments": [
@@ -1604,7 +1607,7 @@ class BuildTestParser:
 
         subcommands = [
             ("clear", ["c"], "Remove all report files"),
-            ("list", ["l"], "List all report files"),
+            ("list", ["ls"], "List all report files"),
             ("path", ["p"], "Print full path to the report file being used"),
             ("summary", ["sm"], "Summarize test report"),
         ]
@@ -1734,7 +1737,7 @@ class BuildTestParser:
                 ],
             },
             "list": {
-                "aliases": ["l"],
+                "aliases": ["ls"],
                 "help": "List all test names, ids, and corresponding buildspecs",
                 "parents": [
                     self.parent_parser["pager"],

--- a/buildtest/cli/config.py
+++ b/buildtest/cli/config.py
@@ -25,8 +25,8 @@ def config_cmd(args, configuration, editor, system):
     if args.config in ["view", "v"]:
         view_configuration(configuration, theme=args.theme, pager=args.pager)
 
-    elif args.config in ["profiles"]:
-        if args.profiles == "list":
+    elif args.config in ["profiles", "prof"]:
+        if args.profiles in ["list", "ls"]:
             list_profiles(configuration, theme=args.theme, print_yaml=args.yaml)
 
         if args.profiles in ["remove", "rm"]:
@@ -34,7 +34,7 @@ def config_cmd(args, configuration, editor, system):
 
     elif args.config in ["executors", "ex"]:
         buildexecutor = BuildExecutor(configuration)
-        if args.executors == "list":
+        if args.executors in ["list", "ls"]:
             view_executors(
                 configuration=configuration,
                 buildexecutor=buildexecutor,

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -842,7 +842,7 @@ def report_cmd(args, configuration, report_file=None):
         clear_report()
         return
 
-    if args.report_subcommand in ["list", "l"]:
+    if args.report_subcommand in ["list", "ls"]:
         list_report()
         return
 

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -250,7 +250,7 @@ def main():
     # running buildtest inspect
     elif args.subcommands in ["inspect", "it"]:
         report = Report(configuration=configuration, report_file=report_file)
-        if args.inspect in ["list", "l"]:
+        if args.inspect in ["list", "ls"]:
             inspect_list(
                 report,
                 terse=args.terse,


### PR DESCRIPTION
This PR will add aliases for following command
- buildtest config executors list
- buildtest config profiles list
- buildtest config profiles
- buildtest inspect list
- buildtest report list