### PR TITLE
fix argparser issue with option --help-all

### DIFF
--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -282,18 +282,6 @@ class BuildTestParser:
             "commands": {"help": "List all buildtest commands", "aliases": ["cmds"]},
         }
 
-        self.hidden_subcommands = {
-            "docs": {},
-            "tutorial-examples": {},
-            "schemadocs": {},
-            "unittests": {"aliases": ["test"]},
-            "stylecheck": {"aliases": ["style"]},
-        }
-
-        self.buildtest_subcommands = list(self.subcommands.keys()) + list(
-            self.hidden_subcommands.keys()
-        )
-
         self.parser = argparse.ArgumentParser(
             prog=self._progname,
             formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -307,15 +295,37 @@ class BuildTestParser:
         )
 
         self._build_options()
-        self._build_subparsers()
 
         # list used to store all main options for buildtest
         self.main_options = self.get_buildtest_options()
 
+        self.hidden_subcommands = {
+            "docs": {},
+            "tutorial-examples": {},
+            "unittests": {"aliases": ["test"]},
+            "stylecheck": {"aliases": ["style"]},
+        }
+
         # Variables needed to show all sub commands and their help message
         show_all_help = any(arg in ["-H", "--help-all"] for arg in sys.argv)
         if show_all_help:
-            self.help_all()
+            self.hidden_subcommands = {
+                "tutorial-examples": {
+                    "help": "Generate documentation examples for Buildtest Tutorial"
+                },
+                "docs": {"help": "Open buildtest docs in browser"},
+                "unittests": {"help": "Run buildtest unit tests", "aliases": ["test"]},
+                "stylecheck": {
+                    "help": "Run buildtest style checks",
+                    "aliases": ["style"],
+                },
+            }
+
+        self.buildtest_subcommands = list(self.subcommands.keys()) + list(
+            self.hidden_subcommands.keys()
+        )
+
+        self._build_subparsers()
 
         self.build_menu()
         self.buildspec_menu()
@@ -435,23 +445,9 @@ class BuildTestParser:
         main_options.add("--help")
         return list(sorted(main_options))
 
-    def help_all(self):
-        """This method will add parser for hidden command that can be shown when using ``--help-all/-H``"""
-
-        hidden_parser = {
-            "tutorial-examples": {
-                "help": "Generate documentation examples for Buildtest Tutorial"
-            },
-            "docs": {"help": "Open buildtest docs in browser"},
-            "schemadocs": {"help": "Open buildtest schema docs in browser"},
-            "unittests": {"help": "Run buildtest unit tests", "aliases": ["test"]},
-            "stylecheck": {"help": "Run buildtest style checks", "aliases": ["style"]},
-        }
-
-        for name, subcommand in hidden_parser.items():
-            self.subparsers.add_parser(
-                name, help=subcommand["help"], aliases=subcommand.get("aliases", [])
-            )
+    def get_subcommands(self):
+        """Return a list of buildtest commands. This is useful for ``buildtest commands`` command to show a list of buildtest commands"""
+        return list(self.subcommands.keys()) + list(self.hidden_subcommands.keys())
 
     def get_parent_parser(self):
         parent_parser = {}

--- a/buildtest/cli/commands.py
+++ b/buildtest/cli/commands.py
@@ -9,7 +9,7 @@ def list_buildtest_commands(with_aliases=None):
     """
 
     cmds = BuildTestParser()
-    subcmds = sorted(cmds.buildtest_subcommands)
+    subcmds = sorted(cmds.get_subcommands())
 
     # if --with-aliases we will show all available choices for subcommands including aliases
     if with_aliases:


### PR DESCRIPTION
This PR will address an issue we were having when running the command

```console
(buildtest) ☁  buildtest [fix_conflict_subparser_tutorial-examples] buildtest --help-all
Traceback (most recent call last):
  File "/Users/siddiq90/Documents/GitHubDesktop/buildtest/bin/buildtest", line 38, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/siddiq90/Documents/GitHubDesktop/buildtest/buildtest/main.py", line 73, in main
    parser = BuildTestParser()
             ^^^^^^^^^^^^^^^^^
  File "/Users/siddiq90/Documents/GitHubDesktop/buildtest/buildtest/cli/__init__.py", line 318, in __init__
    self.help_all()
  File "/Users/siddiq90/Documents/GitHubDesktop/buildtest/buildtest/cli/__init__.py", line 452, in help_all
    self.subparsers.add_parser(
  File "/usr/local/Cellar/python@3.11/3.11.4/Frameworks/Python.framework/Versions/3.11/lib/python3.11/argparse.py", line 1192, in add_parser
    raise ArgumentError(self, _('conflicting subparser: %s') % name)
argparse.ArgumentError: argument : conflicting subparser: tutorial-examples
```

With the new change we can see the output 

```console
(buildtest) ☁  buildtest [fix_help_all_option] buildtest --help-all
usage: buildtest [options] [COMMANDS]

buildtest is a HPC testing framework for building and running tests.

options:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
  -c CONFIGFILE, --configfile CONFIGFILE
                        Specify Path to Configuration File
  -d, --debug           Stream log messages to stdout
  -l {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                        Filter log messages based on logging level
  --editor {vi,vim,emacs,nano}
                        Select your preferred editor when opening files.
  --view-log            Show content of last log
  --logpath             Print full path to last log file
  --print-log           Print content of last log without pagination
  --color COLOR         Print output of table with the selected color.
  --no-color            Disable colored output
  --helpcolor           Print available color options in a table format.
  -r REPORT, --report REPORT
                        Specify path to test report file
  -H, --help-all        List all commands and options

COMMANDS:
  
    build (bd)          Build and Run test
    buildspec (bc)      Buildspec Interface
    config (cg)         Query buildtest configuration
    report (rt)         Query test report
    inspect (it)        Inspect a test
    path (p)            Show path attributes for a given test
    history (hy)        Query build history
    schema              List schema contents and examples
    cdash               Upload test to CDASH server
    cd                  Change directory to root of test given a test name
    clean               Remove all generate files from buildtest including test directory, log files, report file, buildspec cache, history files
    debugreport (debug)
                        Display system information and additional information for debugging purposes.
    stats               Show test statistics for given test
    info                Show details regarding current buildtest setup
    show                buildtest command guide
    commands (cmds)     List all buildtest commands
    tutorial-examples   Generate documentation examples for Buildtest Tutorial
    docs                Open buildtest docs in browser
    unittests (test)    Run buildtest unit tests
    stylecheck (style)  Run buildtest style checks

    References

    GitHub:                  https://github.com/buildtesters/buildtest
    Documentation:           https://buildtest.readthedocs.io/en/latest/index.html
    Slack:                   http://hpcbuildtest.slack.com/

    Please report issues at https://github.com/buildtesters/buildtest/issues

    Copyright (c) 2021-2024, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy), Shahzeb Siddiqui, and Vanessa Sochat. All rights reserved.
```