### PR TITLE
fix bug in save-profile not working 

### DIFF
--- a/buildtest/cli/build.py
+++ b/buildtest/cli/build.py
@@ -667,6 +667,9 @@ class BuildTest:
         """
         self.verbose = verbose
 
+        # variable used to determine if buildtest build command was successful. We initially start with False and if method runs to completion we set to True
+        self.success = False
+
         if self.verbose:
             console.print("[blue]Starting buildtest build")
             console.print(
@@ -1067,9 +1070,6 @@ class BuildTest:
         # if --helpfilter is specified then return immediately.
         if self.helpfilter or self.save_profile:
             return
-
-        # variable used to determine if buildtest build command was successful. We initially start with False and if method runs to completion we set to True
-        self.success = False
 
         self.discovered_bp = discover_buildspecs(
             buildspecs=self.buildspecs,


### PR DESCRIPTION
This PR fixed a bug where some commands in buildtest wont work. 

```console
(buildtest) ☁  tests [devel] ⚡  buildtest bd -t pass --save-profile=xyz
Saved profile xyz to configuration file /Users/siddiq90/Documents/GitHubDesktop/buildtest/buildtest/settings/config.yml
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /Users/siddiq90/Documents/GitHubDesktop/buildtest/bin/buildtest:38 in <module>                   │
│                                                                                                  │
│   35                                                                                             │
│   36 if __name__ == "__main__":                                                                  │
│   37                                                                                             │
│ ❱ 38   sys.exit(main())                                                                          │
│   39                                                                                             │
│                                                                                                  │
│ ╭────────────────────────────────────── locals ──────────────────────────────────────╮           │
│ │ buildtest_file = '/Users/siddiq90/Documents/GitHubDesktop/buildtest/bin/buildtest' │           │
│ │           main = <function main at 0x102f1f240>                                    │           │
│ │             os = <module 'os' (frozen)>                                            │           │
│ │         prefix = '/Users/siddiq90/Documents/GitHubDesktop/buildtest'               │           │
│ │            sys = <module 'sys' (built-in)>                                         │           │
│ ╰────────────────────────────────────────────────────────────────────────────────────╯           │
│                                                                                                  │
│ /Users/siddiq90/Documents/GitHubDesktop/buildtest/buildtest/main.py:199 in main                  │
│                                                                                                  │
│   196 │   │   │   )                                                                              │
│   197 │   │   │   cmd.build()                                                                    │
│   198 │   │                                                                                      │
│ ❱ 199 │   │   if cmd.build_success():                                                            │
│   200 │   │   │   build_history_dir = cmd.get_build_history_dir()                                │
│   201 │   │   │                                                                                  │
│   202 │   │   │   shutil.copyfile(                                                               │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │             args = Namespace(subcommands='bd', configfile=None, debug=False,                 │ │
│ │                    loglevel='DEBUG', editor=None, view_log=False, logpath=False,             │ │
│ │                    print_log=False, color=None, no_color=False, helpcolor=False,             │ │
│ │                    report=None, listopts=False, verbose=False, buildspec=None, exclude=None, │ │
│ │                    name=None, executor=None, exclude_tags=None, tags=['pass'], rerun=False,  │ │
│ │                    filter=None, helpfilter=False, executor_type=None, module_purge=False,    │ │
│ │                    modules=None, unload_modules=None, account=None, maxpendtime=None,        │ │
│ │                    pollinterval=None, procs=None, nodes=None, limit=None, max_jobs=None,     │ │
│ │                    remove_stagedir=False, rebuild=None, retry=1, stage=None, testdir=None,   │ │
│ │                    timeout=None, save_profile='xyz', profile=None)                           │ │
│ │ buildtest_editor = '/usr/bin/vim'                                                            │ │
│ │              cmd = <buildtest.cli.build.BuildTest object at 0x10546dc90>                     │ │
│ │      config_file = None                                                                      │ │
│ │    configuration = <buildtest.config.SiteConfiguration object at 0x10544ce90>                │ │
│ │           logger = <Logger buildtest (DEBUG)>                                                │ │
│ │         no_color = False                                                                     │ │
│ │           parser = <buildtest.cli.BuildTestParser object at 0x102e677d0>                     │ │
│ │      report_file = None                                                                      │ │
│ │      stdout_file = <tempfile._TemporaryFileWrapper object at 0x10512ef90>                    │ │
│ │           system = <buildtest.system.BuildTestSystem object at 0x104efe090>                  │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
│                                                                                                  │
│ /Users/siddiq90/Documents/GitHubDesktop/buildtest/buildtest/cli/build.py:1316 in build_success   │
│                                                                                                  │
│   1313 │   def build_success(self):                                                              │
│   1314 │   │   """Returns status of build whether it was successful or not. The return value is  │
│   1315 │   │   indicates build was successful and ``False`` indicates build failed."""           │
│ ❱ 1316 │   │   return self.success                                                               │
│   1317 │                                                                                         │
│   1318 │   def print_test_summary(self, builders):                                               │
│   1319 │   │   """Print a summary of total pass and fail test with percentage breakdown.         │
│                                                                                                  │
│ ╭─────────────────────────── locals ───────────────────────────╮                                 │
│ │ self = <buildtest.cli.build.BuildTest object at 0x10546dc90> │                                 │
│ ╰──────────────────────────────────────────────────────────────╯                                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'BuildTest' object has no attribute 'success'
(buildtest) ☁  tests [devel] ⚡  

```