### PR TITLE
Enhancement to scheduler logic and code refactoring.

### DIFF
--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -126,7 +126,7 @@ class BaseExecutor:
 
         builder.record_endtime()
 
-        builder.metadata["job"] = builder.job.gather()
+        builder.metadata["job"] = builder.job.jobdata()
         builder.metadata["result"]["returncode"] = builder.job.exitcode()
 
         self.logger.debug(

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -106,10 +106,13 @@ class CobaltExecutor(BaseExecutor):
         logger.debug(f"Output file will be written to: {builder.metadata['outfile']}")
         logger.debug(f"Error file will be written to: {builder.metadata['errfile']}")
 
-        builder.metadata["job"] = builder.job.gather()
+        # gather job record
+        builder.job.retrieve_jobdata()
+        builder.metadata["job"] = builder.job.jobdata()
         logger.debug(json.dumps(builder.metadata["job"], indent=2))
 
         return builder
+
 
     def poll(self, builder):
         """This method is responsible for polling Cobalt job by invoking the builder method

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -130,7 +130,6 @@ class CobaltExecutor(BaseExecutor):
             self.gather(builder)
             return
 
-
         builder.stop()
 
         if builder.job.is_running():
@@ -143,7 +142,7 @@ class CobaltExecutor(BaseExecutor):
             if self._cancel_job_if_pendtime_exceeds_maxpendtime(builder):
                 return
         builder.start()
-        
+
     def gather(self, builder):
         """This method is responsible for moving output and error file in the run
         directory. We need to read ``<JOBID>.cobaltlog`` file which contains

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -113,7 +113,6 @@ class CobaltExecutor(BaseExecutor):
 
         return builder
 
-
     def poll(self, builder):
         """This method is responsible for polling Cobalt job by invoking the builder method
         ``builder.job.poll()``.  We check the job state and existence of output file. If file

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -107,6 +107,8 @@ class SlurmExecutor(BaseExecutor):
 
         msg = f"[blue]{builder}[/blue]: JobID {builder.metadata['jobid']} dispatched to scheduler"
         console.print(msg)
+
+        builder.job.get_output_and_error_files()
         self.logger.debug(msg)
 
         return builder
@@ -128,12 +130,8 @@ class SlurmExecutor(BaseExecutor):
             f"[{builder.name}] returncode: {builder.metadata['result']['returncode']}"
         )
 
-        builder.metadata["outfile"] = os.path.join(
-            builder.job.workdir(), builder.name + ".out"
-        )
-        builder.metadata["errfile"] = os.path.join(
-            builder.job.workdir(), builder.name + ".err"
-        )
+        builder.metadata["outfile"] = buildtest.job.output_file()
+        builder.metadata["errfile"] = buildtest.job.error_file()
 
         console.print(f"[blue]{builder}[/]: Job {builder.job.get()} is complete! ")
         builder.post_run_steps()

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -130,8 +130,8 @@ class SlurmExecutor(BaseExecutor):
             f"[{builder.name}] returncode: {builder.metadata['result']['returncode']}"
         )
 
-        builder.metadata["outfile"] = buildtest.job.output_file()
-        builder.metadata["errfile"] = buildtest.job.error_file()
+        builder.metadata["outfile"] = builder.job.output_file()
+        builder.metadata["errfile"] = builder.job.error_file()
 
         console.print(f"[blue]{builder}[/]: Job {builder.job.get()} is complete! ")
         builder.post_run_steps()

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -122,7 +122,7 @@ class SlurmExecutor(BaseExecutor):
         """
         builder.record_endtime()
 
-        builder.metadata["job"] = builder.job.gather()
+        builder.metadata["job"] = builder.job.jobdata()
 
         builder.metadata["result"]["returncode"] = builder.job.exitcode()
 

--- a/buildtest/scheduler/cobalt.py
+++ b/buildtest/scheduler/cobalt.py
@@ -75,7 +75,7 @@ class CobaltJob(Job):
 
         logger.debug(f"Job ID: '{self.job}' Job State: {self._state}")
 
-    def gather(self):
+    def retrieve_jobdata(self):
         """Gather Job state by running **qstat -lf <jobid>** which retrieves all fields.
         The output is in text format which is parsed into key/value pair and stored in a dictionary. This method will
         return a dict containing the job record
@@ -108,7 +108,8 @@ class CobaltJob(Job):
             value = value.strip()
             job_record[key] = value
 
-        return job_record
+        self._jobdata = job_record
+
 
     def cancel(self):
         """Cancel job by running ``qdel <jobid>``. This method is called if job timer exceeds

--- a/buildtest/scheduler/cobalt.py
+++ b/buildtest/scheduler/cobalt.py
@@ -1,5 +1,6 @@
 import logging
 import time
+
 from buildtest.scheduler.job import Job
 from buildtest.utils.command import BuildTestCommand
 

--- a/buildtest/scheduler/cobalt.py
+++ b/buildtest/scheduler/cobalt.py
@@ -110,7 +110,6 @@ class CobaltJob(Job):
 
         self._jobdata = job_record
 
-
     def cancel(self):
         """Cancel job by running ``qdel <jobid>``. This method is called if job timer exceeds
         ``maxpendtime`` if job is pending.

--- a/buildtest/scheduler/cobalt.py
+++ b/buildtest/scheduler/cobalt.py
@@ -55,21 +55,6 @@ class CobaltJob(Job):
 
         return self._cobaltlog
 
-    def output_file(self):
-        """Return job output file"""
-
-        return self._outfile
-
-    def error_file(self):
-        """Return job error file"""
-
-        return self._errfile
-
-    def exitcode(self):
-        """Return job exit code"""
-
-        return self._exitcode
-
     def poll(self):
         """Poll job by running ``qstat -l --header State <jobid>`` which retrieves job state."""
 

--- a/buildtest/scheduler/cobalt.py
+++ b/buildtest/scheduler/cobalt.py
@@ -1,5 +1,5 @@
 import logging
-
+import time
 from buildtest.scheduler.job import Job
 from buildtest.utils.command import BuildTestCommand
 
@@ -73,7 +73,10 @@ class CobaltJob(Job):
         if job_state:
             self._state = job_state
 
-        logger.debug(f"Job ID: '{self.job}' Job State: {self._state}")
+        logger.debug(f"Job ID: '{self.jobid}' Job State: {self._state}")
+
+        if self.is_running() and not self.starttime:
+            self.starttime = time.time()
 
     def retrieve_jobdata(self):
         """Gather Job state by running **qstat -lf <jobid>** which retrieves all fields.

--- a/buildtest/scheduler/job.py
+++ b/buildtest/scheduler/job.py
@@ -8,6 +8,9 @@ class Job:
     def __init__(self, jobID):
         self.jobid = jobID
         self._state = None
+        self._outfile = None
+        self._errfile = None
+        self._exitcode = None
         # used to store the job elapsed time
         self.elapsedtime = 0
 
@@ -47,3 +50,20 @@ class Job:
     def poll(self):
         """Poll job and update job state."""
         raise NotImplementedError
+
+    def get_output_and_error_files(self):
+        """Get output and error of job"""
+        raise NotImplementedError
+
+
+    def output_file(self):
+        """Return output file of job"""
+        return self._outfile
+
+    def error_file(self):
+        """Return error file of job"""
+        return self._errfile
+
+    def exitcode(self):
+        """Return exit code of job"""
+        return self._exitcode

--- a/buildtest/scheduler/job.py
+++ b/buildtest/scheduler/job.py
@@ -55,7 +55,6 @@ class Job:
         """Get output and error of job"""
         raise NotImplementedError
 
-
     def output_file(self):
         """Return output file of job"""
         return self._outfile

--- a/buildtest/scheduler/job.py
+++ b/buildtest/scheduler/job.py
@@ -11,6 +11,7 @@ class Job:
         self._outfile = None
         self._errfile = None
         self._exitcode = None
+        self._jobdata = None
         # used to store the job elapsed time
         self.elapsedtime = 0
 
@@ -66,3 +67,9 @@ class Job:
     def exitcode(self):
         """Return exit code of job"""
         return self._exitcode
+
+    def retrieve_jobdata(self):
+        raise NotImplementedError
+
+    def jobdata(self):
+        return self._jobdata

--- a/buildtest/scheduler/lsf.py
+++ b/buildtest/scheduler/lsf.py
@@ -93,19 +93,20 @@ class LSFJob(Job):
         # if job is running and the start time is not recorded then we record the start time
         if self.is_running() and not self.starttime:
             self.starttime = time.time()
+
     def get_output_and_error_files(self):
         """This method will extract output and error file for a given jobID by running the following commands:
-           ``bjobs -noheader -o 'output_file' <JOBID>`` and ``bjobs -noheader -o 'error_file' <JOBID>``
+        ``bjobs -noheader -o 'output_file' <JOBID>`` and ``bjobs -noheader -o 'error_file' <JOBID>``
 
-            .. code-block:: console
+         .. code-block:: console
 
-                $ bjobs -noheader -o 'output_file' 70910
-                hold_job.out
+             $ bjobs -noheader -o 'output_file' 70910
+             hold_job.out
 
-            .. code-block:: console
+         .. code-block:: console
 
-                $ bjobs -noheader -o 'error_file' 70910
-                hold_job.err
+             $ bjobs -noheader -o 'error_file' 70910
+             hold_job.err
         """
         # get path to output file
         query = f"bjobs -noheader -o 'output_file' {self.jobid} "

--- a/buildtest/scheduler/lsf.py
+++ b/buildtest/scheduler/lsf.py
@@ -39,21 +39,6 @@ class LSFJob(Job):
 
         return self._state == "EXIT"
 
-    def output_file(self):
-        """Return job output file"""
-
-        return self._outfile
-
-    def error_file(self):
-        """Return job error file"""
-
-        return self._errfile
-
-    def exitcode(self):
-        """Return job exit code"""
-
-        return self._exitcode
-
     def poll(self):
         """Given a job id we poll the LSF Job by retrieving its job state, output file, error file and exit code.
         We run the following commands to retrieve following states
@@ -128,7 +113,7 @@ class LSFJob(Job):
         self._errfile = "".join(cmd.get_output()).rstrip()
         logger.debug(f"Error File: {self._errfile}")
 
-    def gather(self):
+    def retrieve_jobdata(self):
         """We will gather job record at onset of job completion by running ``bjobs -o '<format1> <format2>' <jobid> -json``. T
 
         Shown below is the output format and we retrieve the job records defined in **RECORDS** property
@@ -203,7 +188,7 @@ class LSFJob(Job):
         for field, value in records.items():
             job_data[field] = value
 
-        return job_data
+        self._jobdata = job_data
 
     def cancel(self):
         """Cancel LSF Job by running ``bkill <jobid>``. This method is called if job pending time exceeds

--- a/buildtest/scheduler/pbs.py
+++ b/buildtest/scheduler/pbs.py
@@ -36,18 +36,6 @@ class PBSJob(Job):
         """Return ``True`` if job is suspended which would be in one of these states ``H``, ``U``, ``S``."""
         return self._state in ["H", "U", "S"]
 
-    def output_file(self):
-        """Return output file of job"""
-        return self._outfile
-
-    def error_file(self):
-        """Return error file of job"""
-        return self._errfile
-
-    def exitcode(self):
-        """Return exit code of job"""
-        return self._exitcode
-
     def success(self):
         """This method determines if job was completed successfully and returns ``True`` if exit code is 0.
 
@@ -64,7 +52,7 @@ class PBSJob(Job):
         """Return ``True`` if their is a job failure which would be if exit code is not 0"""
         return not self.success()
 
-    def fetch_output_error_files(self):
+    def get_output_error_files(self):
         """Fetch output and error files right after job submission."""
         query = f"qstat -f {self.jobid}"
         cmd = BuildTestCommand(query)
@@ -96,7 +84,7 @@ class PBSJob(Job):
     def is_output_ready(self):
         """Check if the output and error file exists."""
         if not self._outfile or not self._errfile:
-            self.fetch_output_error_files()
+            self.get_output_error_files()
         return os.path.exists(self._outfile) and os.path.exists(self._errfile)
 
     def poll(self):

--- a/buildtest/scheduler/pbs.py
+++ b/buildtest/scheduler/pbs.py
@@ -247,7 +247,7 @@ class PBSJob(Job):
         if self.is_running() and not self.starttime:
             self.starttime = time.time()
 
-    def gather(self):
+    def retrieve_jobdata(self):
         """This method is called once job is complete. We will gather record of job by running
         ``qstat -x -f -F json <jobid>`` and return the json object as a dict.  This method is responsible
         for getting output file, error file and exit status of job.

--- a/buildtest/scheduler/pbs.py
+++ b/buildtest/scheduler/pbs.py
@@ -94,8 +94,7 @@ class PBSJob(Job):
 
         .. code-block:: console
 
-
-        (buildtest) adaptive50@e4spro-cluster:~/Documents/buildtest/aws_oddc$ qstat -f  40680075.e4spro-cluster
+            (buildtest) adaptive50@e4spro-cluster:~/Documents/buildtest/aws_oddc$ qstat -f  40680075.e4spro-cluster
             Job Id: 40680075.e4spro-cluster
                 Job_Name = hostname_test
                 Job_Owner = adaptive50@server.nodus.com

--- a/buildtest/scheduler/slurm.py
+++ b/buildtest/scheduler/slurm.py
@@ -90,11 +90,6 @@ class SlurmJob(Job):
 
         return self._workdir
 
-    def exitcode(self):
-        """Return job exit code"""
-
-        return self._exitcode
-
     def cancel(self):
         """Cancel job by running ``scancel <jobid>``. If job is specified to a slurm
         cluster we cancel job using ``scancel <jobid> --clusters=<cluster>``. This method
@@ -221,8 +216,8 @@ class SlurmJob(Job):
         logger.debug(f"Output File: {self._outfile}")
         logger.debug(f"Error File: {self._errfile}")
 
-    def gather(self):
-        """Gather job record which is called after job completion. We use `sacct` to gather
+    def retrieve_jobdata(self):
+        """This method will get job record which is called after job completion. We use `sacct` to gather
         job record and return the job record as a dictionary. The command we run is
         ``sacct -j <jobid> -X -n -P -o <field1>,<field2>,...,<fieldN>``. We retrieve the following
         format fields from job record:
@@ -326,4 +321,4 @@ class SlurmJob(Job):
         for field, value in zip(sacct_fields, out):
             job_data[field] = value
 
-        return job_data
+        self._jobdata = job_data

--- a/buildtest/scheduler/slurm.py
+++ b/buildtest/scheduler/slurm.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 
 from buildtest.scheduler.job import Job
@@ -208,7 +209,7 @@ class SlurmJob(Job):
             logger.error(f"Unable to extract StdOut file from output: {content}")
 
         pattern = r"StdErr=(?P<stderr>.+)"
-        match = re.search(pattern, output)
+        match = re.search(pattern, content)
         logger.debug(
             f"Extracting StdOut file by applying regular expression: {pattern}"
         )
@@ -217,8 +218,8 @@ class SlurmJob(Job):
         else:
             logger.error(f"Unable to extract StdErr file from error: {content}")
 
-        self.logger.debug(f"Output File: {self._outfile}")
-        self.logger.debug(f"Error File: {self._errfile}")
+        logger.debug(f"Output File: {self._outfile}")
+        logger.debug(f"Error File: {self._errfile}")
 
     def gather(self):
         """Gather job record which is called after job completion. We use `sacct` to gather

--- a/buildtest/scheduler/slurm.py
+++ b/buildtest/scheduler/slurm.py
@@ -150,38 +150,38 @@ class SlurmJob(Job):
 
     def get_output_and_error_files(self):
         """This method will extract file paths to StdOut and StdErr using ``scontrol show job <jobid>`` command that will
-           be used to set output and error file.
+        be used to set output and error file.
 
-           .. code-block:: console
+        .. code-block:: console
 
-           siddiq90@login07> scontrol show job 23608796
-           JobId=23608796 JobName=perlmutter-gpu.slurm
-               UserId=siddiq90(92503) GroupId=siddiq90(92503) MCS_label=N/A
-               Priority=69119 Nice=0 Account=nstaff_g QOS=gpu_debug
-               JobState=PENDING Reason=Priority Dependency=(null)
-               Requeue=0 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0
-               RunTime=00:00:00 TimeLimit=00:05:00 TimeMin=N/A
-               SubmitTime=2024-03-28T12:36:05 EligibleTime=2024-03-28T12:36:05
-               AccrueTime=2024-03-28T12:36:05
-               StartTime=2024-03-28T12:36:14 EndTime=2024-03-28T12:41:14 Deadline=N/A
-               SuspendTime=None SecsPreSuspend=0 LastSchedEval=2024-03-28T12:36:12 Scheduler=Backfill:*
-               Partition=gpu_ss11 AllocNode:Sid=login07:1529462
-               ReqNodeList=(null) ExcNodeList=(null)
-               NodeList=
-               NumNodes=1-1 NumCPUs=4 NumTasks=4 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
-               ReqTRES=cpu=4,mem=229992M,node=1,billing=4,gres/gpu=1
-               AllocTRES=(null)
-               Socks/Node=* NtasksPerN:B:S:C=4:0:*:* CoreSpec=*
-               MinCPUsNode=4 MinMemoryNode=0 MinTmpDiskNode=0
-               Features=gpu&a100 DelayBoot=00:00:00
-               OverSubscribe=NO Contiguous=0 Licenses=u1:1 Network=(null)
-               Command=/global/u1/s/siddiq90/jobs/perlmutter-gpu.slurm
-               WorkDir=/global/u1/s/siddiq90/jobs
-               StdErr=/global/u1/s/siddiq90/jobs/slurm-23608796.out
-               StdIn=/dev/null
-               StdOut=/global/u1/s/siddiq90/jobs/slurm-23608796.out
-               Power=
-               TresPerJob=gres:gpu:1
+        siddiq90@login07> scontrol show job 23608796
+        JobId=23608796 JobName=perlmutter-gpu.slurm
+            UserId=siddiq90(92503) GroupId=siddiq90(92503) MCS_label=N/A
+            Priority=69119 Nice=0 Account=nstaff_g QOS=gpu_debug
+            JobState=PENDING Reason=Priority Dependency=(null)
+            Requeue=0 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0
+            RunTime=00:00:00 TimeLimit=00:05:00 TimeMin=N/A
+            SubmitTime=2024-03-28T12:36:05 EligibleTime=2024-03-28T12:36:05
+            AccrueTime=2024-03-28T12:36:05
+            StartTime=2024-03-28T12:36:14 EndTime=2024-03-28T12:41:14 Deadline=N/A
+            SuspendTime=None SecsPreSuspend=0 LastSchedEval=2024-03-28T12:36:12 Scheduler=Backfill:*
+            Partition=gpu_ss11 AllocNode:Sid=login07:1529462
+            ReqNodeList=(null) ExcNodeList=(null)
+            NodeList=
+            NumNodes=1-1 NumCPUs=4 NumTasks=4 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
+            ReqTRES=cpu=4,mem=229992M,node=1,billing=4,gres/gpu=1
+            AllocTRES=(null)
+            Socks/Node=* NtasksPerN:B:S:C=4:0:*:* CoreSpec=*
+            MinCPUsNode=4 MinMemoryNode=0 MinTmpDiskNode=0
+            Features=gpu&a100 DelayBoot=00:00:00
+            OverSubscribe=NO Contiguous=0 Licenses=u1:1 Network=(null)
+            Command=/global/u1/s/siddiq90/jobs/perlmutter-gpu.slurm
+            WorkDir=/global/u1/s/siddiq90/jobs
+            StdErr=/global/u1/s/siddiq90/jobs/slurm-23608796.out
+            StdIn=/dev/null
+            StdOut=/global/u1/s/siddiq90/jobs/slurm-23608796.out
+            Power=
+            TresPerJob=gres:gpu:1
 
 
         """
@@ -197,22 +197,25 @@ class SlurmJob(Job):
 
         logger.debug(f"Output of scontrol show job {self.jobid}:\n{content}")
 
-        pattern=r"StdOut=(?P<stdout>.+)"
+        pattern = r"StdOut=(?P<stdout>.+)"
         match = re.search(pattern, content)
-        logger.debug(f"Extracting StdOut file by applying regular expression: {pattern}")
+        logger.debug(
+            f"Extracting StdOut file by applying regular expression: {pattern}"
+        )
         if match:
             self._outfile = match.group("stdout")
         else:
             logger.error(f"Unable to extract StdOut file from output: {content}")
 
-        pattern=r"StdErr=(?P<stderr>.+)"
+        pattern = r"StdErr=(?P<stderr>.+)"
         match = re.search(pattern, output)
-        logger.debug(f"Extracting StdOut file by applying regular expression: {pattern}")
+        logger.debug(
+            f"Extracting StdOut file by applying regular expression: {pattern}"
+        )
         if match:
             self._errfile = match.group("stderr")
         else:
             logger.error(f"Unable to extract StdErr file from error: {content}")
-
 
         self.logger.debug(f"Output File: {self._outfile}")
         self.logger.debug(f"Error File: {self._errfile}")

--- a/buildtest/scheduler/slurm.py
+++ b/buildtest/scheduler/slurm.py
@@ -150,34 +150,34 @@ class SlurmJob(Job):
 
         .. code-block:: console
 
-        siddiq90@login07> scontrol show job 23608796
-        JobId=23608796 JobName=perlmutter-gpu.slurm
-            UserId=siddiq90(92503) GroupId=siddiq90(92503) MCS_label=N/A
-            Priority=69119 Nice=0 Account=nstaff_g QOS=gpu_debug
-            JobState=PENDING Reason=Priority Dependency=(null)
-            Requeue=0 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0
-            RunTime=00:00:00 TimeLimit=00:05:00 TimeMin=N/A
-            SubmitTime=2024-03-28T12:36:05 EligibleTime=2024-03-28T12:36:05
-            AccrueTime=2024-03-28T12:36:05
-            StartTime=2024-03-28T12:36:14 EndTime=2024-03-28T12:41:14 Deadline=N/A
-            SuspendTime=None SecsPreSuspend=0 LastSchedEval=2024-03-28T12:36:12 Scheduler=Backfill:*
-            Partition=gpu_ss11 AllocNode:Sid=login07:1529462
-            ReqNodeList=(null) ExcNodeList=(null)
-            NodeList=
-            NumNodes=1-1 NumCPUs=4 NumTasks=4 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
-            ReqTRES=cpu=4,mem=229992M,node=1,billing=4,gres/gpu=1
-            AllocTRES=(null)
-            Socks/Node=* NtasksPerN:B:S:C=4:0:*:* CoreSpec=*
-            MinCPUsNode=4 MinMemoryNode=0 MinTmpDiskNode=0
-            Features=gpu&a100 DelayBoot=00:00:00
-            OverSubscribe=NO Contiguous=0 Licenses=u1:1 Network=(null)
-            Command=/global/u1/s/siddiq90/jobs/perlmutter-gpu.slurm
-            WorkDir=/global/u1/s/siddiq90/jobs
-            StdErr=/global/u1/s/siddiq90/jobs/slurm-23608796.out
-            StdIn=/dev/null
-            StdOut=/global/u1/s/siddiq90/jobs/slurm-23608796.out
-            Power=
-            TresPerJob=gres:gpu:1
+            siddiq90@login07> scontrol show job 23608796
+            JobId=23608796 JobName=perlmutter-gpu.slurm
+                UserId=siddiq90(92503) GroupId=siddiq90(92503) MCS_label=N/A
+                Priority=69119 Nice=0 Account=nstaff_g QOS=gpu_debug
+                JobState=PENDING Reason=Priority Dependency=(null)
+                Requeue=0 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0
+                RunTime=00:00:00 TimeLimit=00:05:00 TimeMin=N/A
+                SubmitTime=2024-03-28T12:36:05 EligibleTime=2024-03-28T12:36:05
+                AccrueTime=2024-03-28T12:36:05
+                StartTime=2024-03-28T12:36:14 EndTime=2024-03-28T12:41:14 Deadline=N/A
+                SuspendTime=None SecsPreSuspend=0 LastSchedEval=2024-03-28T12:36:12 Scheduler=Backfill:*
+                Partition=gpu_ss11 AllocNode:Sid=login07:1529462
+                ReqNodeList=(null) ExcNodeList=(null)
+                NodeList=
+                NumNodes=1-1 NumCPUs=4 NumTasks=4 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
+                ReqTRES=cpu=4,mem=229992M,node=1,billing=4,gres/gpu=1
+                AllocTRES=(null)
+                Socks/Node=* NtasksPerN:B:S:C=4:0:*:* CoreSpec=*
+                MinCPUsNode=4 MinMemoryNode=0 MinTmpDiskNode=0
+                Features=gpu&a100 DelayBoot=00:00:00
+                OverSubscribe=NO Contiguous=0 Licenses=u1:1 Network=(null)
+                Command=/global/u1/s/siddiq90/jobs/perlmutter-gpu.slurm
+                WorkDir=/global/u1/s/siddiq90/jobs
+                StdErr=/global/u1/s/siddiq90/jobs/slurm-23608796.out
+                StdIn=/dev/null
+                StdOut=/global/u1/s/siddiq90/jobs/slurm-23608796.out
+                Power=
+                TresPerJob=gres:gpu:1
 
 
         """

--- a/tests/examples/jlse/hold_job.yml
+++ b/tests/examples/jlse/hold_job.yml
@@ -1,8 +1,8 @@
 buildspecs:
   hold_job:
-    executor: jlse.cobalt.testing
+    executor: jlse.cobalt.iris
     type: script
     tags: [jobs]
-    description: Hold Job on testing queue
+    description: Hold Job in queue
     cobalt: ["-n 1", "-t 10", "-h"]
     run: hostname

--- a/tests/examples/jlse/hostname.yml
+++ b/tests/examples/jlse/hostname.yml
@@ -1,8 +1,8 @@
 buildspecs:
   hostname_test:
-    executor: jlse.cobalt.testing
+    executor: jlse.cobalt.iris
     type: script
     tags: [jobs]
-    description: Run hostname on testing queue
+    description: Run hostname as batch job
     cobalt: ["-n 1", "-t 10"]
     run: hostname

--- a/tests/settings/jlse.yml
+++ b/tests/settings/jlse.yml
@@ -1,7 +1,7 @@
 system:
   jlse:
     # hostnames on JLSE where jobs are run are jlsebatch[1-2]
-    hostnames: ['^jlsebatch/d{1}$']
+    hostnames: ['^jlsebatch\d{1}$']
     moduletool: environment-modules
     poolsize: 8
     max_jobs: 10
@@ -33,8 +33,8 @@ system:
           description: submit jobs on local machine using python shell
           shell: python
       cobalt:
-        testing:
-          queue: testing
+        iris:
+          queue: iris
     compilers:
       find:
         gcc: "^(gcc)"


### PR DESCRIPTION
This PR will make several enhancement and code refactoring to scheduling class. 


# Slurm job using `scontrol show job`

This PR will use `scontrol show job` to get output and error file instead of using `sacct` since we can use this information at job submission time to get the data. This will address an issue where we can't rely on extracting output from workdir if one specifies an alternative path such as `sacct -o /tmp/job.out -e /tmp/job.err test.sh` 

Shown below is a sample build run with log enabled which shows `scontrol show job` is run

```console
slurm_metadata/5ee906a4 does not have any dependencies adding test to queue
 Builders Eligible to Run
┏━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Builder                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ slurm_metadata/5ee906a4 │
└─────────────────────────┘
                    DEBUG    Changing to directory /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/metadata/slurm_metadata/5ee906a4/stage                                                                                                slurm.py:82
slurm_metadata/5ee906a4: Current Working Directory : /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/metadata/slurm_metadata/5ee906a4/stage
slurm_metadata/5ee906a4: Running Test via command: bash slurm_metadata_build.sh
[03/28/24 13:30:48] DEBUG    Running Test via command: bash slurm_metadata_build.sh                                                                                                                                                                                base.py:378
slurm_metadata/5ee906a4: JobID 23611383 dispatched to scheduler
[03/28/24 13:30:49] DEBUG    Querying JobID: '23611383' by running: 'scontrol show job 23611383'                                                                                                                                                                  slurm.py:196
                    DEBUG    Output of scontrol show job 23611383:                                                                                                                                                                                                slurm.py:199
                             JobId=23611383 JobName=slurm_metadata
                                 UserId=siddiq90(92503) GroupId=siddiq90(92503) MCS_label=N/A
                                 Priority=69119 Nice=0 Account=nstaff QOS=debug
                                 JobState=PENDING Reason=Resources Dependency=(null)
                                 Requeue=0 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0
                                 RunTime=00:00:00 TimeLimit=00:01:00 TimeMin=N/A
                                 SubmitTime=2024-03-28T13:30:48 EligibleTime=2024-03-28T13:30:48
                                 AccrueTime=2024-03-28T13:30:48
                                 StartTime=Unknown EndTime=Unknown Deadline=N/A
                                 SuspendTime=None SecsPreSuspend=0 LastSchedEval=2024-03-28T13:30:48 Scheduler=Main
                                 Partition=regular_milan_ss11 AllocNode:Sid=login38:1876581
                                 ReqNodeList=(null) ExcNodeList=(null)
                                 NodeList=
                                 NumNodes=1-1 NumCPUs=1 NumTasks=1 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
                                 ReqTRES=cpu=1,mem=488002M,node=1,billing=1
                                 AllocTRES=(null)
                                 Socks/Node=* NtasksPerN🅱S:C=0:0:*:* CoreSpec=*
                                 MinCPUsNode=1 MinMemoryNode=0 MinTmpDiskNode=0
                                 Features=cpu DelayBoot=00:00:00
                                 OverSubscribe=NO Contiguous=0 Licenses=u1:1 Network=(null)
                                 Command=/global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/metadata/slurm_metadata/5ee906a4/stage/slurm_metadata.sh
                                 WorkDir=/global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/metadata/slurm_metadata/5ee906a4/stage
                                 StdErr=/global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/metadata/slurm_metadata/5ee906a4/stage/slurm_metadata.err
                                 StdIn=/dev/null
                                 StdOut=/global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/metadata/slurm_metadata/5ee906a4/stage/slurm_metadata.out
                                 Power=


                    DEBUG    Extracting StdOut file by applying regular expression: StdOut=(?P<stdout>.+)                                                                                                                                                         slurm.py:203
                    DEBUG    Extracting StdOut file by applying regular expression: StdErr=(?P<stderr>.+)                                                                                                                                                         slurm.py:213
                    DEBUG    Output File: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/metadata/slurm_metadata/5ee906a4/stage/slurm_metadata.out                                                                                     slurm.py:221
                    DEBUG    Error File: /global/u1/s/siddiq90/gitrepos/buildtest/var/tests/perlmutter.slurm.debug/metadata/slurm_metadata/5ee906a4/stage/slurm_metadata.err                                                                                      slurm.py:222
                    DEBUG    slurm_metadata/5ee906a4: JobID 23611383 dispatched to scheduler                                                                                                                                                                      slurm.py:112
Polling Jobs in 5 seconds
[03/28/24 13:30:54] DEBUG    Querying JobID: '23611383' by running: 'sacct -j 23611383 -o State -n -X -P'                                                                                                                                                         slurm.py:137
                    DEBUG    JobID: '23611383' Job State: PENDING                                                                                                                                                                                                 slurm.py:142
                                       Pending and Suspended Jobs (1)
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ builder                 ┃ executor               ┃ jobid    ┃ jobstate ┃ runtime ┃ elapsedtime ┃ pendtime ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ slurm_metadata/5ee906a4 │ perlmutter.slurm.debug │ 23611383 │ PENDING  │ 12.029  │ 0           │ 5.84     │
└─────────────────────────┴────────────────────────┴──────────┴──────────┴─────────┴─────────────┴──────────┘
```

# Fix bugs with Cobalt Scheduler

This PR will fix job submission issues related to Cobalt scheduler after code refactoring, we were able to submit job 


```console
(buildtest) ac.ssiddiqui@jlsebatch1:~/github/buildtest/tests/examples/jlse> buildtest -d build -b hostname.yml --pollinterval=5
[03/29/24 14:26:40] DEBUG    Starting System Compatibility Check                                                                                                                                system.py:44
                    INFO     Machine: x86_64                                                                                                                                                    system.py:61
                    INFO     Host: jlsebatch1                                                                                                                                                   system.py:62
                    INFO     User: ac.ssiddiqui                                                                                                                                                 system.py:63
                    INFO     Operating System: opensuse                                                                                                                                         system.py:64
                    INFO     System Kernel: Linux and Kernel Release: 5.14.21-150400.24.88-default                                                                                              system.py:65
                    INFO     Python Path: /home/ac.ssiddiqui/.pyenv/buildtest/bin/python3                                                                                                       system.py:68
                    INFO     Python Version: 3.8.12                                                                                                                                             system.py:69
                    INFO     BUILDTEST_ROOT: /home/ac.ssiddiqui/github/buildtest                                                                                                                system.py:70
                    INFO     Path to Buildtest: /home/ac.ssiddiqui/github/buildtest/bin/buildtest                                                                                               system.py:71
                    INFO     Detected module system: environment-modules                                                                                                                       system.py:111
                    INFO     Detected environment-modules with version: /usr/lib64/Modules/modulecmd.tcl                                                                                       system.py:112
                    DEBUG    We will check the following binaries ['sbatch', 'sacct', 'sacctmgr', 'sinfo', 'scancel'] for existence.                                                         detection.py:22
                    DEBUG    Cannot find sbatch command in $PATH                                                                                                                             detection.py:27
                    DEBUG    We will check the following binaries ['bsub', 'bqueues', 'bkill', 'bjobs'] for existence.                                                                       detection.py:22
                    DEBUG    Cannot find bsub command in $PATH                                                                                                                               detection.py:27
                    DEBUG    We will check the following binaries ['qsub', 'qstat', 'qdel', 'nodelist', 'showres', 'partlist'] for existence.                                                detection.py:22
                    DEBUG    qsub: /usr/bin/qsub                                                                                                                                             detection.py:30
                    DEBUG    qstat: /usr/bin/qstat                                                                                                                                           detection.py:30
                    DEBUG    qdel: /usr/bin/qdel                                                                                                                                             detection.py:30
                    DEBUG    nodelist: /usr/bin/nodelist                                                                                                                                     detection.py:30
                    DEBUG    showres: /usr/bin/showres                                                                                                                                       detection.py:30
                    DEBUG    partlist: /usr/bin/partlist                                                                                                                                     detection.py:30
[03/29/24 14:26:41] DEBUG    Get all Cobalt Queues by running qstat -Ql                                                                                                                     detection.py:210
                    DEBUG    Detected Cobalt Scheduler                                                                                                                                          system.py:88
                    DEBUG    We will check the following binaries ['qsub', 'qstat', 'qdel', 'qstart', 'qhold', 'qmgr'] for existence.                                                        detection.py:22
                    DEBUG    qsub: /usr/bin/qsub                                                                                                                                             detection.py:30
                    DEBUG    qstat: /usr/bin/qstat                                                                                                                                           detection.py:30
                    DEBUG    qdel: /usr/bin/qdel                                                                                                                                             detection.py:30
                    DEBUG    Cannot find qstart command in $PATH                                                                                                                             detection.py:27
                    DEBUG    We will check the following binaries ['qsub', 'qstat', 'qdel', 'qstart', 'qhold', 'qmgr'] for existence.                                                        detection.py:22
                    DEBUG    qsub: /usr/bin/qsub                                                                                                                                             detection.py:30
                    DEBUG    qstat: /usr/bin/qstat                                                                                                                                           detection.py:30
                    DEBUG    qdel: /usr/bin/qdel                                                                                                                                             detection.py:30
                    DEBUG    Cannot find qstart command in $PATH                                                                                                                             detection.py:27
                    INFO     Finished System Compatibility Check                                                                                                                                system.py:76
                    DEBUG    List of available systems: ['jlse'] found in configuration file                                                                                                   config.py:102
                    DEBUG    Checking hostname: jlsebatch1 in system: 'jlse' with hostnames: ['^jlsebatch\\d{1}$']                                                                             config.py:117
                    INFO     Found matching system: jlse based on hostname: jlsebatch1                                                                                                         config.py:124
                    DEBUG    Loading default settings schema: /home/ac.ssiddiqui/github/buildtest/buildtest/schemas/settings.schema.json                                                       config.py:143
                    DEBUG    Successfully loaded schema file: /home/ac.ssiddiqui/github/buildtest/buildtest/schemas/settings.schema.json                                                         utils.py:41
                    DEBUG    Validating configuration file with schema: /home/ac.ssiddiqui/github/buildtest/buildtest/schemas/settings.schema.json                                             config.py:146
                    DEBUG    Validation was successful                                                                                                                                         config.py:154
                    DEBUG    We will check the following binaries ['qsub', 'qstat', 'qdel', 'nodelist', 'showres', 'partlist'] for existence.                                                detection.py:22
                    DEBUG    qsub: /usr/bin/qsub                                                                                                                                             detection.py:30
                    DEBUG    qstat: /usr/bin/qstat                                                                                                                                           detection.py:30
                    DEBUG    qdel: /usr/bin/qdel                                                                                                                                             detection.py:30
                    DEBUG    nodelist: /usr/bin/nodelist                                                                                                                                     detection.py:30
                    DEBUG    showres: /usr/bin/showres                                                                                                                                       detection.py:30
                    DEBUG    partlist: /usr/bin/partlist                                                                                                                                     detection.py:30
                    DEBUG    Get all Cobalt Queues by running qstat -Ql                                                                                                                     detection.py:210
                    INFO     Processing buildtest configuration file: /home/ac.ssiddiqui/github/buildtest/tests/settings/jlse.yml                                                                main.py:149
                    DEBUG    Tests will be written in /home/ac.ssiddiqui/github/buildtest/var/tests                                                                                             build.py:792
                    DEBUG    Getting Executors from buildtest settings                                                                                                                           setup.py:89
╭─────────────────────────────────────────────── buildtest summary ───────────────────────────────────────────────╮
│                                                                                                                 │
│ User:               ac.ssiddiqui                                                                                │
│ Hostname:           jlsebatch1                                                                                  │
│ Platform:           Linux                                                                                       │
│ Current Time:       2024/03/29 14:26:41                                                                         │
│ buildtest path:     /home/ac.ssiddiqui/github/buildtest/bin/buildtest                                           │
│ buildtest version:  1.8                                                                                         │
│ python path:        /home/ac.ssiddiqui/.pyenv/buildtest/bin/python3                                             │
│ python version:     3.8.12                                                                                      │
│ Configuration File: /home/ac.ssiddiqui/github/buildtest/tests/settings/jlse.yml                                 │
│ Test Directory:     /home/ac.ssiddiqui/github/buildtest/var/tests                                               │
│ Report File:        /home/ac.ssiddiqui/github/buildtest/var/report.json                                         │
│ Command:            /home/ac.ssiddiqui/github/buildtest/bin/buildtest -d build -b hostname.yml --pollinterval=5 │
│                                                                                                                 │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                    DEBUG    Discovering buildspecs based on tags=None, executor=None, buildspec=['hostname.yml'], excluded buildspec=None                                                      build.py:148
                    DEBUG    Buildspec: hostname.yml is a file                                                                                                                                  build.py:559
                    INFO     Based on input argument we discovered the following buildspecs: ['/home/ac.ssiddiqui/github/buildtest/tests/examples/jlse/hostname.yml']                           build.py:571
                    DEBUG    buildtest discovered the following Buildspecs: ['/home/ac.ssiddiqui/github/buildtest/tests/examples/jlse/hostname.yml']                                            build.py:227
─────────────────────────────────────────────────────────────────────────────────────────  Discovering Buildspecs ──────────────────────────────────────────────────────────────────────────────────────────
                         Discovered buildspecs
╔══════════════════════════════════════════════════════════════════════╗
║ buildspec                                                            ║
╟──────────────────────────────────────────────────────────────────────╢
║ /home/ac.ssiddiqui/github/buildtest/tests/examples/jlse/hostname.yml ║
╟──────────────────────────────────────────────────────────────────────╢
║ Total: 1                                                             ║
╚══════════════════════════════════════════════════════════════════════╝


Total Discovered Buildspecs:  1
Total Excluded Buildspecs:  0
Detected Buildspecs after exclusion:  1
──────────────────────────────────────────────────────────────────────────────────────────── Parsing Buildspecs ────────────────────────────────────────────────────────────────────────────────────────────
                    INFO     Validating /home/ac.ssiddiqui/github/buildtest/tests/examples/jlse/hostname.yml with schema:                                                                      parser.py:164
                             /home/ac.ssiddiqui/github/buildtest/buildtest/schemas/global.schema.json
                    INFO     Validating test - 'hostname_test' in recipe: /home/ac.ssiddiqui/github/buildtest/tests/examples/jlse/hostname.yml                                                 parser.py:176
                    INFO     Test: 'hostname_test' is using schema type: 'script'                                                                                                              parser.py:118
                    INFO     Validating /home/ac.ssiddiqui/github/buildtest/tests/examples/jlse/hostname.yml with schema:                                                                      parser.py:193
                             /home/ac.ssiddiqui/github/buildtest/buildtest/schemas/script.schema.json
                    DEBUG    Searching for builders for test: hostname_test by applying regular expression with available builders: ['jlse.local.bash', 'jlse.local.sh', 'jlse.local.csh',   builders.py:272
                             'jlse.local.python', 'jlse.cobalt.iris']
                    DEBUG    Found a match in buildspec with available executors via re.fullmatch(jlse.cobalt.iris,jlse.cobalt.iris)                                                         builders.py:280
                    DEBUG    Processing Buildspec File: /home/ac.ssiddiqui/github/buildtest/tests/examples/jlse/hostname.yml                                                                     base.py:144
                    DEBUG    Processing Test: hostname_test                                                                                                                                      base.py:145
                    DEBUG    Using shell bash                                                                                                                                                    base.py:181
                    DEBUG    Shebang used for test: #!/usr/bin/bash                                                                                                                              base.py:182
Valid Buildspecs: 1
Invalid Buildspecs: 0
/home/ac.ssiddiqui/github/buildtest/tests/examples/jlse/hostname.yml: VALID
Total builder objects created: 1
                                                                              Builders by type=script
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ builder                ┃ type   ┃ executor         ┃ compiler ┃ nodes ┃ procs ┃ description               ┃ buildspecs                                                           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ hostname_test/b740b9de │ script │ jlse.cobalt.iris │ None     │ None  │ None  │ Run hostname as batch job │ /home/ac.ssiddiqui/github/buildtest/tests/examples/jlse/hostname.yml │
└────────────────────────┴────────┴──────────────────┴──────────┴───────┴───────┴───────────────────────────┴──────────────────────────────────────────────────────────────────────┘
                                                 Batch Job Builders
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ builder                ┃ executor         ┃ buildspecs                                                           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ hostname_test/b740b9de │ jlse.cobalt.iris │ /home/ac.ssiddiqui/github/buildtest/tests/examples/jlse/hostname.yml │
└────────────────────────┴──────────────────┴──────────────────────────────────────────────────────────────────────┘
────────────────────────────────────────────────────────────────────────────────────────────── Building Test ───────────────────────────────────────────────────────────────────────────────────────────────
                    DEBUG    Creating test directory: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de                                             base.py:527
                    DEBUG    Creating the stage directory: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage                                  base.py:536
hostname_test/b740b9de: Creating Test Directory: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de
                    INFO     Opening Test File for Writing: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage/hostname_test.sh                base.py:658
                    DEBUG    Changing permission to 755 for script: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage/hostname_test.sh        base.py:856
                    DEBUG    Writing build script: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage/hostname_test_build.sh                   base.py:631
                    DEBUG    Changing permission to 755 for script: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage/hostname_test_build.sh  base.py:856
                    DEBUG    Copying build script to: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/hostname_test_build.sh                      base.py:637
────────────────────────────────────────────────────────────────────────────────────────────── Running Tests ───────────────────────────────────────────────────────────────────────────────────────────────
Spawning 8 processes for processing builders
─────────────────────────────────────────────────────────────────────────────────────────────── Iteration 1 ────────────────────────────────────────────────────────────────────────────────────────────────
hostname_test/b740b9de does not have any dependencies adding test to queue
 Builders Eligible to Run
┏━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Builder                ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━┩
│ hostname_test/b740b9de │
└────────────────────────┘
hostname_test/b740b9de: Current Working Directory : /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage
hostname_test/b740b9de: Running Test via command: bash hostname_test_build.sh
                    DEBUG    Running Test via command: bash hostname_test_build.sh                                                                                                               base.py:378
hostname_test/b740b9de: JobID: 763827 dispatched to scheduler
                    DEBUG    hostname_test/b740b9de: JobID: 763827 dispatched to scheduler                                                                                                      cobalt.py:93
                    DEBUG    Output file will be written to: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage/763827.output                cobalt.py:106
                    DEBUG    Error file will be written to: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage/763827.error                  cobalt.py:107
                    DEBUG    Executing command: qstat -lf 763827                                                                                                                               cobalt.py:101
[03/29/24 14:26:42] DEBUG    {                                                                                                                                                                 cobalt.py:112
                               "JobID": "763827",
                               "JobName": "hostname_test",
                               "User": "ac.ssiddiqui",
                               "WallTime": "00:10:00",
                               "QueuedTime": "00:00:00",
                               "RunTime": "N/A",
                               "TimeRemaining": "N/A",
                               "Nodes": "1",
                               "State": "queued",
                               "Location": "None",
                               "Mode": "script",
                               "Procs": "1",
                               "Preemptable": "False",
                               "User_Hold": "False",
                               "Admin_Hold": "False",
                               "Queue": "iris",
                               "StartTime": "N/A",
                               "Index": "None",
                               "SubmitTime": "Fri Mar 29 14:26:41 2024 +0000 (UTC)",
                               "Path":
                             "/home/ac.ssiddiqui/github/buildtest/bin:/home/ac.ssiddiqui/.pyenv/buildtest/bin:/home/ac.ssiddiqui/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/lpp/mmfs/bin:/ho
                             me/ac.ssiddiqui/.local/bin:/home/ac.ssiddiqui/bin",
                               "OutputDir": "/home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage",
                               "ErrorPath": "None",
                               "OutputPath": "None",
                               "Envs": "",
                               "Command": "/home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage/hostname_test.sh",
                               "Args": "",
                               "Kernel": "default",
                               "KernelOptions": "None",
                               "ION_Kernel": "default",
                               "ION_KernelOptions": "None",
                               "Project": "None",
                               "Dependencies": "",
                               "S": "Q",
                               "Notify": "None",
                               "Score": "0.1",
                               "Maxtasktime": "None",
                               "attrs": "{}",
                               "dep_frac": "None",
                               "user_list": "ac.ssiddiqui",
                               "Geometry": "Any"
                             }
Polling Jobs in 5 seconds
[03/29/24 14:26:47] DEBUG    Getting Job State for '763827' by running: 'qstat -l --header State 763827'                                                                                        cobalt.py:63
                    DEBUG    Job ID: '763827' Job State: starting                                                                                                                               cobalt.py:76
                                   Pending and Suspended Jobs (1)
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ builder                ┃ executor         ┃ jobid  ┃ jobstate ┃ runtime ┃ elapsedtime ┃ pendtime ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ hostname_test/b740b9de │ jlse.cobalt.iris │ 763827 │ starting │ 5.672   │ 0           │ 5.36     │
└────────────────────────┴──────────────────┴────────┴──────────┴─────────┴─────────────┴──────────┘
Polling Jobs in 5 seconds
[03/29/24 14:26:52] DEBUG    Getting Job State for '763827' by running: 'qstat -l --header State 763827'                                                                                        cobalt.py:63
                    DEBUG    Job ID: '763827' Job State: starting                                                                                                                               cobalt.py:76
                                   Pending and Suspended Jobs (1)
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ builder                ┃ executor         ┃ jobid  ┃ jobstate ┃ runtime ┃ elapsedtime ┃ pendtime ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ hostname_test/b740b9de │ jlse.cobalt.iris │ 763827 │ starting │ 10.851  │ 0           │ 10.53    │
└────────────────────────┴──────────────────┴────────┴──────────┴─────────┴─────────────┴──────────┘
Polling Jobs in 5 seconds
[03/29/24 14:26:57] DEBUG    Getting Job State for '763827' by running: 'qstat -l --header State 763827'                                                                                        cobalt.py:63
                    DEBUG    Job ID: '763827' Job State: running                                                                                                                                cobalt.py:76
                                          Running Jobs (1)
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ builder                ┃ executor         ┃ jobid  ┃ jobstate ┃ runtime ┃ elapsedtime ┃ pendtime ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ hostname_test/b740b9de │ jlse.cobalt.iris │ 763827 │ running  │ 16.03   │ 0.0         │ 10.53    │
└────────────────────────┴──────────────────┴────────┴──────────┴─────────┴─────────────┴──────────┘
Polling Jobs in 5 seconds
[03/29/24 14:27:02] DEBUG    Getting Job State for '763827' by running: 'qstat -l --header State 763827'                                                                                        cobalt.py:63
                    DEBUG    Job ID: '763827' Job State: running                                                                                                                                cobalt.py:76
                                          Running Jobs (1)
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ builder                ┃ executor         ┃ jobid  ┃ jobstate ┃ runtime ┃ elapsedtime ┃ pendtime ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ hostname_test/b740b9de │ jlse.cobalt.iris │ 763827 │ running  │ 21.212  │ 5.18        │ 10.53    │
└────────────────────────┴──────────────────┴────────┴──────────┴─────────┴─────────────┴──────────┘
Polling Jobs in 5 seconds
[03/29/24 14:27:07] DEBUG    Getting Job State for '763827' by running: 'qstat -l --header State 763827'                                                                                        cobalt.py:63
                    DEBUG    Job ID: '763827' Job State: exiting                                                                                                                                cobalt.py:76
                    DEBUG    Sleeping 5 seconds and waiting for Cobalt Scheduler to write output and error file                                                                                cobalt.py:166
[03/29/24 14:27:12] DEBUG    Sleeping 5 seconds and waiting for Cobalt Scheduler to write output and error file                                                                                cobalt.py:166
[03/29/24 14:27:17] DEBUG    Cobalt Log File written to /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage/763827.cobaltlog                  cobalt.py:176
                    DEBUG    Test: hostname_test got returncode: 0 from JobID: 763827                                                                                                          cobalt.py:186
                    DEBUG    Copying cobalt log file: /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/stage/763827.cobaltlog to                 cobalt.py:197
                             /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/763827.cobaltlog
hostname_test/b740b9de: Job 763827 is complete!
hostname_test/b740b9de: Test completed in 5.18 seconds with returncode: 0
hostname_test/b740b9de: Writing output file -  /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/763827.output
hostname_test/b740b9de: Writing error file - /home/ac.ssiddiqui/github/buildtest/var/tests/jlse.cobalt.iris/hostname/hostname_test/b740b9de/763827.error
                                         Completed Jobs (1)
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ builder                ┃ executor         ┃ jobid  ┃ jobstate ┃ runtime ┃ elapsedtime ┃ pendtime ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ hostname_test/b740b9de │ jlse.cobalt.iris │ 763827 │ exiting  │ 5.18    │ 5.18        │ 10.53    │
└────────────────────────┴──────────────────┴────────┴──────────┴─────────┴─────────────┴──────────┘
                                Test Summary
┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━┓
┃ builder                ┃ executor         ┃ status ┃ returncode ┃ runtime ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━┩
│ hostname_test/b740b9de │ jlse.cobalt.iris │ PASS   │ 0          │ 5.180   │
└────────────────────────┴──────────────────┴────────┴────────────┴─────────┘



Passed Tests: 1/1 Percentage: 100.000%
Failed Tests: 0/1 Percentage: 0.000%


                    DEBUG    Updating report file: /home/ac.ssiddiqui/github/buildtest/var/report.json                                                                                         build.py:1721
Adding 1 test results to report file: /home/ac.ssiddiqui/github/buildtest/var/report.json
Writing Logfile to /home/ac.ssiddiqui/github/buildtest/var/logs/buildtest_99oyef_a.log
```