### PR TITLE
Add support for 'paths' in configuration to allow one to search for scheduler binary in non-standard location

### DIFF
--- a/aws_oddc/sleep.yml
+++ b/aws_oddc/sleep.yml
@@ -1,7 +1,7 @@
 buildspecs:
   hostname_test:
     type: script
-    executor: generic.torque.e4spro
+    executor: generic.torque.lbl
     description: run sleep for 5 seconds 
     pbs: ["-l nodes=1"]
     run: |

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -259,7 +259,7 @@ class SiteConfiguration:
 
         executor_type = "lsf"
 
-        lsf = LSF()
+        lsf = LSF(custom_dirs=deep_get(self.target_config, "paths", "lsf"))
         if not lsf.active():
             return
 
@@ -296,7 +296,7 @@ class SiteConfiguration:
             return
 
         executor_type = "slurm"
-        slurm = Slurm()
+        slurm = Slurm(custom_dirs=deep_get(self.target_config, "paths", "slurm"))
 
         if not slurm.active():
             return
@@ -349,7 +349,7 @@ class SiteConfiguration:
 
         executor_type = "cobalt"
 
-        cobalt = Cobalt()
+        cobalt = Cobalt(custom_dirs=deep_get(self.target_config, "paths", "cobalt"))
         if not cobalt.active():
             return
 
@@ -418,7 +418,7 @@ class SiteConfiguration:
 
         executor_type = "pbs"
 
-        pbs = PBS()
+        pbs = PBS(custom_dirs=deep_get(self.target_config, "paths", "pbs"))
         if not pbs.active():
             return
 
@@ -453,7 +453,7 @@ class SiteConfiguration:
 
         executor_type = "torque"
 
-        torque = Torque()
+        torque = Torque(custom_dirs=deep_get(self.target_config, "paths", "torque"))
         if not torque.active():
             return
 

--- a/buildtest/config.py
+++ b/buildtest/config.py
@@ -9,9 +9,9 @@ from buildtest.defaults import (
     console,
 )
 from buildtest.exceptions import BuildTestError, ConfigurationError
+from buildtest.scheduler.detection import LSF, PBS, Cobalt, Slurm, Torque
 from buildtest.schemas.defaults import custom_validator
 from buildtest.schemas.utils import load_recipe, load_schema
-from buildtest.system import LSF, PBS, Cobalt, Slurm, Torque
 from buildtest.utils.file import resolve_path
 from buildtest.utils.shell import Shell
 from buildtest.utils.tools import deep_get

--- a/buildtest/executors/base.py
+++ b/buildtest/executors/base.py
@@ -158,14 +158,12 @@ class BaseExecutor:
     def _cancel_job_if_pendtime_exceeds_maxpendtime(self, builder):
         builder.job.pendtime = time.time() - builder.job.submittime
         builder.job.pendtime = round(builder.job.pendtime, 2)
-
         if builder.job.pendtime > self.maxpendtime:
             builder.job.cancel()
             builder.failed()
             console.print(
                 f"[blue]{builder}[/]: [red]Cancelling Job {builder.job.get()} because job exceeds max pend time of {self.maxpendtime} sec with current pend time of {builder.job.pendtime} sec[/red] "
             )
-            return
 
     def __str__(self):
         return self.name

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -142,7 +142,7 @@ class CobaltExecutor(BaseExecutor):
             builder.job.elapsedtime = round(builder.job.elapsedtime, 2)
             if self._cancel_job_if_elapsedtime_exceeds_timeout(builder):
                 return
-
+           
         if builder.job.is_suspended() or builder.job.is_pending():
             if self._cancel_job_if_pendtime_exceeds_maxpendtime(builder):
                 return
@@ -181,7 +181,7 @@ class CobaltExecutor(BaseExecutor):
 
         # if os.path.exists(cobaltlog):
         content = read_file(cobaltlog)
-        pattern = r"(exit code of.)(\d+)(\;)"
+        pattern = r'(exit code of.)(\d+)(\;)'
         # pattern to check in cobalt log file is 'exit code of <CODE>;'
         m = re.search(pattern, content)
         if m:

--- a/buildtest/executors/cobalt.py
+++ b/buildtest/executors/cobalt.py
@@ -142,7 +142,7 @@ class CobaltExecutor(BaseExecutor):
             builder.job.elapsedtime = round(builder.job.elapsedtime, 2)
             if self._cancel_job_if_elapsedtime_exceeds_timeout(builder):
                 return
-           
+
         if builder.job.is_suspended() or builder.job.is_pending():
             if self._cancel_job_if_pendtime_exceeds_maxpendtime(builder):
                 return
@@ -181,7 +181,7 @@ class CobaltExecutor(BaseExecutor):
 
         # if os.path.exists(cobaltlog):
         content = read_file(cobaltlog)
-        pattern = r'(exit code of.)(\d+)(\;)'
+        pattern = r"(exit code of.)(\d+)(\;)"
         # pattern to check in cobalt log file is 'exit code of <CODE>;'
         m = re.search(pattern, content)
         if m:

--- a/buildtest/executors/setup.py
+++ b/buildtest/executors/setup.py
@@ -407,7 +407,9 @@ class BuildExecutor:
             jobs = [
                 builder
                 for builder in jobs
-                if builder.job.is_running() or builder.job.is_pending() or builder.job.is_suspended()
+                if builder.job.is_running()
+                or builder.job.is_pending()
+                or builder.job.is_suspended()
             ]
 
     def _print_job_details(self, active_jobs):

--- a/buildtest/executors/setup.py
+++ b/buildtest/executors/setup.py
@@ -407,7 +407,7 @@ class BuildExecutor:
             jobs = [
                 builder
                 for builder in jobs
-                if builder.job.is_running() or builder.job.is_pending()
+                if builder.job.is_running() or builder.job.is_pending() or builder.job.is_suspended()
             ]
 
     def _print_job_details(self, active_jobs):

--- a/buildtest/executors/slurm.py
+++ b/buildtest/executors/slurm.py
@@ -130,7 +130,7 @@ class SlurmExecutor(BaseExecutor):
             builder (buildtest.buildsystem.base.BuilderBase): An instance object of BuilderBase type
         """
         builder.record_endtime()
-
+        builder.job.retrieve_jobdata()
         builder.metadata["job"] = builder.job.jobdata()
 
         builder.metadata["result"]["returncode"] = builder.job.exitcode()

--- a/buildtest/scheduler/cobalt.py
+++ b/buildtest/scheduler/cobalt.py
@@ -13,11 +13,12 @@ class CobaltJob(Job):
     is pending, running, complete, suspended.
     """
 
-    def __init__(self, jobID):
+    def __init__(self, jobID, cobalt_cmds):
         super().__init__(jobID)
         self._outfile = str(jobID) + ".output"
         self._errfile = str(jobID) + ".error"
         self._cobaltlog = str(jobID) + ".cobaltlog"
+        self.cobalt_cmds = cobalt_cmds
 
     def is_pending(self):
         """Return ``True`` if job is pending otherwise returns ``False``. When cobalt recieves job it is
@@ -60,7 +61,7 @@ class CobaltJob(Job):
         """Poll job by running ``qstat -l --header State <jobid>`` which retrieves job state."""
 
         # get Job State by running 'qstat -l --header <jobid>'
-        query = f"qstat -l --header State {self.jobid}"
+        query = f"{self.cobalt_cmds['qstat']} -l --header State {self.jobid}"
         logger.debug(f"Getting Job State for '{self.jobid}' by running: '{query}'")
         cmd = BuildTestCommand(query)
         cmd.execute()
@@ -98,7 +99,7 @@ class CobaltJob(Job):
         """
 
         # 'qstat -lf <jobid>' will get all fields of Job.
-        qstat_cmd = f"qstat -lf {self.jobid}"
+        qstat_cmd = f"{self.cobalt_cmds['qstat']} -lf {self.jobid}"
         logger.debug(f"Executing command: {qstat_cmd}")
         cmd = BuildTestCommand(qstat_cmd)
         cmd.execute()
@@ -119,7 +120,7 @@ class CobaltJob(Job):
         ``maxpendtime`` if job is pending.
         """
 
-        query = f"qdel {self.jobid}"
+        query = f"{self.cobalt_cmds['qdel']} {self.jobid}"
         logger.debug(f"Cancelling job {self.jobid} by running: {query}")
         cmd = BuildTestCommand(query)
         cmd.execute()

--- a/buildtest/scheduler/detection.py
+++ b/buildtest/scheduler/detection.py
@@ -1,11 +1,10 @@
 import json
 import logging
-import os
 import re
-import shutil
 
 from buildtest.exceptions import BuildTestError
 from buildtest.utils.command import BuildTestCommand
+from buildtest.utils.tools import check_binaries
 
 
 class Scheduler:
@@ -18,40 +17,18 @@ class Scheduler:
     binaries = []
 
     def __init__(self, custom_dirs=None):
+
         self.logger = logging.getLogger(__name__)
-        self.is_active = self.check_binaries(self.binaries, custom_dirs=custom_dirs)
-        if self.is_active:
+        self.sched_cmds = check_binaries(self.binaries, custom_dirs=custom_dirs)
+        if self.sched_cmds:
             self._queues = self.get_queues()
 
     def queues(self):
         return self._queues
 
-    def check_binaries(self, binaries, custom_dirs=None):
-        """Check if binaries exist binary exist in $PATH
-
-        Args:
-            binaries (list): list of binaries to check for existence in $PATH
-            custom_dirs (list, optional): list of custom directories to check for binaries. Defaults to None.
-        """
-
-        self.logger.debug(
-            f"We will check the following binaries {binaries} for existence."
-        )
-
-        paths = os.getenv("PATH").split(os.pathsep)
-        if custom_dirs:
-            paths.extend(custom_dirs)
-        for command in binaries:
-            if not shutil.which(command, path=paths):
-                self.logger.debug(f"Cannot find {command} command in $PATH")
-                return False
-
-            self.logger.debug(f"{command}: {shutil.which(command)}")
-        return True
-
     def active(self):
         """Returns ``True`` if buildtest is able to retrieve queues from Scheduler otherwises returns ``False``"""
-        return self.is_active
+        return self.sched_cmds
 
     def get_queues(self):
         """This method is implemented by subclass to return a list of queues for a given scheduler"""
@@ -70,10 +47,10 @@ class Slurm(Scheduler):
     def __init__(self, custom_dirs=None):
         self.logger = logging.getLogger(__name__)
 
-        self.is_active = self.check_binaries(self.binaries, custom_dirs=custom_dirs)
+        self.sched_cmds = check_binaries(self.binaries, custom_dirs=custom_dirs)
 
         # retrieve slurm partitions, qos, and cluster only if slurm is detected.
-        if self.is_active:
+        if self.sched_cmds:
             self._partitions = self._get_partitions()
             self._clusters = self._get_clusters()
             self._qos = self._get_qos()
@@ -112,7 +89,7 @@ class Slurm(Scheduler):
         """
         # get list of partitions
 
-        return self.run_command("sinfo -a -h -O partitionname")
+        return self.run_command(f"{self.sched_cmds['sinfo']} -a -h -O partitionname")
 
     def _get_clusters(self):
         """Get list of slurm clusters by running ``sacctmgr list cluster -P -n format=Cluster``.
@@ -125,7 +102,9 @@ class Slurm(Scheduler):
              escori
 
         """
-        return self.run_command("sacctmgr list cluster -P -n format=Cluster")
+        return self.run_command(
+            f"{self.sched_cmds['sacctmgr']} list cluster -P -n format=Cluster"
+        )
 
     def _get_qos(self):
         """Retrieve a list of all slurm qos by running ``sacctmgr list qos -P -n  format=Name``. The output
@@ -142,7 +121,9 @@ class Slurm(Scheduler):
 
         """
 
-        return self.run_command("sacctmgr list qos -P -n  format=Name")
+        return self.run_command(
+            f"{self.sched_cmds['sacctmgr']} list qos -P -n  format=Name"
+        )
 
     def validate_partition(self, slurm_executor):
         """Validate the partition for a given executor.
@@ -164,12 +145,10 @@ class Slurm(Scheduler):
             )
             return False
 
-        self.logger.debug(
-            "Slurm partition: {slurm_executor['partition']} is found in list of partitions."
-        )
+        self.logger.debug(f"Slurm partition: {slurm_executor['partition']} is found.")
         # check if partition is in 'up' state. If not we raise an error.
         part_state = self.run_command(
-            f"sinfo -p {slurm_executor['partition']} -h -O available"
+            f"{self.sched_cmds['sinfo']} -p {slurm_executor['partition']} -h -O available"
         )
 
         if part_state != "up":
@@ -253,7 +232,7 @@ class LSF(Scheduler):
 
         """
 
-        query = "bqueues -o 'queue_name status' -json"
+        query = f"{self.sched_cmds['bqueues']} -o 'queue_name status' -json"
         cmd = BuildTestCommand(query)
         cmd.execute()
         out = cmd.get_output()
@@ -268,8 +247,7 @@ class LSF(Scheduler):
                 raise BuildTestError(
                     f"Unable to process LSF Queues when running: {query}"
                 )
-
-        return queues
+            return queues
 
     def validate_queue(self, executor):
         """This method will validate a LSF queue. We check if queue is available and in 'Open:Active' state.
@@ -317,7 +295,7 @@ class Cobalt(Scheduler):
     def get_queues(self):
         """Get all Cobalt queues by running ``qstat -Ql`` and parsing output"""
 
-        query = "qstat -Ql"
+        query = f"{self.sched_cmds['qstat']} -Ql"
         cmd = BuildTestCommand(query)
         cmd.execute()
         content = cmd.get_output()
@@ -338,14 +316,19 @@ class PBS(Scheduler):
     """The PBS class checks for PBS binaries and gets a list of available queues"""
 
     # specify a set of PBS commands to check for file existence
-    binaries = ["qsub", "qstat", "qdel", "qstart", "qhold", "qmgr"]
+    binaries = ["qsub", "qstat", "qdel", "qhold", "qmgr"]
 
     def __init__(self, custom_dirs=None):
         self.logger = logging.getLogger(__name__)
-        self.is_active = self.check(custom_dirs=custom_dirs)
+        self.sched_cmds = None
+        self._state = self.check(custom_dirs=custom_dirs)
 
-        if self.is_active:
+        if self.sched_cmds:
             self._queues = self.get_queues()
+
+    def active(self):
+        """Return True if PBS Scheduler is detected otherwise return False"""
+        return True if self._state and self._queues else False
 
     def check(self, custom_dirs=None):
         """Check if binaries exist in $PATH and run ``qsub --version`` to see output to
@@ -360,14 +343,14 @@ class PBS(Scheduler):
         Args:
             binaries (list): list of binaries to check for existence in $PATH
         """
-
-        if not super().check_binaries(self.binaries, custom_dirs=custom_dirs):
+        self.sched_cmds = check_binaries(self.binaries, custom_dirs=custom_dirs)
+        if not self.sched_cmds:
             return False
 
         # check output of qsub --version to see if it contains string 'pbs_version'
         # [pbsuser@pbs tmp]$ qsub --version
         # pbs_version = 19.0.0
-        qsub_version = "qsub --version"
+        qsub_version = f"{self.sched_cmds['qsub']} --version"
         cmd = BuildTestCommand(qsub_version)
         cmd.execute()
         out = " ".join(cmd.get_output())
@@ -413,7 +396,7 @@ class PBS(Scheduler):
                  }
              }
         """
-        query = "qstat -Q -f -F json"
+        query = f"{self.sched_cmds['qstat']} -Q -f -F json"
         cmd = BuildTestCommand(query)
         cmd.execute()
         content = " ".join(cmd.get_output())
@@ -464,10 +447,21 @@ class PBS(Scheduler):
         return True
 
 
-class Torque(PBS):
-    """The Torque class is a subclass of PBS class and inherits all methods from PBS class"""
+class Torque(Scheduler):
+    """The Torque class for detecting Torque Scheduler and getting list of queues."""
 
-    def check(self, custom_dirs=None)
+    # specify a set of Torque commands to check for file existence
+    binaries = ["qsub", "qstat", "qdel", "qhold", "qmgr"]
+
+    def __init__(self, custom_dirs=None):
+        self.logger = logging.getLogger(__name__)
+        self.sched_cmds = None
+        self.check(custom_dirs=custom_dirs)
+
+        if self.sched_cmds:
+            self._queues = self.get_queues()
+
+    def check(self, custom_dirs=None):
         """Check if binaries exist in $PATH and run ``qsub --version`` to see output if its Torque Scheduler.
         The return will be a boolean type where ``True`` indicates the check has passed.
 
@@ -484,15 +478,15 @@ class Torque(PBS):
             binaries (list): list of binaries to check for existence in $PATH
 
         """
-
-        if not super().check_binaries(self.binaries, custom_dirs=custom_dirs):
+        self.sched_cmds = check_binaries(self.binaries, custom_dirs=custom_dirs)
+        if not self.sched_cmds:
             return False
 
         # check output of qsub --version to see if it contains 'Commit:'
         # (buildtest) adaptive50@e4spro-cluster:$ qsub --version
         # Version: 7.0.1
         # Commit: b405f8c22d41d29cbf9b9016bc1146bf4559e895
-        qsub_version = "qsub --version"
+        qsub_version = f"{self.sched_cmds['qsub']} --version"
         cmd = BuildTestCommand(qsub_version)
         cmd.execute()
         # output goes to error stream
@@ -508,6 +502,7 @@ class Torque(PBS):
                 f"Found 'Commit:' in output of {qsub_version}, this must be a Torque Scheduler"
             )
             return True
+
         return False
 
     def get_queues(self):
@@ -529,7 +524,7 @@ class Torque(PBS):
 
         """
 
-        query = "qstat -Qf"
+        query = f"{self.sched_cmds['qstat']} -Qf"
         cmd = BuildTestCommand(query)
         cmd.execute()
         self.logger.debug(f"Get Torque Queues details by running '{query}'")

--- a/buildtest/scheduler/detection.py
+++ b/buildtest/scheduler/detection.py
@@ -42,7 +42,7 @@ class Scheduler:
         if custom_dirs:
             paths.extend(custom_dirs)
         for command in binaries:
-            if not shutil.which(command):
+            if not shutil.which(command, path=paths):
                 self.logger.debug(f"Cannot find {command} command in $PATH")
                 return False
 

--- a/buildtest/scheduler/detection.py
+++ b/buildtest/scheduler/detection.py
@@ -323,7 +323,7 @@ class PBS(Scheduler):
         self.sched_cmds = None
         self._state = self.check(custom_dirs=custom_dirs)
 
-        if self.sched_cmds:
+        if self._state:
             self._queues = self.get_queues()
 
     def active(self):
@@ -456,10 +456,14 @@ class Torque(Scheduler):
     def __init__(self, custom_dirs=None):
         self.logger = logging.getLogger(__name__)
         self.sched_cmds = None
-        self.check(custom_dirs=custom_dirs)
+        self._state = self.check(custom_dirs=custom_dirs)
 
-        if self.sched_cmds:
+        if self._state:
             self._queues = self.get_queues()
+
+    def active(self):
+        """Return True if Torque Scheduler is detected otherwise return False"""
+        return True if self._state and self._queues else False
 
     def check(self, custom_dirs=None):
         """Check if binaries exist in $PATH and run ``qsub --version`` to see output if its Torque Scheduler.

--- a/buildtest/scheduler/lsf.py
+++ b/buildtest/scheduler/lsf.py
@@ -9,8 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 class LSFJob(Job):
-    def __init__(self, jobID):
+    def __init__(self, jobID, lsf_cmds):
         super().__init__(jobID)
+        self.lsf_cmds = lsf_cmds
 
     def is_pending(self):
         """Check if Job is pending which is reported by LSF as ``PEND``. Return ``True`` if there is a match otherwise returns ``False``"""
@@ -48,7 +49,7 @@ class LSFJob(Job):
         """
 
         # get job state
-        query = f"bjobs -noheader -o 'stat' {self.jobid}"
+        query = f"{self.lsf_cmds['bjobs']} -noheader -o 'stat' {self.jobid}"
         logger.debug(query)
         logger.debug(
             f"Extracting Job State for job: {self.jobid} by running  '{query}'"
@@ -59,7 +60,7 @@ class LSFJob(Job):
         self._state = "".join(job_state).rstrip()
         logger.debug(f"Job State: {self._state}")
 
-        query = f"bjobs -noheader -o 'EXIT_CODE' {self.jobid} "
+        query = f"{self.lsf_cmds['bjobs']} -noheader -o 'EXIT_CODE' {self.jobid} "
         logger.debug(
             f"Extracting EXIT CODE for job: {self.jobid} by running  '{query}'"
         )
@@ -94,7 +95,7 @@ class LSFJob(Job):
              hold_job.err
         """
         # get path to output file
-        query = f"bjobs -noheader -o 'output_file' {self.jobid} "
+        query = f"{self.lsf_cmds['bjobs']} -noheader -o 'output_file' {self.jobid} "
         logger.debug(
             f"Extracting OUTPUT FILE for job: {self.jobid} by running  '{query}'"
         )
@@ -104,7 +105,7 @@ class LSFJob(Job):
         logger.debug(f"Output File: {self._outfile}")
 
         # get path to error file
-        query = f"bjobs -noheader -o 'error_file' {self.jobid} "
+        query = f"{self.lsf_cmds['bjobs']} -noheader -o 'error_file' {self.jobid} "
         logger.debug(
             f"Extracting ERROR FILE for job: {self.jobid} by running  '{query}'"
         )
@@ -172,7 +173,7 @@ class LSFJob(Job):
             "error_file",
         ]
 
-        query = f"bjobs -o '{' '.join(format_fields)}' {self.jobid} -json"
+        query = f"{self.lsf_cmds['bjobs']} -o '{' '.join(format_fields)}' {self.jobid} -json"
 
         logger.debug(f"Gather LSF job: {self.jobid} data by running: {query}")
         cmd = BuildTestCommand(query)
@@ -195,7 +196,7 @@ class LSFJob(Job):
         """Cancel LSF Job by running ``bkill <jobid>``. This method is called if job pending time exceeds
         `maxpendtime` limit during poll stage."""
 
-        query = f"bkill {self.jobid}"
+        query = f"{self.lsf_cmds['bkill']} {self.jobid}"
         logger.debug(f"Cancelling job {self.jobid} by running: {query}")
         cmd = BuildTestCommand(query)
         cmd.execute()

--- a/buildtest/scheduler/slurm.py
+++ b/buildtest/scheduler/slurm.py
@@ -309,7 +309,7 @@ class SlurmJob(Job):
         # Exit Code field is in format <ExitCode>:<Signal> for now we care only about first number
         self._exitcode = int(exitcode.split(":")[0])
         self._workdir = workdir
-
+        logger.debug(f"JobID: '{self.jobid}' finished with exitcode: {self._exitcode}")
         query = f"{self.slurm_cmds['sacct']} -j {self.jobid} -X -n -P -o {','.join(sacct_fields)}"
 
         # to query jobs from another cluster we must add -M <cluster> to sacct

--- a/buildtest/schemas/examples/settings.schema.json/valid/cobalt-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/cobalt-example.yml
@@ -3,6 +3,22 @@ system:
     hostnames: ['.*']
     moduletool: lmod
     poolsize: 1
+    buildspecs:
+      # whether to rebuild cache file automatically when running `buildtest buildspec find`
+      rebuild: False
+      # limit number of records to display when running `buildtest buildspec find`
+      count: 15
+      # format fields to display when running `buildtest buildspec find`, By default we will show name,description
+      format: "name,description"
+      # enable terse mode
+      terse: False
+    report:
+      count: 25
+      #enable terse mode for report
+      terse: False
+      format: "name,id,state,runtime,returncode"
+    paths:
+      cobalt: /usr/bin
     executors:
       defaults:
         maxpendtime: 30
@@ -15,22 +31,6 @@ system:
           queue: knl
         haswell:
           queue: haswell
-    buildspecs:
-      # whether to rebuild cache file automatically when running `buildtest buildspec find`
-      rebuild: False
-      # limit number of records to display when running `buildtest buildspec find`
-      count: 15
-      # format fields to display when running `buildtest buildspec find`, By default we will show name,description
-      format: "name,description"
-      # enable terse mode
-      terse: False
-
-    report:
-      count: 25
-      #enable terse mode for report
-      terse: False
-      format: "name,id,state,runtime,returncode"
-
     compilers:
       compiler:
         gcc:

--- a/buildtest/schemas/examples/settings.schema.json/valid/combined_executor.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/combined_executor.yml
@@ -12,12 +12,17 @@ system:
       format: "name,description"
       # enable terse mode
       terse: False
-
     report:
       count: 25
       #enable terse mode for report
       terse: False
       format: "name,id,state,runtime,returncode"
+    paths:
+      cobalt: /usr/bin
+      pbs: /usr/bin
+      torque: /usr/bin
+      lsf: /usr/bin
+      slurm: /usr/bin
     executors:
       local:
         bash:

--- a/buildtest/schemas/examples/settings.schema.json/valid/lsf-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/lsf-example.yml
@@ -18,6 +18,8 @@ system:
       #enable terse mode for report
       terse: False
       format: "name,id,state,runtime,returncode"
+    paths:
+      lsf: /usr/bin
     executors:
       defaults:
         pollinterval: 10

--- a/buildtest/schemas/examples/settings.schema.json/valid/pbs-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/pbs-example.yml
@@ -12,12 +12,13 @@ system:
       format: "name,description"
       # enable terse mode
       terse: False
-
     report:
       count: 25
       #enable terse mode for report
       terse: False
       format: "name,id,state,runtime,returncode"
+    paths:
+      pbs: /usr/bin
     executors:
       defaults:
         pollinterval: 10

--- a/buildtest/schemas/examples/settings.schema.json/valid/slurm-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/slurm-example.yml
@@ -12,12 +12,13 @@ system:
       format: "name,description"
       # enable terse mode
       terse: False
-
     report:
       count: 25
       #enable terse mode for report
       terse: False
       format: "name,id,state,runtime,returncode"
+    paths:
+      slurm: /usr/bin
     testdir: /tmp/buildtest
     executors:
       defaults:

--- a/buildtest/schemas/examples/settings.schema.json/valid/torque-example.yml
+++ b/buildtest/schemas/examples/settings.schema.json/valid/torque-example.yml
@@ -12,12 +12,13 @@ system:
       format: "name,description"
       # enable terse mode
       terse: False
-
     report:
       count: 25
       #enable terse mode for report
       terse: False
       format: "name,id,state,runtime,returncode"
+    paths:
+      torque: /usr/bin
     executors:
       defaults:
         pollinterval: 10

--- a/buildtest/schemas/settings.schema.json
+++ b/buildtest/schemas/settings.schema.json
@@ -394,6 +394,34 @@
             }
           }
         },
+        "paths":
+        {
+          "type": "object",
+          "description": "Specify paths to look up for executables",
+          "additionalProperties": false,
+          "properties": {
+            "slurm": {
+              "type": "string",
+              "description": "Specify path to slurm executable"
+            },
+            "lsf": {
+              "type": "string",
+              "description": "Specify path to lsf executable"
+            },
+            "cobalt": {
+              "type": "string",
+              "description": "Specify path to cobalt executable"
+            },
+            "pbs": {
+              "type": "string",
+              "description": "Specify path to pbs executable"
+            },
+            "torque": {
+              "type": "string",
+              "description": "Specify path to torque executable"
+            }
+          }
+        },
         "profiles": {
           "type": "object",
           "description": "The profiles section is used for declaring one or more profiles that can be used to run ``buildtest build`` that are captured as command options ",

--- a/buildtest/settings/aws_oddc_pbs.yml
+++ b/buildtest/settings/aws_oddc_pbs.yml
@@ -3,7 +3,7 @@ system:
     hostnames:
     - .*
     description: Generic System
-    moduletool: environment-modules
+    moduletool: 'none'
     pager: false
     buildspecs:
       rebuild: false
@@ -22,8 +22,8 @@ system:
           description: submit jobs on local machine using bash shell
           shell: bash
       torque:
-        e4spro:
-          queue: e4spro-cluster
+        lbl:
+          queue: lbl-cluster
     compilers:
       find:
         gcc: ^(gcc)

--- a/buildtest/settings/config.yml
+++ b/buildtest/settings/config.yml
@@ -45,6 +45,24 @@ system:
       # specify format fields
       format: name,id,state,runtime,returncode
 
+    # specify directory paths to search for binaries
+    #paths:
+      # directory path to search for slurm binaries.
+      #slurm: "/usr/bin"
+
+      # directory path to search for lsf binaries.
+      #lsf: "/usr/bin"
+
+      # directory path to search for pbs binaries.
+      #pbs: "/usr/bin"
+
+      # directory path to search for torque binaries.
+      #torque: "/usr/bin"
+
+      # directory path to search for cobalt binaries.
+      #cobalt: "/usr/bin"
+
+
     # start of executor configuration
     executors:
       # local executor is used to submit jobs on local machine. In this example we have 4 executors: bash, sh, csh, zsh that will submit jobs using bash, sh, csh, zsh shell respectively.

--- a/buildtest/system.py
+++ b/buildtest/system.py
@@ -13,11 +13,8 @@ import distro
 
 from buildtest.defaults import BUILDTEST_ROOT
 from buildtest.exceptions import BuildTestError
-from buildtest.scheduler.detection import LSF, PBS, Cobalt, Slurm, Torque
 
 SUPPORTED_PLATFORMS = ["Linux", "Darwin"]
-
-SCHEDULERS = [Slurm, LSF, Cobalt, PBS, Torque]
 
 
 class BuildTestSystem:
@@ -72,21 +69,7 @@ class BuildTestSystem:
         self.logger.info(f"Path to Buildtest: {shutil.which('buildtest')}")
 
         self.detect_module_tool()
-        self.check_scheduler()
-
         self.logger.info("Finished System Compatibility Check")
-
-    def check_scheduler(self):
-        """Check existence of batch scheduler and if so determine which scheduler
-        it is. Currently, we support Slurm, LSF, Cobalt, PBS and Torque. We invoke each
-        class and see if its valid state. The checks determine if scheduler
-        binaries exist in $PATH.
-        """
-
-        for scheduler in SCHEDULERS:
-            sched = scheduler()
-            if sched.active():
-                self.logger.debug(f"Detected {sched.__class__.__name__} Scheduler")
 
     def detect_module_tool(self):
         """Check if module tool exists, we check for Lmod or environment-modules by

--- a/buildtest/utils/tools.py
+++ b/buildtest/utils/tools.py
@@ -1,6 +1,13 @@
+import logging
+import os
+import shutil
 from functools import reduce
 
 from rich.color import Color, ColorParseError
+
+from buildtest.utils.file import is_dir, resolve_path
+
+logger = logging.getLogger(__name__)
 
 
 def deep_get(dictionary, *keys):
@@ -28,3 +35,44 @@ def checkColor(colorArg):
         except ColorParseError:
             checkedColor = Color.default().name
         return checkedColor
+
+
+def check_binaries(binaries, custom_dirs=None):
+    """Check if binaries exist in $PATH and any additional directories specified by custom_dirs. The return is a dictionary
+    containing the binary name and full path to binary.
+
+    Args:
+        binaries (list): list of binaries to check for existence in $PATH
+        custom_dirs (list, optional): list of custom directories to check for binaries. Defaults to None.
+
+    Returns:
+        dict: dictionary containing binary name and full path to binary
+    """
+
+    logger.debug(f"Check the following binaries {binaries} for existence.")
+
+    paths = os.getenv("PATH").split(os.pathsep)
+
+    if custom_dirs:
+        resolved_path = resolve_path(custom_dirs)
+        if is_dir(resolved_path):
+            paths.append(resolved_path)
+
+            logger.debug(
+                f"Adding directories {resolved_path} to PATH to check for binaries"
+            )
+
+    # convert list back to str with colon separated list of directory paths
+    paths = ":".join(paths)
+    logger.debug(f"Checking PATH directories: {paths}")
+
+    sched_dict = {}
+    for command in binaries:
+        command_fpath = shutil.which(command, path=paths)
+        if not command_fpath:
+            logger.error(f"Cannot find {command} command")
+
+        sched_dict[command] = command_fpath
+        logger.debug(f"{command}: {command_fpath}")
+
+    return sched_dict

--- a/docs/configuring_buildtest/overview.rst
+++ b/docs/configuring_buildtest/overview.rst
@@ -151,6 +151,26 @@ based on platform (Linux, Mac).
 The buildtest logs will start with **buildtest_** followed by random identifier with
 a **.log** extension.
 
+Specify directory paths to search for binaries
+----------------------------------------------
+
+The ``paths`` property can be used to search for binaries for batch schedulers. If your scheduler binaries
+are installed in a non-standard location that is not in $PATH, you can use this to specify the directory path.
+
+In example below we will, we will specify directories for SLURM, LSF, PBS, TORQUE, and COBALT binaries that
+are not in $PATH and installed in `/usr/local/slurm/bin`, `/usr/local/lsf/bin`,
+`/usr/local/pbs/bin`, `/usr/local/torque/bin`, `/usr/local/cobalt/bin` respectively.
+
+.. code-block:: yaml
+
+    paths:
+      slurm: /usr/local/slurm/bin
+      lsf: /usr/local/lsf/bin
+      pbs: /usr/local/pbs/bin
+      torque: /usr/local/torque/bin
+      cobalt: /usr/local/cobalt/bin
+
+
 Buildspec Cache
 ----------------
 

--- a/scripts/pbs/setup.sh
+++ b/scripts/pbs/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+wget --no-check-certificate https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
 bash ~/miniconda.sh -b -p ~/miniconda
 export PATH=~/miniconda/bin:$PATH
 conda create -n buildtest -y

--- a/tests/examples/pbs/job_dependency.yml
+++ b/tests/examples/pbs/job_dependency.yml
@@ -3,8 +3,7 @@ buildspecs:
     type: script
     executor: generic.pbs.workq
     pbs: ["-l nodes=1", "-l walltime=00:02:00"]
-    needs: [pbs_sleep]
-    run: sleep 5
+    run: hostname
 
   whoami:
     type: script

--- a/tests/examples/torque/sleep_cancel.yml
+++ b/tests/examples/torque/sleep_cancel.yml
@@ -2,5 +2,5 @@ buildspecs:
   sleep_job_cancel:
     type: script
     executor: generic.torque.lbl
-    pbs: ["-l nodes=1", "-l walltime=00:00:05"]
+    pbs: ["-l nodes=1", "-l walltime=00:00:05", "-h"]
     run: sleep 60

--- a/tests/settings/jlse.yml
+++ b/tests/settings/jlse.yml
@@ -1,7 +1,7 @@
 system:
   jlse:
     # hostnames on JLSE where jobs are run are jlsebatch[1-2]
-    hostnames: ['^jlsebatch\d{1}$']
+    hostnames: ['^jlsebatch([1-2]).*']
     moduletool: environment-modules
     poolsize: 8
     max_jobs: 10
@@ -18,7 +18,7 @@ system:
     executors:
       defaults:
         pollinterval: 30
-        maxpendtime: 300
+        maxpendtime: 15
       local:
         bash:
           description: submit jobs on local machine using bash shell

--- a/tests/settings/nersc.yml
+++ b/tests/settings/nersc.yml
@@ -55,7 +55,7 @@ system:
           qos: debug
   perlmutter:
     hostnames:
-      - 'login(0[1-9]|[1-3][0-9]|40)'
+      - 'login(0[1-9]|[1-3][0-9]|40).chn'
     moduletool: lmod
     poolsize: 8
     max_jobs: 10
@@ -106,3 +106,4 @@ system:
         debug:
           description: submit jobs on perlmutter using slurm debug queue
           qos: debug
+          cluster: perlmutter

--- a/tests/settings/pbs.yml
+++ b/tests/settings/pbs.yml
@@ -2,8 +2,8 @@ system:
   generic:
     hostnames: ['.*']
     moduletool: none
-    poolsize: 1
-    max_jobs: 1
+    poolsize: 8
+    max_jobs: 8
     pager: False
     buildspecs:
       rebuild: False


### PR DESCRIPTION
This PR will attempt to add the following keys in configuration file where one can specify an alternate location where to search for scheduler binaries that can be useful if they are not in $PATH

```yaml
    paths:
      lsf: "/usr/local/bin"
      slurm: "/usr/local/bin"
      pbs: "/usr/local/bin"
      cobalt: "/usr/local/bin"
      torque: "/usr/local/bin"
```