### PR TITLE
Add support for specifying a file path via -f/--file when loading buildspec into cache

### DIFF
--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -413,8 +413,8 @@ _buildtest ()
            COMPREPLY=( $( compgen -W "${opts}" -- "${cur}" ) );;
          # completion for rest of arguments
          *)
-           local longopts="--buildspec --count --directory --executors --filter --filterfields --format --formatfields --group-by-executor --group-by-tags --help --helpfilter --helpformat --no-header --pager --paths --quiet --rebuild --row-count --tags --terse"
-           local shortopts="-b -d -e -h -n -p -q -r -t"
+           local longopts="--buildspec --count --directory --executors --file --filter --filterfields --format --formatfields --group-by-executor --group-by-tags --help --helpfilter --helpformat --no-header --pager --paths --quiet --rebuild --row-count --tags --terse"
+           local shortopts="-b -d -e -f -h -n -p -q -r -t"
            local cmds="invalid"
 
            COMPREPLY=( $( compgen -W "${cmds} ${longopts} ${shortopts}" -- "${cur}" ) )

--- a/buildtest/cli/__init__.py
+++ b/buildtest/cli/__init__.py
@@ -1294,6 +1294,14 @@ class BuildTestParser:
                         "help": "Specify root buildspecs (directory) path to load buildspecs into buildspec cache.",
                     },
                 ),
+                (
+                    ["-f", "--file"],
+                    {
+                        "type": str,
+                        "action": "append",
+                        "help": "Specify buildspec file to load into buildspec cache.",
+                    },
+                ),
             ],
         }
 

--- a/buildtest/main.py
+++ b/buildtest/main.py
@@ -252,10 +252,17 @@ def setup(args):
     # build buildspec cache file automatically if it doesn't exist
     if not is_file(BUILDSPEC_CACHE_FILE):
         root_buildspecs = []
+        buildspec_files = []
         if hasattr(args, "directory"):
             root_buildspecs = args.directory
+        if hasattr(args, "file"):
+            buildspec_files = args.file
 
-        BuildspecCache(directory=root_buildspecs, configuration=configuration)
+        BuildspecCache(
+            directory=root_buildspecs,
+            buildspec_files=buildspec_files,
+            configuration=configuration,
+        )
 
     return system, configuration, buildtest_editor, report_file
 

--- a/docs/configuring_buildtest/overview.rst
+++ b/docs/configuring_buildtest/overview.rst
@@ -220,10 +220,12 @@ If you want buildtest to always rebuild cache you can set the following in your 
 The configuration options such as ``count``, ``format``, ``terse`` can  be tweaked to your preference. These configuration values
 can be overridden by command line option.
 
-.. _buildspec_roots:
+.. _search_buildspecs_when_building_cache:
 
-Specify Root Directories for searching buildspecs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Searching for buildspecs when building Buildspec Cache
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When building the buildspec cache, buildtest will search for buildspecs in a list of directories specified in the configuration file.
 
 Buildtest will search for buildspecs by recursively searching for files with **.yml** extension. The ``directory`` property in configuration file
 is a list of directories to search for buildspecs. The ``directory`` property is not **required** in configuration file, but it can be a good

--- a/docs/gettingstarted/buildspecs_interface.rst
+++ b/docs/gettingstarted/buildspecs_interface.rst
@@ -78,8 +78,8 @@ Shown below is an example output.
     .. command-output:: buildtest buildspec find --buildspec
        :ellipsis: 11
 
-Find root paths where buildspecs are searched
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Adding buildspecs to cache
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``buildtest buildspec find --paths`` will display a list of root directories buildtest will search for
 buildspecs when running ``buildtest buildspec find``. One can define these directories in the configuration file
@@ -89,10 +89,8 @@ or pass them via command line.
 
     .. command-output:: buildtest buildspec find --paths
 
-buildtest will search buildspecs in :ref:`buildspecs root <buildspec_roots>` defined in your configuration,
-which is a list of directory paths to search for buildspecs.
-If you want to load buildspecs from a directory path, you can specify a directory
-via ``--directory`` option in the format: ``buildtest buildspec find --directory <path>``.
+buildtest will :ref:`search buildspecs when building cache <search_buildspecs_when_building_cache>` that can be configured via
+configuration or command line. If you want to load buildspecs from a directory, you can use the ``--directory`` option.
 buildtest will rebuild cache when `--directory` option is specified. Note that to rebuild cache you typically
 need to pass **--rebuild** option but that is not required when using **--directory** option because we want
 buildtest to load buildspecs into cache.
@@ -111,6 +109,23 @@ If you want to specify multiple root paths you can specify the  **--directory** 
 Let's rebuild the cache again by running ``buildtest buildspec find`` which will load the default buildspecs into the cache
 
 .. command-output:: buildtest buildspec find --rebuild --quiet
+
+In addition to ``--directory`` option, one can specify a list of files to load into cache using the ``--file`` option. This can be useful
+if you want to load specific buildspecs into cache without having to specify ``--directory``. You can use ``--file`` option with ``--directory``
+and buildtest will recursively search directories and load files specified in ``--file`` option.
+
+If you specify an invalid file path, a directory or file without ``.yml`` extension, buildtest will report a message and skip to next file.
+Shown below, we specify a list of files to load into cache using ``--file`` option.
+
+.. dropdown:: ``buildtest buildspec find --file $BUILDTEST_ROOT/tutorials/vars.yml``
+
+    .. command-output:: buildtest buildspec find --file $BUILDTEST_ROOT/tutorials/vars.yml
+
+    We can confirm the file is loaded into cache using the `-b` option which list all buildspecs in cache and pipe via `grep` to search for `vars.yml`. Note that
+    we specify ``--count=-1`` to show all buildspecs in cache.
+
+    .. command-output:: buildtest bc find -b --terse --count=-1 | grep vars.yml
+
 
 Filtering buildspec
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/gettingstarted/buildspecs_interface.rst
+++ b/docs/gettingstarted/buildspecs_interface.rst
@@ -124,8 +124,8 @@ Shown below, we specify a list of files to load into cache using ``--file`` opti
     We can confirm the file is loaded into cache using the `-b` option which list all buildspecs in cache and pipe via `grep` to search for `vars.yml`. Note that
     we specify ``--count=-1`` to show all buildspecs in cache.
 
-    .. command-output:: buildtest bc find -b --terse --count=-1 | grep vars.yml
-
+    .. command-output:: buildtest builspec find -b --terse --count=-1 | grep vars.yml
+       :shell:
 
 Filtering buildspec
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/gettingstarted/buildspecs_interface.rst
+++ b/docs/gettingstarted/buildspecs_interface.rst
@@ -124,7 +124,7 @@ Shown below, we specify a list of files to load into cache using ``--file`` opti
     We can confirm the file is loaded into cache using the `-b` option which list all buildspecs in cache and pipe via `grep` to search for `vars.yml`. Note that
     we specify ``--count=-1`` to show all buildspecs in cache.
 
-    .. command-output:: buildtest builspec find -b --terse --count=-1 | grep vars.yml
+    .. command-output:: buildtest buildspec find -b --terse --count=-1 | grep vars.yml
        :shell:
 
 Filtering buildspec

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -348,18 +348,27 @@ def test_edit_file():
 
 
 @pytest.mark.cli
-def test_buildspec_find_roots():
+def test_buildspec_find_by_directory_and_files():
     root_buildspecs = [
         os.path.join(BUILDTEST_ROOT, "tests", "buildsystem"),
         os.path.join(BUILDTEST_ROOT, "tutorials"),
     ]
-    # buildtest buildspec find --root $BUILDTEST_ROOT/tests/buildsystem --root $BUILDTEST_ROOT/tutorials
+    # list of buildspec files to add to cache, we have one valid file that exists, one with invalid extension and one file that doesn't exist
+    bp_files = [
+        os.path.join(BUILDTEST_ROOT, "tutorials", "vars.yml"),
+        os.path.join(BUILDTEST_ROOT, "README.rst"),
+        os.path.join(BUILDTEST_ROOT, "badfile.yml"),
+    ]
+    # buildtest buildspec find --directory $BUILDTEST_ROOT/tests/buildsystem --directory $BUILDTEST_ROOT/tutorials
     BuildspecCache(
-        directory=root_buildspecs, configuration=configuration, rebuild=False
+        directory=root_buildspecs,
+        buildspec_files=bp_files,
+        configuration=configuration,
+        rebuild=False,
     )
 
     with pytest.raises(BuildTestError):
-        # buildtest buildspec find --root $BUILDTEST_ROOT/README.rst --root $BUILDTEST_ROOT/environment.yml
+        # buildtest buildspec find --directory $BUILDTEST_ROOT/README.rst --directory $BUILDTEST_ROOT/environment.yml
         BuildspecCache(
             directory=[
                 os.path.join(BUILDTEST_ROOT, "README.rst"),

--- a/tests/cli/test_buildspec.py
+++ b/tests/cli/test_buildspec.py
@@ -356,8 +356,9 @@ def test_buildspec_find_by_directory_and_files():
     # list of buildspec files to add to cache, we have one valid file that exists, one with invalid extension and one file that doesn't exist
     bp_files = [
         os.path.join(BUILDTEST_ROOT, "tutorials", "vars.yml"),
-        os.path.join(BUILDTEST_ROOT, "README.rst"),
-        os.path.join(BUILDTEST_ROOT, "badfile.yml"),
+        os.path.join(BUILDTEST_ROOT, "README.rst"),  # invalid extension
+        os.path.join(BUILDTEST_ROOT, "badfile.yml"),  # file doesn't exist
+        os.path.join(BUILDTEST_ROOT),  # directory path
     ]
     # buildtest buildspec find --directory $BUILDTEST_ROOT/tests/buildsystem --directory $BUILDTEST_ROOT/tutorials
     BuildspecCache(


### PR DESCRIPTION
We have added support for command `buildtest buildspec find -f <file>` to enable buildtest to update buildspec cache with file path

# motivation

Current support was limited to directory when building buildspec cache such that user must specify all buildspec files (.yml) in a directory. If one wants to add a few files into the buildspec cache that was not possible.


Shown below is an example usage, we can see that buildtest will load files `tutorials/vars.yml` and `tutorials/sleep.yml` into the buildspec cache. Buildtest will ignore files that dont exist like `tutorials/x.yml` 

```console
⚡   buildtest bc find -d general_tests/configuration -f tutorials/vars.yml -f tutorials/sleep.yml -f tutorials/x.yml
Path: /Users/siddiq90/Documents/buildtest/tutorials/x.yml does not exist!
Clearing cache file: /Users/siddiq90/Documents/buildtest/var/buildspecs/cache.json
Buildspec Paths: ['/Users/siddiq90/Documents/buildtest/general_tests/configuration']
Updating buildspec cache file: /Users/siddiq90/Documents/buildtest/var/buildspecs/cache.json
                                 Buildspec Cache: /Users/siddiq90/Documents/buildtest/var/buildspecs/cache.json                                  
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ name                         ┃ type   ┃ executor           ┃ tags               ┃ description                                                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ root_disk_usage              │ script │ generic.local.bash │ filesystem storage │ Check root disk usage and report if it exceeds threshold    │
│ kernel_swapusage             │ script │ generic.local.bash │ configuration      │ Retrieve Kernel Swap Usage                                  │
│ systemd_default_target       │ script │ generic.local.bash │ system             │ check if default target is multi-user.target                │
│ ulimit_filelock_unlimited    │ script │ generic.local.bash │ system             │ Check if file lock is set to unlimited in ulimits           │
│ ulimit_cputime_unlimited     │ script │ generic.local.bash │ system             │ Check if cputime is set to unlimited in ulimits             │
│ ulimit_stacksize_unlimited   │ script │ generic.local.bash │ system             │ Check if stack size is set to unlimited in ulimits          │
│ ulimit_vmsize_unlimited      │ script │ generic.local.bash │ system             │ Check virtual memory size and check if its set to unlimited │
│ ulimit_filedescriptor_4096   │ script │ generic.local.bash │ system             │ Check if open file descriptors limit is set to 4096         │
│ ulimit_max_user_process_2048 │ script │ generic.local.bash │ system             │ Check max number of user process limit is set to 2048       │
│ variables_bash               │ script │ generic.local.bash │ tutorials          │ Declare shell variables in bash                             │
│ sleep                        │ script │ generic.local.bash │ tutorials          │ sleep 2 seconds                                             │
└──────────────────────────────┴────────┴────────────────────┴────────────────────┴─────────────────────────────────────────────────────────────┘

⚡  buildtest bc find -b                                                                                            
                                      List of Buildspecs                                      
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Buildspecs                                                                                 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ /Users/siddiq90/Documents/buildtest/general_tests/configuration/disk_usage.yml             │
│ /Users/siddiq90/Documents/buildtest/general_tests/configuration/kernel_state.yml           │
│ /Users/siddiq90/Documents/buildtest/general_tests/configuration/systemd-default-target.yml │
│ /Users/siddiq90/Documents/buildtest/general_tests/configuration/ulimits.yml                │
│ /Users/siddiq90/Documents/buildtest/tutorials/vars.yml                                     │
│ /Users/siddiq90/Documents/buildtest/tutorials/sleep.yml                                    │
└────────────────────────────────────────────────────────────────────────────────────────────┘

```