### PR TITLE
change printing output for 'buildtest buildspec summary' and 'buildtest inspect query

### DIFF
--- a/buildtest/cli/buildspec.py
+++ b/buildtest/cli/buildspec.py
@@ -7,7 +7,6 @@ import sys
 import time
 
 from jsonschema.exceptions import ValidationError
-from rich.layout import Layout
 from rich.panel import Panel
 from rich.pretty import pprint
 
@@ -1310,12 +1309,6 @@ def summary_print(configuration, color=None):
     [yellow]Total Maintainers:[/yellow]             [cyan]{len(cache.get_maintainers())}[/cyan] 
     """
     console.print(Panel.fit(msg))
-    layout = Layout()
-    layout.split_column(Layout(name="top"), Layout(name="bottom"))
-    layout["top"].split_row(
-        Layout(name="top-left"), Layout(name="top-center"), Layout(name="top-right")
-    )
-    layout["top"].ratio = 2
 
     tag_table = create_table(
         title="Tag Breakdown",
@@ -1337,23 +1330,31 @@ def summary_print(configuration, color=None):
         column_style=consoleColor,
     )
 
-    layout["top-left"].update(tag_table)
-    layout["top-center"].update(executor_table)
-    layout["top-right"].update(maintainer_table)
-
     tdata = [[buildspec] for buildspec in cache.get_invalid_buildspecs()]
 
     invalid_buildspecs_table = create_table(
         title="Invalid Buildspecs",
         columns=["Buildspecs"],
         data=tdata,
-        column_style=consoleColor,
-        show_lines=True,
+        column_style="red",
+        show_lines=False,
     )
 
-    layout["bottom"].update(invalid_buildspecs_table)
+    tdata = [[buildspec] for buildspec in cache.get_valid_buildspecs()]
 
-    console.print(layout)
+    valid_buildspecs_table = create_table(
+        title="Valid Buildspecs",
+        columns=["Buildspecs"],
+        data=tdata,
+        column_style="green",
+        show_lines=False,
+    )
+
+    print_table(tag_table)
+    print_table(executor_table)
+    print_table(maintainer_table)
+    print_table(valid_buildspecs_table)
+    print_table(invalid_buildspecs_table)
 
 
 def buildspec_maintainers(

--- a/buildtest/cli/inspect.py
+++ b/buildtest/cli/inspect.py
@@ -69,6 +69,8 @@ def print_by_query(
                 console.print(f"[red]Error File: {test['errfile']}")
                 console.print(f"[red]Log File: {test['logpath']}")
 
+                buildspec = report.get_buildspec_by_test(name)
+
                 if test["metrics"]:
                     table = Table(
                         Column("Name", overflow="fold", header_style="blue"),
@@ -80,26 +82,32 @@ def print_by_query(
 
                     console.print(table)
 
+                if buildspec:
+                    print_file_content(
+                        buildspec, f"Buildspec File: {buildspec} ", "shell", theme
+                    )
                 # print content of output file when 'buildtest inspect query --output' is set
                 if output:
-                    print_file_content(test["outfile"], "Output File: ", "text", theme)
+                    print_file_content(test["outfile"], "Output File ", "text", theme)
 
                 # print content of error file when 'buildtest inspect query --error' is set
                 if error:
-                    print_file_content(test["errfile"], "Error File: ", "text", theme)
+                    print_file_content(test["errfile"], "Error File ", "text", theme)
 
                 # print content of testpath when 'buildtest inspect query --testpath' is set
                 if testpath:
-                    print_file_content(test["testpath"], "Test File: ", "shell", theme)
+                    print_file_content(test["testpath"], "Test File ", "shell", theme)
 
                 # print content of build script when 'buildtest inspect query --buildscript' is set
                 if buildscript:
                     print_file_content(
-                        test["build_script"], "Build Script File: ", "shell", theme
+                        test["build_script"], "Build Script File ", "shell", theme
                     )
 
                 if buildenv:
-                    print_file_content(test["buildenv"], "Test File: ", "text", theme)
+                    print_file_content(
+                        test["buildenv"], "Build Environment File ", "text", theme
+                    )
 
 
 def fetch_test_names(report, names):

--- a/buildtest/cli/report.py
+++ b/buildtest/cli/report.py
@@ -723,6 +723,15 @@ class Report:
 
         return records
 
+    def get_buildspec_by_test(self, name):
+        """Retrieve buildspec file by test name. This method will return buildspec file for a given test name."""
+
+        for buildspec in self.filtered_buildspecs:
+            if name in self.report[buildspec]:
+                return buildspec
+
+        return None
+
 
 def list_report():
     """This method will list all report files. This method will implement ``buildtest report list`` command."""

--- a/docs/gettingstarted/query_test_report.rst
+++ b/docs/gettingstarted/query_test_report.rst
@@ -556,30 +556,45 @@ of test names ``root_disk_usage`` and ``python_hello``
 
 If you want to query specific test ID, you can specify name of test followed by `/` and test ID. You don't need to specify
 the full ID however tab completion is available to help fill in the names. For example if you want to query test record for
-`circle_area/8edce927-2ecc-4991-ac40-e376c03394b4` shown in tab completion you can type a first few characters to query the record
+``circle_area/566399ce-e25b-4630-8bb8-fbf09f6de7d0`` shown in tab completion you can type a first few characters to query the record
 
 .. code-block:: console
 
     $ buildtest inspect query circle_area/
-    circle_area/08f20b50-d2e2-41ab-a75e-a7df75e5afcc  circle_area/8edce927-2ecc-4991-ac40-e376c03394b4  circle_area/d47b6ba8-71b6-4531-b8cd-b6ba9b5f0c6c
-    circle_area/237c3a96-fad0-4ab7-ab1f-3e7ed1816955  circle_area/baea2e9b-a187-4f9f-bcea-75e768ccb0e0  circle_area/e6652700-4cdb-4f6b-80c5-261e4f448876
-    circle_area/2c279160-1abf-4c70-957f-d9e4608f521b  circle_area/bf8f1762-ebf9-458e-92e2-af3fc6e73eac  circle_area/e7cc7138-a650-4cd8-aca8-b904f901a0da
+    circle_area/566399ce-e25b-4630-8bb8-fbf09f6de7d0  circle_area/69b29a2c-55ee-47d0-ac8c-aaa23566619b  circle_area/a6df47b6-4db4-4e5b-b5c4-fadb510ee1d2  circle_area/ace1b02f-1761-443d-b3d8-b6f9ba20291d
 
-    $ buildtest inspect query circle_area/8ed
-    ──────────────────────────────────────────────────────────────────────────────────────────── circle_area/8edce927-2ecc-4991-ac40-e376c03394b4 ─────────────────────────────────────────────────────────────────────────────────────────────
+
+    $ buildtest inspect query circle_area/56
+    ──────────────────────────────────────────────────────────────────────────────────────── circle_area/566399ce-e25b-4630-8bb8-fbf09f6de7d0 ─────────────────────────────────────────────────────────────────────────────────────────
     Executor: generic.local.bash
     Description: Calculate circle of area given a radius
     State: PASS
     Returncode: 0
-    Runtime: 0.360774 sec
-    Starttime: 2021/12/23 12:37:25
-    Endtime: 2021/12/23 12:37:25
-    Command: bash --norc --noprofile -eo pipefail circle_area_build.sh
-    Test Script: /Users/siddiq90/Documents/GitHubDesktop/buildtest/var/tests/generic.local.bash/python-shell/circle_area/8edce927/circle_area.sh
-    Build Script: /Users/siddiq90/Documents/GitHubDesktop/buildtest/var/tests/generic.local.bash/python-shell/circle_area/8edce927/circle_area_build.sh
-    Output File: /Users/siddiq90/Documents/GitHubDesktop/buildtest/var/tests/generic.local.bash/python-shell/circle_area/8edce927/circle_area.out
-    Error File: /Users/siddiq90/Documents/GitHubDesktop/buildtest/var/tests/generic.local.bash/python-shell/circle_area/8edce927/circle_area.err
-    Log File: /Users/siddiq90/Documents/GitHubDesktop/buildtest/var/logs/buildtest_c5dnun2l.log
+    Runtime: 0.318187 sec
+    Starttime: 2024/10/22 12:39:00
+    Endtime: 2024/10/22 12:39:00
+    Command: bash circle_area_build.sh
+    Test Script: /Users/siddiq90/Documents/buildtest/var/tests/generic.local.bash/python-shell/circle_area/566399ce/circle_area.sh
+    Build Script: /Users/siddiq90/Documents/buildtest/var/tests/generic.local.bash/python-shell/circle_area/566399ce/circle_area_build.sh
+    Output File: /Users/siddiq90/Documents/buildtest/var/tests/generic.local.bash/python-shell/circle_area/566399ce/circle_area.out
+    Error File: /Users/siddiq90/Documents/buildtest/var/tests/generic.local.bash/python-shell/circle_area/566399ce/circle_area.err
+    Log File: /Users/siddiq90/Documents/buildtest/var/logs/buildtest_t6dmyvv3.log
+    ───────────────────────────────────────────────────────────────────────── Buildspec File: /Users/siddiq90/Documents/buildtest/tutorials/python-shell.yml  ─────────────────────────────────────────────────────────────────────────
+    buildspecs:
+      circle_area:
+        executor: generic.local.bash
+        type: script
+        shell: python
+        description: "Calculate circle of area given a radius"
+        tags: [tutorials, python]
+        run: |
+          import math
+          radius = 2
+          area = math.pi * radius * radius
+          print("Circle Radius ", radius)
+          print("Area of circle ", area)
+
+    ─────────────────────────────────────────────────────────────────────────────────────────────────
 
 buildtest will search for test ID using `re.match <https://docs.python.org/3/library/re.html#re.match>`_ so it is possible to apply a regular expression to seek
 out multiple test records. The tests must be enclosed in quotes ``"`` in-order to have a valid regular expression. Here are few examples that can be useful
@@ -619,6 +634,6 @@ The report file must be valid JSON file that buildtest understands in order to u
     │ python_hello                                                       │ dd447e43                                      │
     └────────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────┘
 
-You can view path to all report files via ``buildtest report list`` which keeps track of any new report files created when using ``buildtest build -r`` option.
+You can view path to all report files via ``buildtest report list`` which keeps track of any new report files created when using ``buildtest -r <report_file> build`` option.
 
 .. command-output:: buildtest report list


### PR DESCRIPTION
In this PR we have changed the output for 'buildtest buildspec summary' to show content of tables without using `rich.Layout` which helps show all entries of tables since `rich.Layout` will hide some entries.

We color code valid and invalid buildspecs with green and red color.

<img width="938" alt="Screenshot 2024-10-22 at 12 22 25 PM" src="https://github.com/user-attachments/assets/acfb95c0-9ad9-485d-8241-4da50fbfa709">
<img width="898" alt="Screenshot 2024-10-22 at 12 22 37 PM" src="https://github.com/user-attachments/assets/8c432e9f-5be9-46c6-929b-b27040a6a95a">
<img width="814" alt="Screenshot 2024-10-22 at 12 22 45 PM" src="https://github.com/user-attachments/assets/5e13163f-c948-4818-8881-9344ac79a9ce">

We now show content of buildspec in `buildtest inspect query` command
<img width="1034" alt="Screenshot 2024-10-22 at 12 23 11 PM" src="https://github.com/user-attachments/assets/ec6ce16a-14d2-41b3-81f0-1f0eae26a35d">
